### PR TITLE
Allow a delay in an AuraBar

### DIFF
--- a/Options/RegionOptions/aurabar.lua
+++ b/Options/RegionOptions/aurabar.lua
@@ -626,10 +626,24 @@ local function createOptions(id, data)
             disabled = function() return not data.stacks end,
             hidden = function() return not data.stacks end,
         },
+		additional_options = {
+			type = "header",
+			name = L["Additional Settings"],
+			order = 58.1
+		},
+        delay = {
+            type = "range",
+            name = L["Delay"],
+            order = 58.2,
+            min = 0,
+            max = .99,
+            step = .01,
+            order = 58.2
+        },
         spacer = {
             type = "header",
             name = "",
-            order = 58
+            order = 59
         },
     };
     

--- a/RegionTypes/aurabar.lua
+++ b/RegionTypes/aurabar.lua
@@ -59,7 +59,9 @@ local default = {
   icon_side = "RIGHT",
   rotateText = "NONE",
   frameStrata = 1,
-  customTextUpdate = "update"
+  customTextUpdate = "update",
+  delay = 0,
+  inverse = false
 };
 
 -- Returns tex Coord for 90° rotations + x or y flip
@@ -91,12 +93,27 @@ end
 local barPrototype = {
   -- Apply settings to bar (re-align textures)
   ["Update"] = function(self, OnSizeChanged)
+    
+    -- Do we need to be this safe here?
+    if self.delay == nil then self.delay = 0 end
+    if self.inverse == nil then self.inverse = false end
+    
+    -- Apply delay
+    local lMin = self.min
+    local lMax = self.max
+    
+    if self.inverse then
+      lMin = lMin + self.delay
+    else
+      lMax = lMax - self.delay
+    end
+    
     -- Limit values
-    self.value   = math.max(self.min, self.value);
-    self.value   = math.min(self.max, self.value);
-
+    self.value = math.max(lMin, self.value);
+    self.value = math.min(lMax, self.value);
+    
     -- Alignment variables
-    local progress = (self.value - self.min) / (self.max - self.min);
+    local progress = (self.value - lMin) / (lMax - lMin);
     local align1, align2, alignSpark;
     local xProgress, yProgress, sparkOffset;
     local TLx,  TLy,  BLx,  BLy,  TRx,  TRy,  BRx,  BRy;
@@ -799,6 +816,10 @@ local function modify(parent, region, data)
   -- Localize
   local bar, border, timer, text, iconFrame, icon, stacks = region.bar, region.border, region.timer, region.text, region.iconFrame, region.icon, region.stacks;
 
+  bar.delay = data.delay
+  bar.inverse = data.inverse
+  
+  
   -- Adjust framestrata
     if data.frameStrata == 1 then
         region:SetFrameStrata(region:GetParent():GetFrameStrata());

--- a/RegionTypes/aurabar.lua
+++ b/RegionTypes/aurabar.lua
@@ -784,10 +784,6 @@ local function UpdateTime(region, data, inverse)
   -- Update text
   UpdateText(region, data);
 end
-local function UpdateTimeInverse(region, data)
-  -- Relay
-  UpdateTime(region, data, true);
-end
 
 -- Update current state (progress)
 local function UpdateValue(region, data, value, total)
@@ -1158,11 +1154,7 @@ local function modify(parent, region, data)
         else
       -- Enable OnUpdate script
             if duration > 0 then
-                if inverse then
-                    self:SetScript("OnUpdate", function() UpdateTimeInverse(self, data) end);
-                else
-                    self:SetScript("OnUpdate", function() UpdateTime(self, data, inverse) end);
-                end
+                self:SetScript("OnUpdate", function() UpdateTime(self, data, inverse) end);
       -- Reset to full
             else
                 bar:SetValue(1);


### PR DESCRIPTION
This will cause the bar to ignore a percentage of its timer;  For example, if a skill has a 10 second cooldown and the delay is set to .5, the bar will remain at 100% until 5 seconds have passed, and then will tick down from 100% to 0 between the 5 and 10 second mark.

This is intended to be used with the Remaining Time trigger in order to display a percentage of a timer as if it were the full timer.
