### PR TITLE
yOffset still bugged for invisible auras

### DIFF
--- a/Options/WeakAurasOptions.lua
+++ b/Options/WeakAurasOptions.lua
@@ -8000,7 +8000,12 @@ tXmdmY4fDE5]];
       
       if(displayButtons[centerId]) then
         local _, _, _, _, yOffset = displayButtons[centerId].frame:GetPoint(1);
-        self.buttonsScroll:SetScrollPos(yOffset, yOffset - 32);
+        if not yOffset then
+          yOffset = displayButtons[centerId].frame.yOffset
+        end
+        if yOffset then
+          self.buttonsScroll:SetScrollPos(yOffset, yOffset - 32);
+        end
       end
     end
   end


### PR DESCRIPTION
Error:
2x WeakAurasOptions\WeakAurasOptions-2.0.9.7-16-g5cc82e3.lua:8005: attempt to perform arithmetic on local 'yOffset' (a nil value)
WeakAurasOptions\WeakAurasOptions-2.0.9.7-16-g5cc82e3.lua:8005: in function `CenterOnPicked'
WeakAurasOptions\WeakAurasOptions-2.0.9.7-16-g5cc82e3.lua:8260: in function`SortDisplayButtons'
WeakAurasOptions\WeakAurasOptions-2.0.9.7-16-g5cc82e3.lua:600: in function <WeakAurasOptions\WeakAurasOptions.lua:582>

First fix by stanzilla:
https://github.com/WeakAuras/WeakAuras2/commit/305d07e01638cdcfcd70ae15714a508094f938b4
