### PR TITLE
Fix taint while deleting auras

### DIFF
--- a/WeakAuras.lua
+++ b/WeakAuras.lua
@@ -2850,7 +2850,7 @@ function WeakAuras.Rename(data, newid)
   loaded[newid] = loaded[oldid];
   loaded[oldid] = nil;
 
-  loaded_events[newid] = oldid;
+  loaded_events[newid] = loaded_events[oldid];
   loaded_events[oldid] = nil;
 
   db.displays[newid] = db.displays[oldid];


### PR DESCRIPTION
How to reproduce: Create a new icon aura, rename it, move it to an existing dynamic group, duplicate the aura and delete the duplicate.

Error:
1x WeakAuras\WeakAuras-2.0.9.7-19-ge8def1e.lua:2819: attempt to index local 'v' (a string value)
WeakAuras\WeakAuras-2.0.9.7-19-ge8def1e.lua:2819: in function `Delete'
WeakAurasOptions\WeakAurasOptions-2.0.9.7-19-ge8def1e.lua:1173: in function `DeleteOption'
...eGUI-Widgets\AceGUIWidget-WeakAurasDisplayButton.lua:146: in function `func'
FrameXML\UIDropDownMenu.lua:748: in function `UIDropDownMenuButton_OnClick'
[string "*:OnClick"]:1: in function <[string "*:OnClick"]:1>