### PR TITLE
Pass aura id to custom init function

### DIFF
--- a/WeakAuras.lua
+++ b/WeakAuras.lua
@@ -287,9 +287,9 @@ function WeakAuras.ActivateAuraEnvironment(id)
       -- Run the init function if supplied
       local actions = data.actions.init;
       if(actions and actions.do_custom and actions.custom) then
-        local func = WeakAuras.LoadFunction("return function() "..(actions.custom).." end");
+        local func = WeakAuras.LoadFunction("return function(id) "..(actions.custom).." end");
         if func then
-          func();
+          func(id);
         end
       end
       data.init_completed = 1;


### PR DESCRIPTION
This change passes an aura's ID into the custom init function. This will enable initializers to pull details about the aura like it's triggers, region settings (e.g. x/y position) and modify them if necessary by going through WeakAuras.auras

It would also allow for simple/consolidating loading of "saved" data and registration of events for certain kinds of auras.

Thoughts: might be better to pass a table named "aura" with ID among other properties?