### PR TITLE
Dialog as a Sound Channel

### DIFF
--- a/Types.lua
+++ b/Types.lua
@@ -49,7 +49,8 @@ WeakAuras.sound_channel_types = {
   Master = L["Master"],
   SFX = L["Sound Effects"],
   Ambience = L["Ambience"],
-  Music = L["Music"]
+  Music = L["Music"],
+  Dialog = L["Dialog"]
 };
 WeakAuras.trigger_require_types = {
   any = L["Any Triggers"],


### PR DESCRIPTION
Not sure if this has been left out for a good reason or not?, but I updated Types.lua to include the "Dialog" sound channel as a selection during WeakAura creation.