### PR TITLE
WeakAura Ticket 480

### DIFF
--- a/Options/WeakAurasOptions.lua
+++ b/Options/WeakAurasOptions.lua
@@ -4728,8 +4728,54 @@ function WeakAuras.ReloadTriggerOptions(data)
       order = 0,
       hidden = function() return not (data.additional_triggers and #data.additional_triggers > 0) end,
       values = WeakAuras.trigger_require_types,
-      get = function() return data.disjunctive and "any" or "all" end,
-      set = function(info, v) data.disjunctive = (v == "any") end
+      get = function() return data.disjunctive end,
+      set = function(info, v) data.disjunctive = v end
+    },
+	custom_trigger_combination = {
+      type = "input",
+      name = L["Custom"],
+      order = 0.1,
+      multiline = true,
+      width = "normal",
+      hidden = function() return not (data.disjunctive == "custom") end,
+      get = function() return data.customTriggerLogic end,
+      set = function(info, v) 
+	    data.customTriggerLogic = v;
+	    WeakAuras.Add(data); 
+	  end
+    },
+    custom_trigger_combination_expand = {
+      type = "execute",
+      order = 0.15,
+      name = L["Expand Text Editor"],
+      func = function()
+        WeakAuras.TextEditor(data, {"customTriggerLogic"})
+      end,
+      hidden = function() return not (data.disjunctive == "custom") end,
+    },
+    custom_trigger_combination_error = {
+      type = "description",
+      name = function()
+        if not(data.customTriggerLogic) then
+          return "";
+        end
+        local _, errorString = loadstring("return "..data.customTriggerLogic);
+        return errorString and "|cFFFF0000"..errorString or "";
+      end,
+      width = "double",
+      order = 0.2,
+      hidden = function()
+        if not(data.disjunctive == "custom" and data.customTriggerLogic) then
+          return true;
+        else
+          local loadedFunction, errorString = loadstring("return "..data.customTriggerLogic);
+          if(errorString and not loadedFunction) then
+            return false;
+          else
+            return true;
+          end
+        end
+      end
     },
     addTrigger = {
       type = "execute",

--- a/Transmission.lua
+++ b/Transmission.lua
@@ -520,635 +520,657 @@ end
 
 local function checkTrigger(codes, id, trigger, untrigger)
     if (not trigger) then return end;
-        if trigger.type == "custom" then
-            local t = {};
-            if (trigger.custom) then
-                t.text = L["%s Trigger Function"]:format(id);
-                t.value = t.text;
-                t.code = trigger.custom;
-                tinsert(codes, t);
-            end
+    local t = {};
+    if (trigger.custom) then
+        t.text = L["%s Trigger Function"]:format(id);
+        t.value = t.text;
+        t.code = trigger.custom;
+        tinsert(codes, t);
+    end
+    
+    if (untrigger and untrigger.custom) then
+        t = {}
+        t.text = L["%s Untrigger Function"]:format(id);
+        t.value = t.text;
+        t.code = untrigger.custom;
+        tinsert(codes, t);
+    end
+    
+    if (trigger.customDuration) then
+        t = {}
+        t.text = L["%s Duration Function"]:format(id);
+        t.value = t.text;
+        t.code = trigger.customDuration
+        tinsert(codes, t);
+    end
+    
+    if (trigger.customName) then
+        t = {}
+        t.text = L["%s Name Function"]:format(id);
+        t.value = t.text;
+        t.code = trigger.customName
+        tinsert(codes, t);
+    end
+    
+    if (trigger.customIcon) then
+        t = {}
+        t.text = L["%s Icon Function"]:format(id);
+        t.value = t.text;
+        t.code = trigger.customIcon
+        tinsert(codes, t);
+    end
+    
+    if (trigger.customTexture) then
+        t = {}
+        t.text = L["%s Texture Function"]:format(id);
+        t.value = t.text;
+        t.code = trigger.customTexture
+        tinsert(codes, t);
+    end
+    
+    if (trigger.customStacks) then
+        t = {}
+        t.text = L["%s Stacks Function"]:format(id);
+        t.value = t.text;
+        t.code = trigger.customStacks
+        tinsert(codes, t);
+    end
+end
 
-            if (untrigger and untrigger.custom) then
-                t = {}
-                t.text = L["%s Untrigger Function"]:format(id);
-                t.value = t.text;
-                t.code = untrigger.custom;
-                tinsert(codes, t);
-            end
+local function checkCustom(codes, id, base)
+    if (not base) then return end
+    if (base.custom) then
+        local t = {};
+        t.text = id;
+        t.value = id;
+        t.code = base.custom
+        tinsert(codes, t);
+    end
+end
 
-            if (trigger.customDuration) then
-                t = {}
-                t.text = L["%s Duration Function"]:format(id);
-                t.value = t.text;
-                t.code = trigger.customDuration
-                tinsert(codes, t);
-            end
+local function checkAnimation(codes, id, a)
+    if (not a) then return end
+    if (a.alphaType == "custom" and a.use_alpha and a.alphaFunc) then
+        local t = {};
+        t.text = L["%s - Alpha Animation"]:format(id);
+        t.value = t.text;
+        t.code = a.alphaFunc;
+        tinsert(codes, t);
+    end
+    
+    if (a.translateType == "custom" and a.use_translate and a.translateFunc) then
+        local t = {};
+        t.text = L["%s - Translate Animation"]:format(id);
+        t.value = t.text;
+        t.code = a.translateFunc;
+        tinsert(codes, t);
+    end
+    
+    if (a.scaleType == "custom" and a.use_scale and a.scaleFunc) then
+        local t = {};
+        t.text = L["%s - Scale Animation"]:format(id);
+        t.value = t.text;
+        t.code = a.scaleFunc;
+        tinsert(codes, t);
+    end
+    
+    if (a.rotateType == "custom" and a.use_rotate and a.rotateFunc) then
+        local t = {};
+        t.text = L["%s - Rotate Animation"]:format(id);
+        t.value = t.text;
+        t.code = a.rotateFunc;
+        tinsert(codes, t);
+    end
+    
+    if (a.colorType == "custom" and a.use_color and a.colorFunc) then
+        local t = {};
+        t.text = L["%s - Color Animation"]:format(id);
+        t.value = t.text;
+        t.code = a.colorFunc
+        tinsert(codes, t);
+    end
+end
 
-            if (trigger.customName) then
-                t = {}
-                t.text = L["%s Name Function"]:format(id);
-                t.value = t.text;
-                t.code = trigger.customName
-                tinsert(codes, t);
-            end
+local function checkTriggerLogic(codes, id, logic)
+    if (not logic) then return end
+    local t = {};
+    t.text = id;
+    t.value = id;
+    t.code = logic;
+    tinsert(codes, t);
+end
 
-            if (trigger.customIcon) then
-                t = {}
-                t.text = L["%s Icon Function"]:format(id);
-                t.value = t.text;
-                t.code = trigger.customIcon
-                tinsert(codes, t);
-            end
+local function checkText(codes, id, customText)
+    if (not customText) then return end
+    local t = {};
+    t.text = id;
+    t.value = id;
+    t.code = customText;
+    tinsert(codes, t);
+end
 
-            if (trigger.customTexture) then
-                t = {}
-                t.text = L["%s Texture Function"]:format(id);
-                t.value = t.text;
-                t.code = trigger.customTexture
-                tinsert(codes, t);
-            end
-
-            if (trigger.customStacks) then
-                t = {}
-                t.text = L["%s Stacks Function"]:format(id);
-                t.value = t.text;
-                t.code = trigger.customStacks
-                tinsert(codes, t);
-            end
+local function scamCheck(codes, data)
+    local r
+    checkTrigger(codes, L["%s - 1. Trigger"]:format(data.id), data.trigger, data.untrigger);
+    if (data.additional_triggers) then
+        for i, v in ipairs(data.additional_triggers) do
+            checkTrigger(codes, L["%s - %i. Trigger"]:format(data.id, i+1), v.trigger, v.untrigger);
         end
     end
 
-    local function checkCustom(codes, id, base)
-        if (not base) then return end
-        if (base.do_custom) then
-            local t = {};
-            t.text = id;
-            t.value = id;
-            t.code = base.custom
-            tinsert(codes, t);
-        end
+    if (data.actions) then
+        r = checkCustom(codes, L["%s - Init Action"]:format(data.id), data.actions.init);
+        r = checkCustom(codes, L["%s - Start Action"]:format(data.id), data.actions.start);
+        r = checkCustom(codes, L["%s - Finish Action"]:format(data.id), data.actions.finish);
     end
 
-    local function checkAnimation(codes, id, a)
-        if (not a) then return end
-        if (a.type == "custom") then
-            if (a.alphaType == "custom" and a.use_alpha and a.alphaFunc) then
-                local t = {};
-                t.text = L["%s - Alpha Animation"]:format(id);
-                t.value = t.text;
-                t.code = a.alphaFunc;
-                tinsert(codes, t);
-            end
-
-            if (a.translateType == "custom" and a.use_translate and a.translateFunc) then
-                local t = {};
-                t.text = L["%s - Translate Animation"]:format(id);
-                t.value = t.text;
-                t.code = a.translateFunc;
-                tinsert(codes, t);
-            end
-
-            if (a.scaleType == "custom" and a.use_scale and a.scaleFunc) then
-                local t = {};
-                t.text = L["%s - Scale Animation"]:format(id);
-                t.value = t.text;
-                t.code = a.scaleFunc;
-                tinsert(codes, t);
-            end
-
-            if (a.rotateType == "custom" and a.use_rotate and a.rotateFunc) then
-                local t = {};
-                t.text = L["%s - Rotate Animation"]:format(id);
-                t.value = t.text;
-                t.code = a.rotateFunc;
-                tinsert(codes, t);
-            end
-
-            if (a.colorType == "custom" and a.use_color and a.colorFunc) then
-                local t = {};
-                t.text = L["%s - Color Animation"]:format(id);
-                t.value = t.text;
-                t.code = a.colorFunc
-                tinsert(codes, t);
-            end
-        end
+    if (data.animation) then
+        r = checkAnimation(codes, L["%s - Start"]:format(data.id), data.animation.start);
+        r = checkAnimation(codes, L["%s - Main"]:format(data.id), data.animation.main);
+        r = checkAnimation(codes, L["%s - Finish"]:format(data.id), data.animation.finish);
     end
-
-    local function scamCheck(codes, data)
-        local r
-        checkTrigger(codes, L["%s - 1. Trigger"]:format(data.id), data.trigger, data.untrigger);
-        if (data.additional_triggers) then
-            for i, v in ipairs(data.additional_triggers) do
-                checkTrigger(codes, L["%s - %i. Trigger"]:format(data.id, i+1), v.trigger, v.untrigger);
-            end
-        end
-
-        if (data.actions) then
-            r = checkCustom(codes, L["%s - Init Action"]:format(data.id), data.actions.init);
-            r = checkCustom(codes, L["%s - Start Action"]:format(data.id), data.actions.start);
-            r = checkCustom(codes, L["%s - Finish Action"]:format(data.id), data.actions.finish);
-        end
-
-        if (data.animation) then
-            r = checkAnimation(codes, L["%s - Start"]:format(data.id), data.animation.start);
-            r = checkAnimation(codes, L["%s - Main"]:format(data.id), data.animation.main);
-            r = checkAnimation(codes, L["%s - Finish"]:format(data.id), data.animation.finish);
-        end
+	
+    if(data.customTriggerLogic) then
+        r = checkTriggerLogic(codes,  L["%s - Trigger Logic"]:format(data.id), data.customTriggerLogic);
     end
+    
+    if(data.customText) then
+        r = checkText(codes, L["%s - Custom Text"]:format(data.id), data.customText);
+    end
+end
 
-    function WeakAuras.ShowDisplayTooltip(data, children, icon, icons, import, compressed, alterdesc)
-        if(type(data) == "table") then
-            if(compressed) then
-                DecompressDisplay(data);
-                data.controlledChildren = nil;
+function WeakAuras.ShowDisplayTooltip(data, children, icon, icons, import, compressed, alterdesc)
+    if(type(data) == "table") then
+        if(compressed) then
+            DecompressDisplay(data);
+            data.controlledChildren = nil;
+        end
+
+        local regionType = data.regionType;
+        local regionData = regionOptions[regionType or ""]
+        local displayName = regionData and regionData.displayName or "";
+
+        local tooltip = {
+            -- 1. parameter: 1 => AddLine, 2=> AddDoubleLine,
+            -- Rest of parameters identically to AddLine or AddDoubleLine:
+            -- AddLine: text [, red, green, blue [, wrapText]]
+            -- AddDoubleLine: textLeft, textRight, textLeft.r, textLeft.g, textLeft.b, textRight.r, textRight.g, textRight.b
+            {2, data.id, "          ", 0.5333, 0, 1},
+            {2, displayName, "          ", 1, 0.82, 0},
+            {1, " ", 1, 1, 1}
+        };
+
+        local codes = {};
+        scamCheck(codes, data);
+        if(children) then
+            for index, childData in pairs(children) do
+                tinsert(tooltip, {2, " ", childData.id, 1, 1, 1, 1, 1, 1});
+                scamCheck(codes, childData);
             end
-
-            local regionType = data.regionType;
-            local regionData = regionOptions[regionType or ""]
-            local displayName = regionData and regionData.displayName or "";
-
-            local tooltip = {
-                -- 1. parameter: 1 => AddLine, 2=> AddDoubleLine,
-                -- Rest of parameters identically to AddLine or AddDoubleLine:
-                -- AddLine: text [, red, green, blue [, wrapText]]
-                -- AddDoubleLine: textLeft, textRight, textLeft.r, textLeft.g, textLeft.b, textRight.r, textRight.g, textRight.b
-                {2, data.id, "          ", 0.5333, 0, 1},
-                {2, displayName, "          ", 1, 0.82, 0},
-                {1, " ", 1, 1, 1}
-            };
-
-            local codes = {};
-            scamCheck(codes, data);
-            if(children) then
-                for index, childData in pairs(children) do
-                    tinsert(tooltip, {2, " ", childData.id, 1, 1, 1, 1, 1, 1});
-                    scamCheck(codes, childData);
-                end
-                if(#tooltip > 3) then
-                    tooltip[4][2] = L["Children:"];
-                else
-                    tinsert(tooltip, {1, L["No Children:"], 1, 1, 1});
-                end
-            elseif(data.controlledChildren) then
-                for index, childId in pairs(data.controlledChildren) do
-                    tinsert(tooltip, {2, " ", childId, 1, 1, 1, 1, 1, 1});
-                end
-                if(#tooltip > 3) then
-                    tooltip[4][2] = L["Children:"];
-                else
-                    tinsert(tooltip, {1, L["No Children:"], 1, 1, 1});
-                end
+            if(#tooltip > 3) then
+                tooltip[4][2] = L["Children:"];
             else
-                for triggernum = 0, 9 do
-                    local trigger;
-                    if(triggernum == 0) then
-                        trigger = data.trigger;
-                    elseif(data.additional_triggers and data.additional_triggers[triggernum]) then
-                        trigger = data.additional_triggers[triggernum].trigger;
-                    end
-                    if(trigger) then
-                        if(trigger.type == "aura") then
-                            for index, name in pairs(trigger.names) do
-                                local left = " ";
-                                if(index == 1) then
-                                    if(#trigger.names > 0) then
-                                        if(#trigger.names > 1) then
-                                            left = L["Auras:"];
-                                        else
-                                            left = L["Aura:"];
-                                        end
+                tinsert(tooltip, {1, L["No Children:"], 1, 1, 1});
+            end
+        elseif(data.controlledChildren) then
+            for index, childId in pairs(data.controlledChildren) do
+                tinsert(tooltip, {2, " ", childId, 1, 1, 1, 1, 1, 1});
+            end
+            if(#tooltip > 3) then
+                tooltip[4][2] = L["Children:"];
+            else
+                tinsert(tooltip, {1, L["No Children:"], 1, 1, 1});
+            end
+        else
+            for triggernum = 0, 9 do
+                local trigger;
+                if(triggernum == 0) then
+                    trigger = data.trigger;
+                elseif(data.additional_triggers and data.additional_triggers[triggernum]) then
+                    trigger = data.additional_triggers[triggernum].trigger;
+                end
+                if(trigger) then
+                    if(trigger.type == "aura") then
+                        for index, name in pairs(trigger.names) do
+                            local left = " ";
+                            if(index == 1) then
+                                if(#trigger.names > 0) then
+                                    if(#trigger.names > 1) then
+                                        left = L["Auras:"];
+                                    else
+                                        left = L["Aura:"];
                                     end
                                 end
+                            end
 
-                                local i = icons or (WeakAurasOptionsSaved and WeakAurasOptionsSaved.iconCache);
-                                tinsert(tooltip, {2, left, name..(i and i[name] and (" |T"..i[name]..":12:12:0:0:64:64:4:60:4:60|t") or ""), 1, 1, 1, 1, 1, 1});
-                            end
-                        elseif(trigger.type == "event" or trigger.type == "status") then
-                            if(trigger.type == "event") then
-                                tinsert(tooltip, {2, L["Trigger:"], (event_types[trigger.event] or L["Undefined"]), 1, 1, 1, 1, 1, 1});
-                            else
-                                tinsert(tooltip, {2, L["Trigger:"], (status_types[trigger.event] or L["Undefined"]), 1, 1, 1, 1, 1, 1});
-                            end
-                            if(trigger.event == "Combat Log" and trigger.subeventPrefix and trigger.subeventSuffix) then
-                                tinsert(tooltip, {2, L["Message type:"], (WeakAuras.subevent_prefix_types[trigger.subeventPrefix] or L["Undefined"]).." "..(WeakAuras.subevent_suffix_types[trigger.subeventSuffix] or L["Undefined"]), 1, 1, 1, 1, 1, 1});
-                            end
-                        else
-                            tinsert(tooltip, {2, L["Trigger:"], L["Custom"], 1, 1, 1, 1, 1, 1});
+                            local i = icons or (WeakAurasOptionsSaved and WeakAurasOptionsSaved.iconCache);
+                            tinsert(tooltip, {2, left, name..(i and i[name] and (" |T"..i[name]..":12:12:0:0:64:64:4:60:4:60|t") or ""), 1, 1, 1, 1, 1, 1});
                         end
-                    end
-                end
-            end
-
-            if (import and #tooltip > 30) then
-                -- Truncate the tooltip to ~25 auras if there are more than ~30
-                local size = #tooltip
-                tooltip[26] = {2, " ",  "[...]", 1, 1, 1, 1, 1, 1};
-                local nrOfChildren = children and #children or data.controlledChildren and #data.controlledChildren or 0
-                tooltip[27] = {1, string.format(L["%s total auras"], nrOfChildren), "", 1, 1, 1, 1, 1, 1};
-                for i = 28, size do
-                    tooltip[i] = nil;
-                end
-            end
-
-            if(data.desc and data.desc ~= "") then
-                tinsert(tooltip, {1, " "});
-                tinsert(tooltip, {1, "\""..data.desc.."\"", 1, 0.82, 0, 1});
-            end
-
-            local importbutton;
-            local showcodebutton;
-            if(import) then
-                tinsert(tooltip, {1, " "});
-                if(type(import) == "string" and import ~= "unknown") then
-                    tinsert(tooltip, {2, L["From"]..": "..import, "                         ", 0, 1, 0});
-                end
-
-                if #codes > 0 then
-                    tinsert(tooltip, {1, "The Aura you are importing contains custom code.", 1, 0, 0});
-                    tinsert(tooltip, {1, "Make sure you can trust the person who sent it!", 1, 0, 0});
-                end
-
-                tinsert(tooltip, {2, " ", "                         ", 0, 1, 0});
-                tinsert(tooltip, {2, " ", "                         ", 0, 1, 0});
-
-                if not(ItemRefTooltip.WeakAuras_Tooltip_Button) then
-                    ItemRefTooltip.WeakAuras_Tooltip_Button = CreateFrame("Button", "WeakAurasTooltipImportButton", ItemRefTooltip, "UIPanelButtonTemplate")
-                end
-                importbutton = ItemRefTooltip.WeakAuras_Tooltip_Button;
-                importbutton:SetPoint("BOTTOMRIGHT", ItemRefTooltip, "BOTTOMRIGHT", -8, 8);
-                importbutton:SetWidth(90);
-                importbutton:RegisterEvent("PLAYER_REGEN_ENABLED");
-                importbutton:RegisterEvent("PLAYER_REGEN_DISABLED");
-
-                if not(ItemRefTooltip.WeakAuras_Tooltip_Button2) then
-                    ItemRefTooltip.WeakAuras_Tooltip_Button2 = CreateFrame("Button", "WeakAurasTooltipImportButton", ItemRefTooltip, "UIPanelButtonTemplate")
-                end
-                showcodebutton = ItemRefTooltip.WeakAuras_Tooltip_Button2;
-                showcodebutton:SetPoint("BOTTOMLEFT", ItemRefTooltip, "BOTTOMLEFT", 8, 8);
-                showcodebutton:SetWidth(90);
-
-                local function onCombat(self, event)
-                    if (event == "PLAYER_REGEN_ENABLED") then
-                        importbutton:Enable();
+                    elseif(trigger.type == "event" or trigger.type == "status") then
+                        if(trigger.type == "event") then
+                            tinsert(tooltip, {2, L["Trigger:"], (event_types[trigger.event] or L["Undefined"]), 1, 1, 1, 1, 1, 1});
+                        else
+                            tinsert(tooltip, {2, L["Trigger:"], (status_types[trigger.event] or L["Undefined"]), 1, 1, 1, 1, 1, 1});
+                        end
+                        if(trigger.event == "Combat Log" and trigger.subeventPrefix and trigger.subeventSuffix) then
+                            tinsert(tooltip, {2, L["Message type:"], (WeakAuras.subevent_prefix_types[trigger.subeventPrefix] or L["Undefined"]).." "..(WeakAuras.subevent_suffix_types[trigger.subeventSuffix] or L["Undefined"]), 1, 1, 1, 1, 1, 1});
+                        end
                     else
-                        importbutton:Disable();
+                        tinsert(tooltip, {2, L["Trigger:"], L["Custom"], 1, 1, 1, 1, 1, 1});
                     end
                 end
+            end
+        end
 
-                importbutton:SetScript("OnEvent", onCombat);
-                if (InCombatLockdown()) then
+        if (import and #tooltip > 30) then
+            -- Truncate the tooltip to ~25 auras if there are more than ~30
+            local size = #tooltip
+            tooltip[26] = {2, " ",  "[...]", 1, 1, 1, 1, 1, 1};
+            local nrOfChildren = children and #children or data.controlledChildren and #data.controlledChildren or 0
+            tooltip[27] = {1, string.format(L["%s total auras"], nrOfChildren), "", 1, 1, 1, 1, 1, 1};
+            for i = 28, size do
+                tooltip[i] = nil;
+            end
+        end
+
+        if(data.desc and data.desc ~= "") then
+            tinsert(tooltip, {1, " "});
+            tinsert(tooltip, {1, "\""..data.desc.."\"", 1, 0.82, 0, 1});
+        end
+
+        local importbutton;
+        local showcodebutton;
+        if(import) then
+            tinsert(tooltip, {1, " "});
+            if(type(import) == "string" and import ~= "unknown") then
+                tinsert(tooltip, {2, L["From"]..": "..import, "                         ", 0, 1, 0});
+            end
+
+            if #codes > 0 then
+                tinsert(tooltip, {1, "The Aura you are importing contains custom code.", 1, 0, 0});
+                tinsert(tooltip, {1, "Make sure you can trust the person who sent it!", 1, 0, 0});
+            end
+
+            tinsert(tooltip, {2, " ", "                         ", 0, 1, 0});
+            tinsert(tooltip, {2, " ", "                         ", 0, 1, 0});
+
+            if not(ItemRefTooltip.WeakAuras_Tooltip_Button) then
+                ItemRefTooltip.WeakAuras_Tooltip_Button = CreateFrame("Button", "WeakAurasTooltipImportButton", ItemRefTooltip, "UIPanelButtonTemplate")
+            end
+            importbutton = ItemRefTooltip.WeakAuras_Tooltip_Button;
+            importbutton:SetPoint("BOTTOMRIGHT", ItemRefTooltip, "BOTTOMRIGHT", -8, 8);
+            importbutton:SetWidth(90);
+            importbutton:RegisterEvent("PLAYER_REGEN_ENABLED");
+            importbutton:RegisterEvent("PLAYER_REGEN_DISABLED");
+
+            if not(ItemRefTooltip.WeakAuras_Tooltip_Button2) then
+                ItemRefTooltip.WeakAuras_Tooltip_Button2 = CreateFrame("Button", "WeakAurasTooltipImportButton", ItemRefTooltip, "UIPanelButtonTemplate")
+            end
+            showcodebutton = ItemRefTooltip.WeakAuras_Tooltip_Button2;
+            showcodebutton:SetPoint("BOTTOMLEFT", ItemRefTooltip, "BOTTOMLEFT", 8, 8);
+            showcodebutton:SetWidth(90);
+
+            local function onCombat(self, event)
+                if (event == "PLAYER_REGEN_ENABLED") then
+                    importbutton:Enable();
+                else
                     importbutton:Disable();
                 end
-                showcodebutton:SetText(L["Show Code"]);
-                if not WeakAurasSaved.import_disabled or WeakAuras.IsImporting() then
-                    importbutton:SetText("Import");
-                    importbutton:SetScript("OnClick", function()
-                        local func = function()
-                            WeakAuras.SetImporting(true);
-                            WeakAuras.OpenOptions();
+            end
 
-                            local optionsFrame = WeakAuras.OptionsFrame();
-                            if not(optionsFrame) then
-                                WeakAuras.ToggleOptions();
-                                optionsFrame = WeakAuras.OptionsFrame();
+            importbutton:SetScript("OnEvent", onCombat);
+            if (InCombatLockdown()) then
+                importbutton:Disable();
+            end
+            showcodebutton:SetText(L["Show Code"]);
+            if not WeakAurasSaved.import_disabled or WeakAuras.IsImporting() then
+                importbutton:SetText("Import");
+                importbutton:SetScript("OnClick", function()
+                    local func = function()
+                        WeakAuras.SetImporting(true);
+                        WeakAuras.OpenOptions();
+
+                        local optionsFrame = WeakAuras.OptionsFrame();
+                        if not(optionsFrame) then
+                            WeakAuras.ToggleOptions();
+                            optionsFrame = WeakAuras.OptionsFrame();
+                        end
+
+                        if not(WeakAuras.IsOptionsOpen()) then
+                            WeakAuras.ToggleOptions();
+                        end
+
+                        local function importData(data)
+                            local id = data.id
+                            local num = 2;
+                            while(WeakAurasSaved.displays[id]) do
+                                id = data.id.." "..num;
+                                num = num + 1;
                             end
+                            data.id = id;
+                            data.parent = nil;
 
-                            if not(WeakAuras.IsOptionsOpen()) then
-                                WeakAuras.ToggleOptions();
-                            end
-
-                            local function importData(data)
-                                local id = data.id
-                                local num = 2;
-                                while(WeakAurasSaved.displays[id]) do
-                                    id = data.id.." "..num;
-                                    num = num + 1;
-                                end
-                                data.id = id;
-                                data.parent = nil;
-
-                                WeakAuras.Add(data);
-                                WeakAuras.NewDisplayButton(data);
-                            end
-
-                            importData(data);
                             WeakAuras.Add(data);
                             WeakAuras.NewDisplayButton(data);
-                            coroutine.yield();
-
-                            if(children) then
-                                for index, childData in pairs(children) do
-                                    importData(childData);
-                                    tinsert(data.controlledChildren, childData.id);
-                                    childData.parent = data.id;
-                                    WeakAuras.Add(data);
-                                    WeakAuras.Add(childData);
-                                    coroutine.yield();
-                                end
-                            end
-
-                            if (children) then
-                                for index, childData in pairs(children) do
-                                    WeakAuras.NewDisplayButton(childData);
-                                    local childButton = WeakAuras.GetDisplayButton(childData.id);
-                                    childButton:SetGroup(data.id, data.regionType == "dynamicgroup");
-                                    childButton:SetGroupOrder(index, #data.controlledChildren);
-                                    coroutine.yield();
-                                end
-
-                                local button = WeakAuras.GetDisplayButton(data.id);
-                                button.callbacks.UpdateExpandButton();
-                                WeakAuras.UpdateDisplayButton(data);
-                                WeakAuras.ReloadGroupRegionOptions(data);
-                                WeakAuras.SortDisplayButtons();
-                            end
-
-                            WeakAuras.Add(data);
-                            ItemRefTooltip:Hide();
-                            WeakAuras.PickDisplay(data.id);
-                            WeakAuras.CloseImportExport();
-                            WeakAuras.SetImporting(false);
                         end
 
-                        local co = coroutine.create(func);
-                        WeakAuras.dynFrame:AddAction("import", co);
-                    end);
-                else
-                    -- TODO enable button after importing finished
-                    importbutton:SetText("Import disabled");
-                    importbutton:SetScript("OnClick", function()
+                        importData(data);
+                        WeakAuras.Add(data);
+                        WeakAuras.NewDisplayButton(data);
+                        coroutine.yield();
+
+                        if(children) then
+                            for index, childData in pairs(children) do
+                                importData(childData);
+                                tinsert(data.controlledChildren, childData.id);
+                                childData.parent = data.id;
+                                WeakAuras.Add(data);
+                                WeakAuras.Add(childData);
+                                coroutine.yield();
+                            end
+                        end
+
+                        if (children) then
+                            for index, childData in pairs(children) do
+                                WeakAuras.NewDisplayButton(childData);
+                                local childButton = WeakAuras.GetDisplayButton(childData.id);
+                                childButton:SetGroup(data.id, data.regionType == "dynamicgroup");
+                                childButton:SetGroupOrder(index, #data.controlledChildren);
+                                coroutine.yield();
+                            end
+
+                            local button = WeakAuras.GetDisplayButton(data.id);
+                            button.callbacks.UpdateExpandButton();
+                            WeakAuras.UpdateDisplayButton(data);
+                            WeakAuras.ReloadGroupRegionOptions(data);
+                            WeakAuras.SortDisplayButtons();
+                        end
+
+                        WeakAuras.Add(data);
+                        ItemRefTooltip:Hide();
+                        WeakAuras.PickDisplay(data.id);
                         WeakAuras.CloseImportExport();
-                    end);
-                end
+                        WeakAuras.SetImporting(false);
+                    end
 
-                showcodebutton:SetScript("OnClick", function()
-                    WeakAuras.OpenOptions();
-                    WeakAuras.OpenCodeReview(codes);
+                    local co = coroutine.create(func);
+                    WeakAuras.dynFrame:AddAction("import", co);
+                end);
+            else
+                -- TODO enable button after importing finished
+                importbutton:SetText("Import disabled");
+                importbutton:SetScript("OnClick", function()
+                    WeakAuras.CloseImportExport();
                 end);
             end
 
-            ShowTooltip(tooltip);
+            showcodebutton:SetScript("OnClick", function()
+                WeakAuras.OpenOptions();
+                WeakAuras.OpenCodeReview(codes);
+            end);
+        end
 
-            if(import) then
-                importbutton:Show();
-                if (#codes > 0) then
-                    showcodebutton:Show();
-                else
-                    showcodebutton:Hide();
-                end
+        ShowTooltip(tooltip);
+
+        if(import) then
+            importbutton:Show();
+            if (#codes > 0) then
+                showcodebutton:Show();
+            else
+                showcodebutton:Hide();
             end
+        end
 
-            if not(ItemRefTooltip.WeakAuras_Tooltip_Thumbnail_Frame) then
-                ItemRefTooltip.WeakAuras_Tooltip_Thumbnail_Frame = CreateFrame("frame", nil, ItemRefTooltip);
+        if not(ItemRefTooltip.WeakAuras_Tooltip_Thumbnail_Frame) then
+            ItemRefTooltip.WeakAuras_Tooltip_Thumbnail_Frame = CreateFrame("frame", nil, ItemRefTooltip);
+        end
+        local thumbnail_frame = ItemRefTooltip.WeakAuras_Tooltip_Thumbnail_Frame;
+        thumbnail_frame:SetWidth(40);
+        thumbnail_frame:SetHeight(40);
+        thumbnail_frame:SetPoint("TOPRIGHT", ItemRefTooltip, "TOPRIGHT", -27, -7);
+
+        if(alterdesc) then
+            if not(ItemRefTooltip.WeakAuras_Desc_Box) then
+                ItemRefTooltip.WeakAuras_Desc_Box = CreateFrame("frame", nil, ItemRefTooltip);
             end
-            local thumbnail_frame = ItemRefTooltip.WeakAuras_Tooltip_Thumbnail_Frame;
-            thumbnail_frame:SetWidth(40);
-            thumbnail_frame:SetHeight(40);
-            thumbnail_frame:SetPoint("TOPRIGHT", ItemRefTooltip, "TOPRIGHT", -27, -7);
+            local descboxframe = ItemRefTooltip.WeakAuras_Desc_Box;
+            descboxframe:SetBackdrop({
+                bgFile = "Interface\\Tooltips\\UI-Tooltip-Background",
+                edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
+                edgeSize = 16,
+                insets = {
+                    left = 4,
+                    right = 3,
+                    top = 4,
+                    bottom = 3
+                }
+            });
+            descboxframe:SetBackdropColor(0, 0, 0);
+            descboxframe:SetBackdropBorderColor(0.4, 0.4, 0.4);
+            descboxframe:SetHeight(80);
+            descboxframe:SetWidth(260);
+            descboxframe:SetPoint("TOP", ItemRefTooltip, "BOTTOM");
+            descboxframe:Show();
 
-            if(alterdesc) then
-                if not(ItemRefTooltip.WeakAuras_Desc_Box) then
-                    ItemRefTooltip.WeakAuras_Desc_Box = CreateFrame("frame", nil, ItemRefTooltip);
-                end
-                local descboxframe = ItemRefTooltip.WeakAuras_Desc_Box;
-                descboxframe:SetBackdrop({
-                    bgFile = "Interface\\Tooltips\\UI-Tooltip-Background",
-                    edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
-                    edgeSize = 16,
-                    insets = {
-                        left = 4,
-                        right = 3,
-                        top = 4,
-                        bottom = 3
-                    }
-                });
-                descboxframe:SetBackdropColor(0, 0, 0);
-                descboxframe:SetBackdropBorderColor(0.4, 0.4, 0.4);
-                descboxframe:SetHeight(80);
-                descboxframe:SetWidth(260);
-                descboxframe:SetPoint("TOP", ItemRefTooltip, "BOTTOM");
-                descboxframe:Show();
-
-                local descbox = descboxframe.descbox;
-                if not(descbox) then
-                    descbox = CreateFrame("editbox", nil, descboxframe);
-                    descboxframe.descbox = descbox;
-                end
-                descbox:SetPoint("BOTTOMLEFT", descboxframe, "BOTTOMLEFT", 8, 8);
-                descbox:SetPoint("TOPRIGHT", descboxframe, "TOPRIGHT", -8, -8);
-                descbox:SetFont("Fonts\\FRIZQT__.TTF", 12);
-                descbox:EnableMouse(true);
-                descbox:SetAutoFocus(false);
-                descbox:SetCountInvisibleLetters(false);
-                descbox:SetMultiLine(true);
-                descbox:SetScript("OnEscapePressed", function()
-                    descbox:ClearFocus();
-                    if(data.desc and data.desc ~= "") then
-                        descbox:SetText(data.desc);
-                    else
-                        descbox:SetText("");
-                    end
-                end);
-                descbox:SetScript("OnEnterPressed", function()
-                    if(descbox:GetText() ~= "") then
-                        data.desc = descbox:GetText();
-                    else
-                        data.desc = nil;
-                    end
-                    WeakAuras.ShowDisplayTooltip(data, children, nil, nil, import, nil, true);
-                    descbox:ClearFocus();
-                    if(WeakAuras.GetDisplayButton) then
-                        local button = WeakAuras.GetDisplayButton(data.id);
-                        if(button) then
-                            button:SetNormalTooltip();
-                        end
-                    end
-                end);
+            local descbox = descboxframe.descbox;
+            if not(descbox) then
+                descbox = CreateFrame("editbox", nil, descboxframe);
+                descboxframe.descbox = descbox;
+            end
+            descbox:SetPoint("BOTTOMLEFT", descboxframe, "BOTTOMLEFT", 8, 8);
+            descbox:SetPoint("TOPRIGHT", descboxframe, "TOPRIGHT", -8, -8);
+            descbox:SetFont("Fonts\\FRIZQT__.TTF", 12);
+            descbox:EnableMouse(true);
+            descbox:SetAutoFocus(false);
+            descbox:SetCountInvisibleLetters(false);
+            descbox:SetMultiLine(true);
+            descbox:SetScript("OnEscapePressed", function()
+                descbox:ClearFocus();
                 if(data.desc and data.desc ~= "") then
                     descbox:SetText(data.desc);
                 else
                     descbox:SetText("");
                 end
-                descbox:SetFocus();
-                descbox:Show();
+            end);
+            descbox:SetScript("OnEnterPressed", function()
+                if(descbox:GetText() ~= "") then
+                    data.desc = descbox:GetText();
+                else
+                    data.desc = nil;
+                end
+                WeakAuras.ShowDisplayTooltip(data, children, nil, nil, import, nil, true);
+                descbox:ClearFocus();
+                if(WeakAuras.GetDisplayButton) then
+                    local button = WeakAuras.GetDisplayButton(data.id);
+                    if(button) then
+                        button:SetNormalTooltip();
+                    end
+                end
+            end);
+            if(data.desc and data.desc ~= "") then
+                descbox:SetText(data.desc);
+            else
+                descbox:SetText("");
+            end
+            descbox:SetFocus();
+            descbox:Show();
+        end
+
+        local RegularGetData;
+        if(children) then
+            data.controlledChildren = {};
+            for index, childData in pairs(children) do
+                if(compressed) then
+                    DecompressDisplay(childData);
+                end
+                data.controlledChildren[index] = childData.id;
             end
 
-            local RegularGetData;
-            if(children) then
-                data.controlledChildren = {};
-                for index, childData in pairs(children) do
-                    if(compressed) then
-                        DecompressDisplay(childData);
-                    end
-                    data.controlledChildren[index] = childData.id;
-                end
-
-                -- WeakAuras.GetData needs to be replaced temporarily so that when the subsequent code constructs the thumbnail for
-                -- the tooltip, it will look to the incoming transmission data for child data. This allows thumbnails of incoming
-                -- groups to be constructed properly.
-                RegularGetData = WeakAuras.GetData;
-                WeakAuras.GetData = function(id)
-                    if(children) then
-                        for index, childData in pairs(children) do
-                            if(childData.id == id) then
-                                return childData;
-                            end
+            -- WeakAuras.GetData needs to be replaced temporarily so that when the subsequent code constructs the thumbnail for
+            -- the tooltip, it will look to the incoming transmission data for child data. This allows thumbnails of incoming
+            -- groups to be constructed properly.
+            RegularGetData = WeakAuras.GetData;
+            WeakAuras.GetData = function(id)
+                if(children) then
+                    for index, childData in pairs(children) do
+                        if(childData.id == id) then
+                            return childData;
                         end
                     end
                 end
             end
-
-            if (not IsAddOnLoaded('WeakAurasOptions')) then
-                LoadAddOn('WeakAurasOptions')
-            end
-
-            local ok,thumbnail = pcall(regionOptions[regionType].createThumbnail,thumbnail_frame, regionTypes[regionType].create);
-            if not ok then
-                error("Error creating thumbnail", 2)
-            else
-                --print("OK")
-            end
-
-            WeakAuras.validate(data, regionTypes[regionType].default);
-            regionOptions[regionType].modifyThumbnail(thumbnail_frame, thumbnail, data, regionTypes[regionType].modify);
-            ItemRefTooltip.WeakAuras_Tooltip_Thumbnail = thumbnail;
-
-            thumbnail:SetAllPoints(thumbnail_frame);
-            if(thumbnail.SetIcon) then
-                local i;
-                if(icon) then
-                    i = icon;
-                elseif(WeakAuras.transmitCache and WeakAuras.transmitCache[data.id]) then
-                    i = WeakAuras.transmitCache[data.id];
-                end
-                thumbnail:SetIcon(i);
-            end
-            thumbnail_frame:Show();
-
-            if(children and RegularGetData) then
-                WeakAuras.GetData = RegularGetData;
-                data.controlledChildren = nil;
-            end
-        elseif(type(data) == "string") then
-            ShowTooltip({
-                {1, "WeakAuras", 0.5333, 0, 1},
-                {1, data, 1, 0, 0}
-            });
         end
-    end
 
-    function WeakAuras.ImportString(str)
-        local received = StringToTable(str, true);
-        if(received and type(received) == "table" and received.m) then
-            if(received.m == "d") then
-                tooltipLoading = nil;
-                if(version < received.v) then
-                    local errorMsg = L["Version error received higher"]
-                    ShowTooltip({
-                        {1, "WeakAuras", 0.5333, 0, 1},
-                        {1, errorMsg:format(received.s, versionString), 1, 0, 0}
-                    });
-                else
-                    local data = received.d;
-                    WeakAuras.ShowDisplayTooltip(data, received.c, received.i, received.a, "unknown", true)
-                end
-            end
-        elseif(type(received) == "string") then
-            ShowTooltip({
-                {1, "WeakAuras", 0.5333, 0, 1},
-                {1, received, 1, 0, 0, 1}
-            });
+        if (not IsAddOnLoaded('WeakAurasOptions')) then
+            LoadAddOn('WeakAurasOptions')
         end
-    end
 
-    local safeSenders = {}
-    function RequestDisplay(characterName, displayName)
-        safeSenders[characterName] = true
-        safeSenders[Ambiguate(characterName, "none")] = true
-        local transmit = {
-            m = "dR",
-            d = displayName
-        };
-        local transmitString = TableToString(transmit);
-        Comm:SendCommMessage("WeakAuras", transmitString, "WHISPER", characterName);
-    end
-
-    function TransmitError(errorMsg, characterName)
-        local transmit = {
-            m = "dE",
-            eM = errorMsg
-        };
-        Comm:SendCommMessage("WeakAuras", TableToString(transmit), "WHISPER", characterName);
-    end
-
-    function TransmitDisplay(id, characterName)
-        local encoded = WeakAuras.DisplayToString(id);
-        if(encoded ~= "") then
-            Comm:SendCommMessage("WeakAuras", encoded, "WHISPER", characterName, "BULK", function(displayName, done, total)
-                Comm:SendCommMessage("WeakAurasProg", done.." "..total.." "..displayName, "WHISPER", characterName, "ALERT");
-            end, id);
+        local ok,thumbnail = pcall(regionOptions[regionType].createThumbnail,thumbnail_frame, regionTypes[regionType].create);
+        if not ok then
+            error("Error creating thumbnail", 2)
         else
-            TransmitError("dne", characterName);
+            --print("OK")
         end
-    end
 
-    Comm:RegisterComm("WeakAurasProg", function(prefix, message, distribution, sender)
-            if tooltipLoading and ItemRefTooltip:IsVisible() and safeSenders[sender] then
-                local done, total, displayName = strsplit(" ", message, 3)
-                local done = tonumber(done)
-                local total = tonumber(total)
-                if(done and total and total >= done) then
-                    local red = min(255, (1 - done / total) * 511)
-                    local green = min(255, (done / total) * 511)
-                    ShowTooltip({
-                        {2, "WeakAuras", displayName, 0.5, 0, 1, 1, 1, 1},
-                        {1, L["Receiving display information"]:format(sender), 1, 0.82, 0},
-                        {2, " ", ("|cFF%2x%2x00"):format(red, green)..done.."|cFF00FF00/"..total}
-                    })
-                end
+        WeakAuras.validate(data, regionTypes[regionType].default);
+        regionOptions[regionType].modifyThumbnail(thumbnail_frame, thumbnail, data, regionTypes[regionType].modify);
+        ItemRefTooltip.WeakAuras_Tooltip_Thumbnail = thumbnail;
+
+        thumbnail:SetAllPoints(thumbnail_frame);
+        if(thumbnail.SetIcon) then
+            local i;
+            if(icon) then
+                i = icon;
+            elseif(WeakAuras.transmitCache and WeakAuras.transmitCache[data.id]) then
+                i = WeakAuras.transmitCache[data.id];
             end
-        end)
+            thumbnail:SetIcon(i);
+        end
+        thumbnail_frame:Show();
 
-    Comm:RegisterComm("WeakAuras", function(prefix, message, distribution, sender)
-            local received = StringToTable(message);
-            if(received and type(received) == "table" and received.m) then
-                if(received.m == "d") and safeSenders[sender] then
-                    tooltipLoading = nil;
-                    if(version ~= received.v) then
-                        local errorMsg = version > received.v and L["Version error received lower"] or L["Version error received higher"]
-                        ShowTooltip({
-                            {1, "WeakAuras", 0.5333, 0, 1},
-                            {1, errorMsg:format(received.s, versionString), 1, 0, 0}
-                        });
-                    else
-                        local data = received.d;
-                        WeakAuras.ShowDisplayTooltip(data, received.c, received.i, received.a, sender, true)
-                    end
-                elseif(received.m == "dR") then
-                    --if(WeakAuras.linked[received.d]) then
-                    TransmitDisplay(received.d, sender);
-                    --else
-                    --    TransmitError("not authorized", sender);
-                    --end
-                elseif(received.m == "dE") then
-                    tooltipLoading = nil;
-                    if(received.eM == "dne") then
-                        ShowTooltip({
-                            {1, "WeakAuras", 0.5333, 0, 1},
-                            {1, L["Requested display does not exist"], 1, 0, 0}
-                        });
-                    elseif(received.eM == "na") then
-                        ShowTooltip({
-                            {1, "WeakAuras", 0.5333, 0, 1},
-                            {1, L["Requested display not authorized"], 1, 0, 0}
-                        });
-                    end
-                end
-            elseif(ItemRefTooltip.WeakAuras_Tooltip_Thumbnail and ItemRefTooltip.WeakAuras_Tooltip_Thumbnail:IsVisible()) then
+        if(children and RegularGetData) then
+            WeakAuras.GetData = RegularGetData;
+            data.controlledChildren = nil;
+        end
+    elseif(type(data) == "string") then
+        ShowTooltip({
+            {1, "WeakAuras", 0.5333, 0, 1},
+            {1, data, 1, 0, 0}
+        });
+    end
+end
+
+function WeakAuras.ImportString(str)
+    local received = StringToTable(str, true);
+    if(received and type(received) == "table" and received.m) then
+        if(received.m == "d") then
+            tooltipLoading = nil;
+            if(version < received.v) then
+                local errorMsg = L["Version error received higher"]
                 ShowTooltip({
                     {1, "WeakAuras", 0.5333, 0, 1},
-                    {1, L["Transmission error"], 1, 0, 0}
+                    {1, errorMsg:format(received.s, versionString), 1, 0, 0}
                 });
+            else
+                local data = received.d;
+                WeakAuras.ShowDisplayTooltip(data, received.c, received.i, received.a, "unknown", true)
             end
-        end);
+        end
+    elseif(type(received) == "string") then
+        ShowTooltip({
+            {1, "WeakAuras", 0.5333, 0, 1},
+            {1, received, 1, 0, 0, 1}
+        });
+    end
+end
+
+local safeSenders = {}
+function RequestDisplay(characterName, displayName)
+    safeSenders[characterName] = true
+    safeSenders[Ambiguate(characterName, "none")] = true
+    local transmit = {
+        m = "dR",
+        d = displayName
+    };
+    local transmitString = TableToString(transmit);
+    Comm:SendCommMessage("WeakAuras", transmitString, "WHISPER", characterName);
+end
+
+function TransmitError(errorMsg, characterName)
+    local transmit = {
+        m = "dE",
+        eM = errorMsg
+    };
+    Comm:SendCommMessage("WeakAuras", TableToString(transmit), "WHISPER", characterName);
+end
+
+function TransmitDisplay(id, characterName)
+    local encoded = WeakAuras.DisplayToString(id);
+    if(encoded ~= "") then
+        Comm:SendCommMessage("WeakAuras", encoded, "WHISPER", characterName, "BULK", function(displayName, done, total)
+            Comm:SendCommMessage("WeakAurasProg", done.." "..total.." "..displayName, "WHISPER", characterName, "ALERT");
+        end, id);
+    else
+        TransmitError("dne", characterName);
+    end
+end
+
+Comm:RegisterComm("WeakAurasProg", function(prefix, message, distribution, sender)
+     if tooltipLoading and ItemRefTooltip:IsVisible() and safeSenders[sender] then
+         local done, total, displayName = strsplit(" ", message, 3)
+         local done = tonumber(done)
+         local total = tonumber(total)
+         if(done and total and total >= done) then
+             local red = min(255, (1 - done / total) * 511)
+             local green = min(255, (done / total) * 511)
+             ShowTooltip({
+                 {2, "WeakAuras", displayName, 0.5, 0, 1, 1, 1, 1},
+                 {1, L["Receiving display information"]:format(sender), 1, 0.82, 0},
+                 {2, " ", ("|cFF%2x%2x00"):format(red, green)..done.."|cFF00FF00/"..total}
+             })
+         end
+     end
+ end)
+
+ Comm:RegisterComm("WeakAuras", function(prefix, message, distribution, sender)
+     local received = StringToTable(message);
+     if(received and type(received) == "table" and received.m) then
+         if(received.m == "d") and safeSenders[sender] then
+             tooltipLoading = nil;
+             if(version ~= received.v) then
+                 local errorMsg = version > received.v and L["Version error received lower"] or L["Version error received higher"]
+                 ShowTooltip({
+                     {1, "WeakAuras", 0.5333, 0, 1},
+                     {1, errorMsg:format(received.s, versionString), 1, 0, 0}
+                 });
+             else
+                 local data = received.d;
+                 WeakAuras.ShowDisplayTooltip(data, received.c, received.i, received.a, sender, true)
+             end
+         elseif(received.m == "dR") then
+             --if(WeakAuras.linked[received.d]) then
+             TransmitDisplay(received.d, sender);
+             --else
+             --    TransmitError("not authorized", sender);
+             --end
+         elseif(received.m == "dE") then
+             tooltipLoading = nil;
+             if(received.eM == "dne") then
+                 ShowTooltip({
+                     {1, "WeakAuras", 0.5333, 0, 1},
+                     {1, L["Requested display does not exist"], 1, 0, 0}
+                 });
+             elseif(received.eM == "na") then
+                 ShowTooltip({
+                     {1, "WeakAuras", 0.5333, 0, 1},
+                     {1, L["Requested display not authorized"], 1, 0, 0}
+                 });
+             end
+         end
+     elseif(ItemRefTooltip.WeakAuras_Tooltip_Thumbnail and ItemRefTooltip.WeakAuras_Tooltip_Thumbnail:IsVisible()) then
+         ShowTooltip({
+             {1, "WeakAuras", 0.5333, 0, 1},
+             {1, L["Transmission error"], 1, 0, 0}
+         });
+     end
+ end);

--- a/Types.lua
+++ b/Types.lua
@@ -54,7 +54,8 @@ WeakAuras.sound_channel_types = {
 };
 WeakAuras.trigger_require_types = {
   any = L["Any Triggers"],
-  all = L["All Triggers"]
+  all = L["All Triggers"],
+  custom = L["Custom Function"]
 };
 WeakAuras.trigger_types = {
   aura = L["Aura"],

--- a/WeakAuras.lua
+++ b/WeakAuras.lua
@@ -82,6 +82,9 @@ local squelch_actions = true;
 -- Load functions, keyed on id
 local loadFuncs = {}
 
+--custom trigger logic functions, keyed on id
+local triggerLogicFuncs = {}
+
 -- All regions keyed on id, has properties: region, regionType, also see clones
 WeakAuras.regions = {};
 local regions = WeakAuras.regions;
@@ -1252,6 +1255,7 @@ function WeakAuras.Delete(data)
   regions[id] = nil;
   loaded[id] = nil;
   loadFuncs[id] = nil;
+  triggerLogicFuncs[id] = nil;
 
   db.displays[id] = nil;
 
@@ -1282,6 +1286,8 @@ function WeakAuras.Rename(data, newid)
   loaded[oldid] = nil;
   loadFuncs[newid] = loadFuncs[oldid];
   loadFuncs[oldid] = nil;
+  triggerLogicFuncs[newid] = triggerLogicFuncs[oldid];
+  triggerLogicFuncs[oldid] = nil;
 
   db.displays[newid] = db.displays[oldid];
   db.displays[oldid] = nil;
@@ -1545,6 +1551,14 @@ function WeakAuras.Modernize(data)
     load.talent = {};
     load.talent.single = talent;
     load.talent.multi = {}
+  end
+  
+  --upgrade to support custom trigger combination logic
+  if (data.disjunctive == true) then
+    data.disjunctive = "any";
+  end
+  if(data.disjunctive == false) then
+    data.disjunctive = "all";
   end
 
   for _, triggerSystem in pairs(triggerSystems) do
@@ -1819,10 +1833,12 @@ function WeakAuras.pAdd(data)
     data.actions.finish = data.actions.finish or {};
     local loadFuncStr = WeakAuras.ConstructFunction(load_prototype, data.load);
     local loadFunc = WeakAuras.LoadFunction(loadFuncStr);
+    local triggerLogicFunc = WeakAuras.LoadFunction("return "..(data.customTriggerLogic or ""));
     WeakAuras.debug(id.." - Load", 1);
     WeakAuras.debug(loadFuncStr);
 
     loadFuncs[id] = loadFunc;
+    triggerLogicFuncs[id] = triggerLogicFunc;
 
     if(WeakAuras.CanHaveClones(data)) then
       clones[id] = clones[id] or {};
@@ -2014,8 +2030,19 @@ function WeakAuras.SetRegion(data, cloneId)
         region.trigger_count = region.trigger_count or 0;
         region.triggers = region.triggers or {};
 
-        function region:TestTriggers(trigger_count)
-          if(trigger_count > ((data.disjunctive and 0) or #data.additional_triggers)) then
+        function region:TestTriggers(triggers, trigger_count)
+          if(data.disjunctive == "custom") then
+            local customFunc = triggerLogicFuncs[data.id];
+            if customFunc then
+              if(customFunc(triggers)) then
+                region:Expand();
+                return true;
+              else
+                region:Collapse();
+                return false;
+              end
+            end
+          elseif(trigger_count > (((data.disjunctive == "any") and 0) or #data.additional_triggers)) then
             region:Expand();
             return true;
           else
@@ -2025,20 +2052,20 @@ function WeakAuras.SetRegion(data, cloneId)
         end
 
         function region:EnableTrigger(triggernum)
-          if not(region.triggers[triggernum]) then
-            region.triggers[triggernum] = true;
+          if not(region.triggers[triggernum+1]) then
+            region.triggers[triggernum+1] = true;
             region.trigger_count = region.trigger_count + 1;
-            return region:TestTriggers(region.trigger_count);
+            return region:TestTriggers(region.triggers, region.trigger_count);
           else
             return nil;
           end
         end
 
         function region:DisableTrigger(triggernum)
-          if(region.triggers[triggernum]) then
-            region.triggers[triggernum] = nil;
+          if(region.triggers[triggernum+1]) then
+            region.triggers[triggernum+1] = nil;
             region.trigger_count = region.trigger_count - 1;
-            return not region:TestTriggers(region.trigger_count);
+            return not region:TestTriggers(region.triggers, region.trigger_count);
           else
             return nil;
           end


### PR DESCRIPTION
Add capability to specify a custom trigger combination function that will be run to decide whether the overall aura is triggered based on the status of the individual triggers. This enhances the current funcitonality of ANY or ALL triggers to allow complex logic, such as "Trigger 1 AND (Trigger 2 OR Trigger 3)"

http://pastebin.com/Dw1nVVJs is an example aura using this change.

Additionally, this change REMOVES the checks in Tranmission.lua:scamCheck that only showed code int the code review if the code was enabled. With this change, if their is custom code present in the WA when transmitted, the code is shown.

remove checks in scamCheck that only showed enabled code. All code is shown in the transmitted aura

http://pastebin.com/ki2heZzx is an example of an aura that (in today's client) would show as having no code, but after this change, exposes it has a large number of functions defined, but disabled.