### PR TITLE
WeakAuras: Prepare for StopMotion Addon

### DIFF
--- a/Options/AceGUI-Widgets/AceGUIWidget-WeakAurasDisplayButton.lua
+++ b/Options/AceGUI-Widgets/AceGUIWidget-WeakAurasDisplayButton.lua
@@ -1,4 +1,4 @@
-local Type, Version = "WeakAurasDisplayButton", 22
+local Type, Version = "WeakAurasDisplayButton", 23
 local AceGUI = LibStub and LibStub("AceGUI-3.0", true)
 if not AceGUI or (AceGUI:GetWidgetVersion(Type) or 0) >= Version then return end
 
@@ -613,7 +613,7 @@ local methods = {
         end
         tinsert(namestable, {" ", "|cFF00FFFF"..L["Shift-click to create chat link"]});
         local regionData = WeakAuras.regionOptions[data.regionType or ""]
-        local displayName = regionData and regionData.displayName or "";
+        local displayName = regionData and regionData.displayName or regionType or "";
         self:SetDescription({data.id, displayName}, unpack(namestable));
     end,
     ["ReloadTooltip"] = function(self)if(

--- a/Options/AceGUI-Widgets/AceGUIWidget-WeakAurasTextureButton.lua
+++ b/Options/AceGUI-Widgets/AceGUIWidget-WeakAurasTextureButton.lua
@@ -1,4 +1,4 @@
-local Type, Version = "WeakAurasTextureButton", 20
+local Type, Version = "WeakAurasTextureButton", 21
 local AceGUI = LibStub and LibStub("AceGUI-3.0", true)
 if not AceGUI or (AceGUI:GetWidgetVersion(Type) or 0) >= Version then return end
 
@@ -60,6 +60,12 @@ local methods = {
     end
     self.texture:SetVertexColor(r, g, b, a);
     self.texture:SetBlendMode(blendMode);
+  end,
+  ["SetTexCoord"] = function(self, left, right, top, bottom)
+    self.texture:SetTexCoord(left, right, top, bottom);
+  end,
+  ["SetOnUpdate"] = function(self, func)
+    self.frame:SetScript("OnUpdate", func);
   end,
   ["GetTexturePath"] = function(self)
     return self.texture.path;

--- a/Options/RegionOptions/aurabar.lua
+++ b/Options/RegionOptions/aurabar.lua
@@ -370,7 +370,7 @@ local function createOptions(id, data)
             width = "half",
             order = 44.3,
             func = function()
-                WeakAuras.OpenTexturePick(data, "sparkTexture");
+                WeakAuras.OpenTexturePick(data, "sparkTexture", WeakAuras.texture_types);
             end,
             disabled = function() return not data.spark end,
             hidden = function() return not data.spark end,

--- a/Options/RegionOptions/progresstexture.lua
+++ b/Options/RegionOptions/progresstexture.lua
@@ -27,13 +27,8 @@ local function createOptions(id, data)
             width = "half",
             order = 12,
             func = function()
-                WeakAuras.OpenTexturePick(data, "foregroundTexture");
+                WeakAuras.OpenTexturePick(data, "foregroundTexture", WeakAuras.texture_types);
             end
-        },
-		desaturateForeground = {
-            type = "toggle",
-            name = L["Desaturate"],
-            order = 17.5,
         },
         sameTexture = {
             type = "toggle",
@@ -41,20 +36,25 @@ local function createOptions(id, data)
             width = "half",
             order = 15
         },
-		desaturateBackground = {
-            type = "toggle",
-            name = L["Desaturate"],
-            order = 17.6,
-        },
         chooseBackgroundTexture = {
             type = "execute",
             name = L["Choose"],
             width = "half",
             order = 17,
             func = function()
-                WeakAuras.OpenTexturePick(data, "backgroundTexture");
+                WeakAuras.OpenTexturePick(data, "backgroundTexture", WeakAuras.texture_types);
             end,
             disabled = function() return data.sameTexture; end
+        },
+		desaturateForeground = {
+            type = "toggle",
+            name = L["Desaturate"],
+            order = 17.5,
+        },
+		desaturateBackground = {
+            type = "toggle",
+            name = L["Desaturate"],
+            order = 17.6,
         },
         blendMode = {
             type = "select",

--- a/Options/RegionOptions/texture.lua
+++ b/Options/RegionOptions/texture.lua
@@ -26,7 +26,7 @@ local function createOptions(id, data)
             width = "half",
             order = 7,
             func = function()
-                WeakAuras.OpenTexturePick(data, "texture");
+                WeakAuras.OpenTexturePick(data, "texture", WeakAuras.texture_types);
             end
         },
         color = {

--- a/Options/WeakAurasOptions.lua
+++ b/Options/WeakAurasOptions.lua
@@ -292,7 +292,6 @@ local aura_types = WeakAuras.aura_types;
 local orientation_types = WeakAuras.orientation_types;
 local spec_types = WeakAuras.spec_types;
 local totem_types = WeakAuras.totem_types;
-local texture_types = WeakAuras.texture_types;
 local operator_types = WeakAuras.operator_types;
 local string_operator_types = WeakAuras.string_operator_types;
 local weapon_types = WeakAuras.weapon_types;
@@ -1965,7 +1964,7 @@ function WeakAuras.AddOption(id, data)
     regionOption = {
       unsupported = {
         type = "description",
-        name = L["This region of type \"%s\" has no configuration options."]:format(data.regionType)
+        name = L["This region of type \"%s\" is not supported."]:format(data.regionType)
       }
     };
   end
@@ -5512,7 +5511,17 @@ function WeakAuras.ReloadTriggerOptions(data)
     replaceNameDescFuncs(displayOptions[id], data);
     replaceImageFuncs(displayOptions[id], data);
 
-    local regionOption = regionOptions[data.regionType].create(id, data);
+    local regionOption;
+    if (regionOptions[data.regionType]) then
+      regionOption = regionOptions[data.regionType].create(id, data);
+    else
+      regionOption = {
+        unsupported = {
+          type = "description",
+          name = L["This region of type \"%s\" is not supported."]:format(data.regionType)
+        }
+      };
+    end
     displayOptions[id].args.group = {
       type = "group",
       name = L["Group"],
@@ -5652,6 +5661,13 @@ function WeakAuras.ReloadGroupRegionOptions(data)
   if(regionType) then
     if(regionOptions[regionType]) then
       regionOption = regionOptions[regionType].create(id, data);
+    else
+      regionOption = {
+        unsupported = {
+          type = "description",
+          name = L["This region of type \"%s\" is not supported."]:format(data.regionType)
+        }
+      };
     end
   end
   if(regionOption) then
@@ -6342,14 +6358,19 @@ function WeakAuras.CreateFrame()
 
   local function texturePickGroupSelected(widget, event, uniquevalue)
     texturePickScroll:ReleaseChildren();
-    for texturePath, textureName in pairs(texture_types[uniquevalue]) do
+    for texturePath, textureName in pairs(texturePick.textures[uniquevalue]) do
       local textureWidget = AceGUI:Create("WeakAurasTextureButton");
-      textureWidget:SetTexture(texturePath, textureName);
+      if (texturePick.SetTextureFunc) then
+        texturePick.SetTextureFunc(textureWidget, texturePath, textureName);
+      else
+        textureWidget:SetTexture(texturePath, textureName);
+        local d = texturePick.textureData;
+        textureWidget:ChangeTexture(d.r, d.g, d.b, d.a, d.rotate, d.discrete_rotation, d.rotation, d.mirror, d.blendMode);
+      end
+
       textureWidget:SetClick(function()
         texturePick:Pick(texturePath);
       end);
-      local d = texturePick.textureData;
-      textureWidget:ChangeTexture(d.r, d.g, d.b, d.a, d.rotate, d.discrete_rotation, d.rotation, d.mirror, d.blendMode);
       texturePickScroll:AddChild(textureWidget);
       table.sort(texturePickScroll.children, function(a, b)
         local aPath, bPath = a:GetTexturePath(), b:GetTexturePath();
@@ -6369,7 +6390,7 @@ function WeakAuras.CreateFrame()
 
   function texturePick.UpdateList(self)
     wipe(texturePickDropdown.list);
-    for categoryName, category in pairs(texture_types) do
+    for categoryName, category in pairs(self.textures) do
       local match = false;
       for texturePath, textureName in pairs(category) do
         if(texturePath == self.data[self.field]) then
@@ -6393,6 +6414,7 @@ function WeakAuras.CreateFrame()
     if(pickedwidget) then
       pickedwidget:Pick();
     end
+
     if(self.data.controlledChildren) then
       setAll(self.data, {"region", self.field}, texturePath);
     else
@@ -6408,9 +6430,11 @@ function WeakAuras.CreateFrame()
     texturePickDropdown.dropdown:SetText(texturePickDropdown.list[status.selected]);
   end
 
-  function texturePick.Open(self, data, field)
+  function texturePick.Open(self, data, field, textures, SetTextureFunc)
     self.data = data;
     self.field = field;
+    self.textures = textures;
+    self.SetTextureFunc = SetTextureFunc
     if(data.controlledChildren) then
       self.givenPath = {};
       for index, childId in pairs(data.controlledChildren) do
@@ -6458,7 +6482,7 @@ function WeakAuras.CreateFrame()
       _, givenPath = next(self.givenPath);
     end
     WeakAuras.debug(givenPath, 3);
-    for categoryName, category in pairs(texture_types) do
+    for categoryName, category in pairs(self.textures) do
       if not(picked) then
         for texturePath, textureName in pairs(category) do
           if(texturePath == givenPath) then
@@ -6471,7 +6495,7 @@ function WeakAuras.CreateFrame()
       end
     end
     if not(picked) then
-      for categoryName, category in pairs(texture_types) do
+      for categoryName, category in pairs(self.textures) do
         texturePickDropdown:SetGroup(categoryName);
         break;
       end
@@ -8508,12 +8532,7 @@ function WeakAuras.UpdateDisplayButton(data)
   if not(button) then
     error("Button for "..id.." was not found!");
   else
-    if(regionOptions[data.regionType]) then
-      button:SetIcon(WeakAuras.SetThumbnail(data));
-    else
-      button:SetIcon("Interface\\Icons\\INV_Misc_QuestionMark");
-    end
-
+    button:SetIcon(WeakAuras.SetThumbnail(data));
   end
 end
 
@@ -8523,39 +8542,34 @@ function WeakAuras.SetThumbnail(data)
   if not(regionType) then
     error("Improper arguments to WeakAuras.SetThumbnail - regionType not defined");
   else
-    if(regionTypes[regionType]) then
-      local id = data.id;
-      if not(id) then
-        error("Improper arguments to WeakAuras.SetThumbnail - id not defined");
+    local id = data.id;
+    local button = displayButtons[id];
+    local thumbnail;
+    if((not thumbnails[id]) or (not thumbnails[id].region) or thumbnails[id].regionType ~= regionType) then
+      if(regionOptions[regionType] and regionOptions[regionType].createThumbnail and regionOptions[regionType].modifyThumbnail) then
+        thumbnail = regionOptions[regionType].createThumbnail(button.frame, regionTypes[regionType].create);
       else
-        local button = displayButtons[id];
-        local thumbnail, region;
-        if(regionOptions[regionType].createThumbnail and regionOptions[regionType].modifyThumbnail) then
-          if((not thumbnails[id]) or (not thumbnails[id].region) or thumbnails[id].regionType ~= regionType) then
-            thumbnail = regionOptions[regionType].createThumbnail(button.frame, regionTypes[regionType].create);
-            thumbnails[id] = {
-              regionType = regionType,
-              region = thumbnail
-            };
-          else
-            thumbnail = thumbnails[id].region;
-          end
-          WeakAuras.validate(data, regionTypes[regionType].default);
-          regionOptions[regionType].modifyThumbnail(button.frame, thumbnail, data, regionTypes[regionType].modify);
-        else
-          thumbnail = regionOptions[regionType].icon;
-        end
-
-        return thumbnail;
+        thumbnail = button.frame:CreateTexture();
+        thumbnail:SetTexture("Interface\\Icons\\INV_Misc_QuestionMark");
       end
-    else
-      error("Improper arguments to WeakAuras.SetThumbnail - regionType \""..data.regionType.."\" is not supported and no custom region was supplied");
+      thumbnails[id] = {
+        regionType = regionType,
+        region = thumbnail
+      };
     end
+
+    thumbnail = thumbnails[id].region;
+    if(regionOptions[regionType] and regionOptions[regionType].modifyThumbnail) then
+       WeakAuras.validate(data, regionTypes[regionType].default);
+      regionOptions[regionType].modifyThumbnail(button.frame, thumbnail, data, regionTypes[regionType].modify);
+    end
+
+    return thumbnail;
   end
 end
 
-function WeakAuras.OpenTexturePick(data, field)
-  frame.texturePick:Open(data, field);
+function WeakAuras.OpenTexturePick(data, field, textures, stopMotion)
+  frame.texturePick:Open(data, field, textures, stopMotion);
 end
 
 function WeakAuras.OpenIconPick(data, field)

--- a/RegionTypes/text.lua
+++ b/RegionTypes/text.lua
@@ -243,3 +243,31 @@ local function modify(parent, region, data)
 end
 
 WeakAuras.RegisterRegionType("text", create, modify, default);
+
+-- Fallback region type
+
+local function fallbackmodify(parent, region, data)
+    local text = region.text;
+
+    if(data.frameStrata == 1) then
+        region:SetFrameStrata(region:GetParent():GetFrameStrata());
+    else
+        region:SetFrameStrata(WeakAuras.frame_strata_types[data.frameStrata]);
+    end
+
+    text:SetFont("Fonts\\FRIZQT__.TTF", data.fontSize <= 35 and data.fontSize or 35, data.outline and "OUTLINE" or nil);
+    if text:GetFont() then
+        text:SetText(WeakAuras.L["Region type %s not supported"]:format(data.regionType));
+    end
+
+    text:ClearAllPoints();
+    text:SetPoint("CENTER", region, "CENTER");
+
+    region:SetWidth(text:GetWidth());
+    region:SetHeight(text:GetHeight());
+
+    region:ClearAllPoints();
+    region:SetPoint(data.selfPoint, parent, data.anchorPoint, data.xOffset, data.yOffset);
+end
+
+WeakAuras.RegisterRegionType("fallback", create, fallbackmodify, default);

--- a/Transmission.lua
+++ b/Transmission.lua
@@ -688,7 +688,7 @@ function WeakAuras.ShowDisplayTooltip(data, children, icon, icons, import, compr
 
         local regionType = data.regionType;
         local regionData = regionOptions[regionType or ""]
-        local displayName = regionData and regionData.displayName or "";
+        local displayName = regionData and regionData.displayName or regionType or "";
 
         local tooltip = {
             -- 1. parameter: 1 => AddLine, 2=> AddDoubleLine,


### PR DESCRIPTION
There are 3 parts to that preparation:
- In Transmission.lua change how the auras are created on login, basically some code moves from ADDON_LOADED to PLAYER_LOGIN. That allows other addons to register their region types in their ADDON_LOADED handler and be ready before the regions are created.

- Improve the code that deals with unknown region types. Regions that are not supported are displayed as text auras with a informative text message.

- Make the texture selector useable for the StopMotion addon, by allowing that addon to pass in the textures table and allow it to display it's special textures.

If I uploaded the current state of my StopMotion addon to: https://onedrive.live.com/redir?resid=6F73AA556E38CB8B%2154583

I do have plans for some additional features and more textures, but I think I'm done with a initial version. And I'd like to have this patch in WA, so that I can release the first version.