### PR TITLE
Add Trigger States to store information

### DIFF
--- a/BuffTrigger.lua
+++ b/BuffTrigger.lua
@@ -70,7 +70,6 @@ local specificBosses = WeakAuras.specificBosses;
 local specificUnits = WeakAuras.specificUnits;
 local loaded_auras = WeakAuras.loaded_auras;
 local duration_cache = WeakAuras.duration_cache;
-local clones = WeakAuras.clones;
 
 -- GLOBALS: GameTooltip UNKNOWNOBJECT
 
@@ -296,70 +295,84 @@ do
 end
 WeakAuras.aura_cache = aura_cache;
 
-function WeakAuras.SetAuraVisibility(id, triggernum, data, active, unit, duration, expirationTime, name, icon, count, cloneId, index, spellId)
-  local region;
-  local showClones;
+function WeakAuras.SetAuraVisibility(id, triggernum, cloneId, inverse, active, unit, duration, expirationTime, name, icon, count, index, spellId)
+  local triggerState = WeakAuras.GetTriggerStateForTrigger(id, triggernum);
 
-  if(cloneId) then
-    if(data.numAdditionalTriggers > 0) then
-      showClones = data.region.toShow and true or false;
-    else
-      showClones = true;
-    end
-    region = WeakAuras.EnsureClone(id, cloneId);
-  else
-    region = data.region;
-  end
-
-  region.index = index;
-  region.spellId = spellId;
-
-  local show;
+  local show = false
   if(active ~= nil) then
-    if not(data.inverse and UnitExists(unit)) then
-      show = true;
-    end
-  elseif(data.inverse and UnitExists(unit)) then
+    if not(inverse and UnitExists(unit)) then
+     show = true;
+   end
+  elseif(inverse and UnitExists(unit)) then
     show = true;
   end
 
-  if(show) then
-    if(triggernum == 0) then
-      if(region.SetDurationInfo) then
-        region:SetDurationInfo(duration, expirationTime > 0 and expirationTime or math.huge);
-      end
+  cloneId = cloneId or "";
 
-      WeakAuras.ControlChildren(id);
-
-      duration_cache:SetDurationInfo(id, duration, expirationTime, nil, nil, cloneId);
-      if(region.SetName) then
-        region:SetName(name);
-      end
-      if(region.SetIcon) then
-        region:SetIcon(icon or "Interface\\Icons\\INV_Misc_QuestionMark");
-      end
-      if(region.SetStacks) then
-        region:SetStacks(count);
-      end
-      if(region.UpdateCustomText and not WeakAuras.IsRegisteredForCustomTextUpdates(region)) then
-        region.UpdateCustomText();
-      end
-      WeakAuras.UpdateMouseoverTooltip(region);
-    end
-
-    if(data.numAdditionalTriggers > 0 and showClones == nil) then
-      region:EnableTrigger(triggernum);
-    elseif(showClones ~= false) then
-      region:Expand();
-    end
-  else
-    if(data.numAdditionalTriggers > 0 and showClones == nil) then
-      region:DisableTrigger(triggernum)
-    elseif(showClones ~= false) then
-      region:Collapse();
-    end
+  if (not show and not triggerState[cloneId]) then
+    return false;
   end
-end
+
+  triggerState[cloneId] = triggerState[cloneId] or {};
+  local state = triggerState[cloneId];
+  if (state.index ~= index) then
+    state.index = index;
+    state.changed = true;
+  end
+  if (state.spellId ~= spellId) then
+    state.spellId = spellId;
+    state.changed = true;
+  end
+
+  if (state.show ~= show) then
+    state.show = show;
+    state.changed = true;
+  end
+  if (state.progressType ~= "timed") then
+    state.progressType = "timed";
+    state.changed = true;
+  end
+  if (state.expirationTime ~= expirationTime) then
+    state.resort = true;
+    state.expirationTime = expirationTime;
+    state.changed = true;
+  end
+  if (state.duration ~= duration) then
+    state.duration = duration;
+    state.changed = true;
+  end
+
+  local autoHide = not inverse and duration ~= 0;
+  if (state.autoHide ~= autoHide) then
+    state.autoHide = autoHide;
+    state.changed = true;
+  end
+
+  if (state.name ~= name) then
+    state.name = name;
+    state.changed = true;
+  end
+
+  if (state.icon ~= icon) then
+    state.icon = icon;
+    state.changed = true;
+  end
+
+  if (state.stacks ~= count) then
+    state.stacks = count;
+    state.changed = true;
+  end
+
+  if (state.GUID ~= UnitGUID(unit)) then
+    state.GUID = UnitGUID(unit);
+    state.changed = true;
+  end
+
+  if (state.changed) then
+    return true;
+  end
+  return false;
+ end
 
 local aura_scan_cache = {};
 local aura_lists = {};
@@ -423,6 +436,7 @@ function WeakAuras.ScanAuras(unit)
     -- Iterate over all displays (display lists)
     for id,triggers in pairs(aura_list) do
       -- Iterate over all triggers
+      local updateTriggerState = false;
       for triggernum, data in pairs(triggers) do
         if(not data.specificUnit or UnitIsUnit(data.unit, unit)) then
           -- Filters
@@ -503,15 +517,16 @@ function WeakAuras.ScanAuras(unit)
                 WeakAuras.SetTempIconCache(name, icon);
                 if(data.autoclone) then
                   local cloneId = name.."-"..(casGUID or "unknown");
-                  if(not clones[id][cloneId] or clones[id][cloneId].expirationTime ~= expirationTime) then
-                    WeakAuras.SetAuraVisibility(id, triggernum, data, true, unit, duration, expirationTime, name, icon, count, cloneId, index, spellId);
-                    clones[id][cloneId].expirationTime = expirationTime;
+                  if (WeakAuras.SetAuraVisibility(id, triggernum, cloneId, data.inverse, true, unit, duration, expirationTime, name, icon, count, index, spellId)) then
+                    updateTriggerState = true;
                   end
                   active = true;
                   cloneIdList[cloneId] = true;
                   -- Simply show display (show)
                 else
-                  WeakAuras.SetAuraVisibility(id, triggernum, data, true, unit, duration, expirationTime, name, icon, count, nil, index, spellId);
+                  if (WeakAuras.SetAuraVisibility(id, triggernum, nil, data.inverse, true, unit, duration, expirationTime, name, icon, count, index, spellId)) then
+                    updateTriggerState = true;
+                  end
                   active = true;
                   break;
                 end
@@ -520,10 +535,13 @@ function WeakAuras.ScanAuras(unit)
 
             -- Update display visibility and clones visibility (hide)
             if not(active) then
-              WeakAuras.SetAuraVisibility(id, triggernum, data, nil, unit, 0, math.huge);
+              if (WeakAuras.SetAuraVisibility(id, triggernum, nil, data.inverse, nil, unit, 0, math.huge)) then
+                updateTriggerState = true;
+              end
             end
             if(data.autoclone) then
-              WeakAuras.HideAllClonesExcept(id, cloneIdList);
+              WeakAuras.SetAllStatesHiddenExcept(id, triggernum, cloneIdList);
+              updateTriggerState = true;
             end
 
           -- Not using full aura scan
@@ -574,7 +592,9 @@ function WeakAuras.ScanAuras(unit)
                   end
                 -- Simply update visibility (show)
                 else
-                  WeakAuras.SetAuraVisibility(id, triggernum, data, true, unit, duration, expirationTime, name, icon, count, nil, nil, spellId);
+                  if (WeakAuras.SetAuraVisibility(id, triggernum, nil, data.inverse, true, unit, duration, expirationTime, name, icon, count, nil, spellId)) then
+                    updateTriggerState = true;
+                  end
                   break;
                 end
 
@@ -607,9 +627,13 @@ function WeakAuras.ScanAuras(unit)
                     for guid, playerName in pairs(groupcloneToUpdate) do
                       local duration, expirationTime, name, icon, count, spellId = aura_object:GetPlayerDynamicInfo(id, guid, data);
                       if(name ~= "") then
-                        WeakAuras.SetAuraVisibility(id, triggernum, data, true, unit, duration, expirationTime, playerName, icon, count, playerName, nil, spellId);
+                        if (WeakAuras.SetAuraVisibility(id, triggernum, playerName, data.inverse, true, unit, duration, expirationTime, playerName, icon, count, nil, spellId)) then
+                          updateTriggerState = true;
+                        end
                       else
-                        WeakAuras.SetAuraVisibility(id, triggernum, data, nil, unit, duration, expirationTime, playerName, icon, count, playerName, nil, spellId);
+                        if (WeakAuras.SetAuraVisibility(id, triggernum, playerName, data.inverse, nil, unit, duration, expirationTime, playerName, icon, count, nil, spellId, unitCaster)) then
+                          updateTriggerState = true;
+                        end
                       end
                     end
 
@@ -656,27 +680,37 @@ function WeakAuras.ScanAuras(unit)
                     end
 
                     -- Update display visibility (show)
-                    WeakAuras.SetAuraVisibility(id, triggernum, data, true, unit, duration, expirationTime, name, icon, count, nil, nil, spellId);
+                    if (WeakAuras.SetAuraVisibility(id, triggernum, nil, data.inverse, true, unit, duration, expirationTime, name, icon, count, nil, spellId)) then
+                      updateTriggerState = true;
+                    end
                   end
 
                 -- Not satisfying count
                 else
                   -- Update clones
                   if(data.groupclone) then
-                    WeakAuras.HideAllClones(id);
+                    WeakAuras.SetAllStatesHidden(id, triggernum);
+                    updateTriggerState = true;
                     -- Update display visibility (hide)
                   else
-                    WeakAuras.SetAuraVisibility(id, triggernum, data, nil, unit, 0, math.huge);
+                    if (WeakAuras.SetAuraVisibility(id, triggernum, nil, data.inverse, nil, unit, 0, math.huge)) then
+                      updateTriggerState = true;
+                    end
                   end
                 end
               end
 
             -- Update display visibility (hide)
             elseif not(active) then
-              WeakAuras.SetAuraVisibility(id, triggernum, data, nil, unit, 0, math.huge);
+              if (WeakAuras.SetAuraVisibility(id, triggernum, nil, data.inverse, nil, unit, 0, math.huge)) then
+                updateTriggerState = true;
+              end
             end
           end
         end
+      end
+      if (updateTriggerState) then
+        WeakAuras.UpdatedTriggerState(id);
       end
     end
   end
@@ -802,56 +836,70 @@ do
   end
 
   local function updateRegion(id, data, triggernum, GUID)
-    local auradata,showClones = data.GUIDs[GUID];
-    if(data.numAdditionalTriggers > 0) then
-      showClones = data.region.toShow and true or false;
-    else
-      showClones = true;
+     local auradata = data.GUIDs[GUID];
+     local triggerState = WeakAuras.GetTriggerStateForTrigger(id, triggernum);
+     triggerState[GUID] = triggerState[GUID] or {};
+     local state = triggerState[GUID];
+     if (state.progressType ~= "timed") then
+       state.progressType = "timed";
+       state.changed = true;
+     end
+
+     if(auradata and auradata.unitName) then
+       if (state.show ~= true) then
+         state.show = true;
+         state.changed = true;
+       end
+       if (state.expirationTime ~= auradata.expirationTime) then
+         state.resort = state.expirationTime ~= auradata.expirationTime;
+         state.expirationTime = auradata.expirationTime;
+         state.changed = true;
+       end
+       if (state.duration ~= auradata.duration) then
+         state.duration = auradata.duration;
+         state.changed = true;
+       end
+
+       if (state.autoHide ~= true) then
+         state.autoHide = true;
+         state.changed = true;
+       end
+
+       if (state.name ~= auradata.unitname) then
+         state.name = auradata.unitName;
+         state.changed = true;
+       end
+       local icon = auradata.icon or WeakAuras.GetTempIconCache(auradata.name) or "Interface\\Icons\\INV_Misc_QuestionMark";
+       if (state.icon ~= icon) then
+         state.icon = icon;
+         state.changed = true;
+       end
+
+       if (state.stacks ~= auradata.count) then
+         state.stacks = auradata.count;
+         state.changed  = true;
+       end
+       if (state.GUID ~= GUID) then
+         state.GUID = GUID;
+         state.changed = true;
+       end
+     else
+       if (state.show ~= false) then
+         state.show = false;
+         state.changed = true;
+       end
     end
-    local region = WeakAuras.EnsureClone(id, GUID);
-    if(auradata.unitName) then
-      if(triggernum == 0) then
-      if(region.SetDurationInfo) then
-        local resort = region.expirationTime ~= auradata.expirationTime;
-        region:SetDurationInfo(auradata.duration, auradata.expirationTime);
 
-        if (resort) then
-          WeakAuras.ControlChildren(id);
-        end
-      end
-
-      duration_cache:SetDurationInfo(id, auradata.duration, auradata.expirationTime, nil, nil, GUID);
-      if(region.SetName) then
-        region:SetName(auradata.unitName);
-      end
-      if(region.SetIcon) then
-        region:SetIcon(auradata.icon or WeakAuras.GetTempIconCache(auradata.name) or "Interface\\Icons\\INV_Misc_QuestionMark");
-      end
-      if(region.SetStacks) then
-        region:SetStacks(auradata.count);
-      end
-      if(region.UpdateCustomText and not WeakAuras.IsRegisteredForCustomTextUpdates(region)) then
-        region.UpdateCustomText();
-      end
-      WeakAuras.UpdateMouseoverTooltip(region);
-      end
-
-      if(data.numAdditionalTriggers > 0 and showClones == nil) then
-      region:EnableTrigger(triggernum);
-      elseif(showClones ~= false) then
-      region:Expand();
-      end
-    else
-      if(data.numAdditionalTriggers > 0 and showClones == nil) then
-      region:DisableTrigger(triggernum)
-      elseif(showClones ~= false) then
-      region:Collapse();
-      end
+    if (state.changed) then
+      return true;
     end
+    return false;
   end
+
 
   local function updateSpell(spellName, unit, destGUID)
    for id, triggers in pairs(loaded_auras[spellName]) do
+    local updateTriggerState = false;
     for triggernum, data in pairs(triggers) do
       local filter = data.debuffType..(data.ownOnly and "|PLAYER" or "");
       local name, rank, icon, count, debuffType, duration, expirationTime, unitCaster, isStealable, shouldConsolidate, spellId = UnitAura(unit, spellName, nil, filter);
@@ -864,8 +912,11 @@ do
         data.GUIDs[destGUID].expirationTime = expirationTime;
         data.GUIDs[destGUID].icon = icon;
         data.GUIDs[destGUID].count = count;
-        updateRegion(id, data, triggernum, destGUID);
+        updateTriggerState = updateRegion(id, data, triggernum, destGUID) or updateTriggerState;
       end
+    end
+    if (updateTriggerState) then
+      WeakAuras.UpdatedTriggerState(id);
     end
    end
   end
@@ -878,46 +929,52 @@ do
         updateSpell(spellName, unit, destGUID);
       else
         for id, triggers in pairs(loaded_auras[spellName]) do
-        for triggernum, data in pairs(triggers) do
-          if((not data.ownOnly) or UnitIsUnit(sourceName or "", "player")) then
-          pendingTracks[destGUID] = pendingTracks[destGUID] or {};
-          pendingTracks[destGUID][spellName] = true;
+          local updateTriggerState = false;
+          for triggernum, data in pairs(triggers) do
+            if((not data.ownOnly) or UnitIsUnit(sourceName or "", "player")) then
+            pendingTracks[destGUID] = pendingTracks[destGUID] or {};
+            pendingTracks[destGUID][spellName] = true;
 
-          data.GUIDs = data.GUIDs or {};
-          data.GUIDs[destGUID] = data.GUIDs[destGUID] or {};
-          data.GUIDs[destGUID].name = spellName;
-          data.GUIDs[destGUID].unitName = destName;
-          if (message == "SPELL_AURA_APPLIED_DOSE" or message == "SPELL_AURA_REMOVED_DOSE") then
-            -- Shouldn't affect duration/expirationTime nor icon
-            data.GUIDs[destGUID].duration = data.GUIDs[destGUID].duration or 0;
-            data.GUIDs[destGUID].expirationTime = data.GUIDs[destGUID].expirationTime or math.huge;
-            data.GUIDs[destGUID].icon = data.GUIDs[destGUID].icon or nil;
-          else
-            data.GUIDs[destGUID].duration = 0;
-            data.GUIDs[destGUID].expirationTime = math.huge;
-            data.GUIDs[destGUID].icon = nil;
-          end
-          data.GUIDs[destGUID].count = amount or 0;
+            data.GUIDs = data.GUIDs or {};
+            data.GUIDs[destGUID] = data.GUIDs[destGUID] or {};
+            data.GUIDs[destGUID].name = spellName;
+            data.GUIDs[destGUID].unitName = destName;
+            if (message == "SPELL_AURA_APPLIED_DOSE" or message == "SPELL_AURA_REMOVED_DOSE") then
+              -- Shouldn't affect duration/expirationTime nor icon
+              data.GUIDs[destGUID].duration = 0;
+              data.GUIDs[destGUID].expirationTime = math.huge;
+              data.GUIDs[destGUID].icon = nil;
+            else
+              data.GUIDs[destGUID].duration = 0;
+              data.GUIDs[destGUID].expirationTime = math.huge;
+              data.GUIDs[destGUID].icon = nil;
+            end
+            data.GUIDs[destGUID].count = amount or 0;
 
-          updateRegion(id, data, triggernum, destGUID);
+            updateTriggerState = updateRegion(id, data, triggernum, destGUID) or updateTriggerState;
+            end
           end
-        end
+          if (updateTriggerState) then
+            WeakAuras.UpdatedTriggerState(id);
+          end
         end
       end
       elseif(message == "SPELL_AURA_REMOVED") then
-      for id, triggers in pairs(loaded_auras[spellName]) do
-        for triggernum, data in pairs(triggers) do
-        if((not data.ownOnly) or UnitIsUnit(sourceName or "", "player")) then
-          -- WeakAuras.debug("Removed "..spellName.." from "..destGUID.." ("..(data.GUIDs and data.GUIDs[destGUID] and data.GUIDs[destGUID].unitName or "error")..") - "..(data.ownOnly and "own only" or "not own only")..", "..sourceName, 3);
-          data.GUIDs = data.GUIDs or {};
-          data.GUIDs[destGUID] = nil;
+        for id, triggers in pairs(loaded_auras[spellName]) do
+          local updateTriggerState = false;
+          for triggernum, data in pairs(triggers) do
+            if((not data.ownOnly) or UnitIsUnit(sourceName or "", "player")) then
+              -- WeakAuras.debug("Removed "..spellName.." from "..destGUID.." ("..(data.GUIDs and data.GUIDs[destGUID] and data.GUIDs[destGUID].unitName or "error")..") - "..(data.ownOnly and "own only" or "not own only")..", "..sourceName, 3);
+              data.GUIDs = data.GUIDs or {};
+              data.GUIDs[destGUID] = nil;
 
-          if(clones[id] and clones[id][destGUID]) then
-          clones[id][destGUID]:Collapse();
+              updateTriggerState = updateRegion(id, data, triggernum, destGUID) or updateTriggerState;
+            end
+          end
+          if (updateTriggerState) then
+            WeakAuras.UpdatedTriggerState(id);
           end
         end
-        end
-      end
       end
     end
   end
@@ -950,17 +1007,19 @@ do
     for unit, auras in pairs(loaded_auras) do
       if not(WeakAuras.unit_types[unit]) then
         for id, triggers in pairs(auras) do
+          local updateTriggerState = false;
           for triggernum, data in pairs(triggers) do
             if(data.GUIDs) then
               for GUID, GUIDData in pairs(data.GUIDs) do
                 if(GUIDData.expirationTime and GUIDData.expirationTime + 2 < GetTime()) then
                   data.GUIDs[GUID] = nil;
-                  if clones[id] and clones[id][GUID] ~= nil then
-                      clones[id][GUID]:Collapse();
-                  end
+                  updateTriggerState = updateRegion(id, data, triggernum, GUID) or updateTriggerState;
                 end
               end
             end
+          end
+          if (updateTriggerState) then
+            WeakAuras.UpdatedTriggerState(id);
           end
         end
       end
@@ -984,6 +1043,7 @@ do
       for spellName, auras in pairs(loaded_auras) do
         if not(WeakAuras.unit_types[spellName]) then
           for id, triggers in pairs(auras) do
+            local updateTriggerState = false;
             for triggernum, data in pairs(triggers) do
               local filter = data.debuffType..(data.ownOnly and "|PLAYER" or "");
               local name, rank, icon, count, debuffType, duration, expirationTime, unitCaster, isStealable, shouldConsolidate, spellId = UnitAura(uid, spellName, nil, filter);
@@ -996,9 +1056,11 @@ do
                 data.GUIDs[guid].expirationTime = expirationTime;
                 data.GUIDs[guid].icon = icon;
                 data.GUIDs[guid].count = count;
-
-                updateRegion(id, data, triggernum, guid);
+                updateTriggerState = updateRegion(id, data, triggernum, guid) or updateTriggerState;
               end
+            end
+            if (updateTriggerState) then
+              WeakAuras.UpdatedTriggerState(id);
             end
           end
         end
@@ -1172,7 +1234,7 @@ function BuffTrigger.Rename(oldid, newid)
   end
 end
 
-function BuffTrigger.Add(data, region)
+function BuffTrigger.Add(data)
   local id = data.id;
   auras[id] = nil;
 
@@ -1281,7 +1343,6 @@ function BuffTrigger.Add(data, region)
           useCount = trigger.useCount,
           ownOnly = trigger.ownOnly,
           inverse = trigger.inverse and not (trigger.unit == "group" and not trigger.groupclone),
-          region = region,
           numAdditionalTriggers = data.additional_triggers and #data.additional_triggers or 0,
           hideAlone = trigger.hideAlone,
           stack_info = trigger.stack_info,
@@ -1320,8 +1381,13 @@ function BuffTrigger.Modernize(data)
   end
 end
 
-function BuffTrigger.CanGroupShowWithZero(data)
-  local trigger = data.trigger;
+function BuffTrigger.CanGroupShowWithZero(data, triggernum)
+  local trigger
+  if (triggernum == 0) then
+    trigger = data.trigger;
+  else
+    trigger = data.additional_triggers[triggernum].trigger;
+  end
   local group_countFunc, group_countFuncStr;
   if(trigger.unit == "group") then
     local count, countType = WeakAuras.ParseNumber(trigger.group_count);
@@ -1341,8 +1407,13 @@ function BuffTrigger.CanGroupShowWithZero(data)
   end
 end
 
-function BuffTrigger.CanHaveDuration(data)
-  local trigger = data.trigger;
+function BuffTrigger.CanHaveDuration(data, triggernum)
+  local trigger
+  if (triggernum == 0) then
+    trigger = data.trigger;
+  else
+    trigger = data.additional_triggers[triggernum].trigger;
+  end
   if (not trigger.inverse) then
     return "timed";
   else
@@ -1350,20 +1421,35 @@ function BuffTrigger.CanHaveDuration(data)
   end
 end
 
-function BuffTrigger.CanHaveAuto(data)
-  local trigger = data.trigger;
+function BuffTrigger.CanHaveAuto(data, triggernum)
+  local trigger;
+  if (triggernum == 0) then
+    trigger = data.trigger;
+  else
+    trigger = data.additional_triggers[triggernum].trigger;
+  end
   return not trigger.inverse or trigger.unit == "group";
 end
 
-function BuffTrigger.CanHaveClones(data)
-  local trigger = data.trigger;
+function BuffTrigger.CanHaveClones(data, triggernum)
+  local trigger;
+  if (triggernum == 0) then
+    trigger = data.trigger;
+  else
+    trigger = data.additional_triggers[triggernum].trigger;
+  end
   return (trigger.fullscan and trigger.autoclone)
           or (trigger.unit == "group" and trigger.groupclone)
           or (trigger.unit == "multi");
 end
 
-function BuffTrigger.CanHaveTooltip(data)
-  local trigger = data.trigger;
+function BuffTrigger.CanHaveTooltip(data, triggernum)
+  local trigger;
+  if (triggernum == 0) then
+    trigger = data.trigger;
+  else
+    trigger = data.additional_triggers[triggernum].trigger;
+  end
   if(trigger.unit == "group" and trigger.name_info ~= "aura" and not trigger.groupclone) then
     return "playerlist";
   elseif(trigger.fullscan and trigger.unit ~= "group") then
@@ -1373,16 +1459,16 @@ function BuffTrigger.CanHaveTooltip(data)
   end
 end
 
-function BuffTrigger.SetToolTip(data, region)
-  local trigger = data.trigger;
+function BuffTrigger.SetToolTip(trigger, state)
+  local data = auras[state.id][state.triggernum];
   if(trigger.unit == "group" and trigger.name_info ~= "aura" and not trigger.groupclone) then
     local name = "";
     local playerList;
     if(trigger.name_info == "players") then
-      playerList = WeakAuras.aura_cache:GetAffected(trigger.names, data);
+      playerList = WeakAuras.aura_cache:GetAffected(state.id, data);
       name = L["Affected"]..":";
     elseif(trigger.name_info == "nonplayers") then
-      playerList = WeakAuras.aura_cache:GetUnaffected(trigger.names, data);
+      playerList = WeakAuras.aura_cache:GetUnaffected(state.id, data);
       name = L["Missing"]..":";
     end
 
@@ -1437,24 +1523,44 @@ function BuffTrigger.SetToolTip(data, region)
     else
       GameTooltip:AddLine(name.." "..L["None"]);
     end
-  elseif(trigger.fullscan and trigger.unit ~= "group" and region.index) then
+  elseif(trigger.fullscan and trigger.unit ~= "group" and state.index) then
     local unit = trigger.unit == "member" and trigger.specificUnit or trigger.unit;
     if(trigger.debuffType == "HELPFUL") then
-      GameTooltip:SetUnitBuff(unit, region.index);
+      GameTooltip:SetUnitBuff(unit, state.index);
     elseif(trigger.debuffType == "HARMFUL") then
-      GameTooltip:SetUnitDebuff(unit, region.index);
+      GameTooltip:SetUnitDebuff(unit, state.index);
     end
   else
-    if (region.spellId) then
-      GameTooltip:SetSpellByID(region.spellId);
+    if (state.spellId) then
+      GameTooltip:SetSpellByID(state.spellId);
     end
   end
 end
 
-function BuffTrigger.GetNameAndIcon(data)
-  -- Stub for now, the code from WeakAuras.SetIconName in WeakAurasOptions.lua
-  -- should be moved to here, but that code depends on the iconCache
-  return nil, nil;
+function BuffTrigger.GetNameAndIcon(data, triggernum)
+  local name, icon;
+  local trigger;
+  if (triggernum == 0) then
+    trigger = data.trigger;
+ else
+    trigger = data.additional_triggers[triggernum].trigger;
+  end
+  if(not (trigger.inverse or BuffTrigger.CanGroupShowWithZero(data, triggernum))
+     and trigger.names) then
+    -- Try to get an icon from the icon cache
+    for index, checkname in pairs(trigger.names) do
+      if(WeakAuras.iconCache[checkname]) then
+        name, icon = checkname, WeakAuras.iconCache[checkname];
+        break;
+      end
+    end
+  end
+  return name, icon;
+end
+
+function BuffTrigger.CreateFallbackState(data, triggernum, state)
+  state.show = true;
+  state.changed = true;
 end
 
 WeakAuras.RegisterTriggerSystem({"aura"}, BuffTrigger);

--- a/BuffTrigger.lua
+++ b/BuffTrigger.lua
@@ -1582,8 +1582,8 @@ end
 
 function BuffTrigger.GetAdditionalProperties(data, triggernum)
   local ret = "\n\n" .. L["Additional Trigger Replacements"] .. "\n";
-  ret = ret .. "|cFFFF0000#spellId#|r -" .. L["Spell ID"] .. "\n";
-  ret = ret .. "|cFFFF0000#unitCaster#|r -" .. L["Caster"] .. "\n";
+  ret = ret .. "|cFFFF0000%spellId|r -" .. L["Spell ID"] .. "\n";
+  ret = ret .. "|cFFFF0000%unitCaster|r -" .. L["Caster"] .. "\n";
   return ret;
 end
 

--- a/GenericTrigger.lua
+++ b/GenericTrigger.lua
@@ -855,6 +855,13 @@ do
   end
 end
 
+local combatLogUpgrade = {
+  ["sourceunit"] = "sourceUnit",
+  ["source"] = "sourceName",
+  ["destunit"] = "destUnit",
+  ["dest"] = "destName"
+}
+
 function GenericTrigger.Modernize(data)
   -- Convert any references to "COMBAT_LOG_EVENT_UNFILTERED_CUSTOM" to "COMBAT_LOG_EVENT_UNFILTERED"
   for triggernum=0,(data.numTriggers or 9) do
@@ -938,6 +945,18 @@ function GenericTrigger.Modernize(data)
             end
             trigger.use_inverse = nil
         end
+    end
+
+    for old, new in pairs(combatLogUpgrade) do
+      if (trigger[old]) then
+        local useOld = "use_" .. old;
+        local useNew = "use_" .. new;
+        trigger[useNew] = trigger[useOld];
+        trigger[new] = trigger[old];
+
+        trigger[old] = nil;
+        trigger[useOld] = nil;
+      end
     end
   end
 end

--- a/GenericTrigger.lua
+++ b/GenericTrigger.lua
@@ -948,7 +948,7 @@ function GenericTrigger.Modernize(data)
     end
 
     for old, new in pairs(combatLogUpgrade) do
-      if (trigger[old]) then
+      if (trigger and trigger[old]) then
         local useOld = "use_" .. old;
         local useNew = "use_" .. new;
         trigger[useNew] = trigger[useOld];

--- a/GenericTrigger.lua
+++ b/GenericTrigger.lua
@@ -2273,7 +2273,7 @@ function GenericTrigger.GetAdditionalProperties(data, triggernum)
       for _, v in pairs(WeakAuras.event_prototypes[trigger.event].args) do
         if (v.store and v.name and v.display) then
           found = true;
-          additional = additional .. "|cFFFF0000#" .. v.name .. "#|r - " .. v.display .. "\n";
+          additional = additional .. "|cFFFF0000%" .. v.name .. "|r - " .. v.display .. "\n";
         end
       end
 

--- a/GenericTrigger.lua
+++ b/GenericTrigger.lua
@@ -712,27 +712,27 @@ function GenericTrigger.Add(data, region)
           end
         else
           triggerFunc = WeakAuras.LoadFunction("return "..(trigger.custom or ""));
-          if(trigger.custom_type == "status" or trigger.custom_hide == "custom") then
+          if(trigger.custom_type == "status" or trigger.custom_type == "event" and trigger.custom_hide == "custom") then
             untriggerFunc = WeakAuras.LoadFunction("return "..(untrigger.custom or ""));
           end
 
-          if(trigger.customDuration and trigger.customDuration ~= "") then
+          if(trigger.custom_type ~= "stateupdate" and trigger.customDuration and trigger.customDuration ~= "") then
             durationFunc = WeakAuras.LoadFunction("return "..trigger.customDuration);
           end
-          if(trigger.customName and trigger.customName ~= "") then
+          if(trigger.custom_type ~= "stateupdate" and trigger.customName and trigger.customName ~= "") then
             nameFunc = WeakAuras.LoadFunction("return "..trigger.customName);
           end
-          if(trigger.customIcon and trigger.customIcon ~= "") then
+          if(trigger.custom_type ~= "stateupdate" and trigger.customIcon and trigger.customIcon ~= "") then
             iconFunc = WeakAuras.LoadFunction("return "..trigger.customIcon);
           end
-          if(trigger.customTexture and trigger.customTexture ~= "") then
+          if(trigger.custom_type ~= "stateupdate" and trigger.customTexture and trigger.customTexture ~= "") then
             textureFunc = WeakAuras.LoadFunction("return "..trigger.customTexture);
           end
-          if(trigger.customStacks and trigger.customStacks ~= "") then
+          if(trigger.custom_type ~= "stateupdate" and trigger.customStacks and trigger.customStacks ~= "") then
             stacksFunc = WeakAuras.LoadFunction("return "..trigger.customStacks);
           end
 
-          if(trigger.custom_type == "status" and trigger.check == "update") then
+          if((trigger.custom_type == "status" or trigger.custom_type == "stateupdate") and trigger.check == "update") then
             register_for_frame_updates = true;
             trigger_events = {"FRAME_UPDATE"};
           else
@@ -754,6 +754,9 @@ function GenericTrigger.Add(data, region)
                 WeakAuras.forceable_events[event] = true;
               end
             end
+          end
+          if (trigger.custom_type == "stateupdate") then
+            statesParameter = "full";
           end
         end
 
@@ -2168,10 +2171,10 @@ function GenericTrigger.CanHaveAuto(data, triggernum)
   )
   or (
     trigger.type == "custom"
-    and (
+    and ((
       trigger.customIcon
       and trigger.customIcon ~= ""
-    )
+    ) or trigger.custom_type == "stateupdate")
   )
   ) then
     return true;

--- a/GenericTrigger.lua
+++ b/GenericTrigger.lua
@@ -52,6 +52,8 @@ CanHaveTooltip(data)
 GetNameAndIcon(data)
     Returns the name and icon to show in the options
 
+GetAdditionalProperties(data)
+  Returns the a tooltip for the additional properties
 ]]--
 
 
@@ -2122,6 +2124,10 @@ function GenericTrigger.SetToolTip(trigger, state)
       end
     end
   end
+end
+
+function GenericTrigger.GetAdditionalProperties(data, triggernum)
+  return "";
 end
 
 function GenericTrigger.CreateFallbackState(data, triggernum, state)

--- a/Options/AceGUI-Widgets/AceGUIWidget-WeakAurasDisplayButton.lua
+++ b/Options/AceGUI-Widgets/AceGUIWidget-WeakAurasDisplayButton.lua
@@ -425,7 +425,7 @@ local methods = {
         end
 
         function self.frame.terribleCodeOrganizationHackTable.OnHide()
-            WeakAuras.HideAllClones(data.id);
+            WeakAuras.CollapseAllClones(data.id);
         end
 
         self:SetTitle(data.id);

--- a/Options/RegionOptions/aurabar.lua
+++ b/Options/RegionOptions/aurabar.lua
@@ -30,7 +30,11 @@ local function createOptions(id, data)
                     return L["Top Text"];
                 end
             end,
-            desc = L["Dynamic text tooltip"],
+            desc = function()
+                 local ret = L["Dynamic text tooltip"];
+                 ret = ret .. WeakAuras.GetAdditionalProperties(data);
+                 return ret
+            end,
             order = 9
         },
         displayTextRight = {
@@ -46,7 +50,11 @@ local function createOptions(id, data)
                     return L["Bottom Text"];
                 end
             end,
-            desc = L["Dynamic text tooltip"],
+            desc = function()
+                 local ret = L["Dynamic text tooltip"];
+                 ret = ret .. WeakAuras.GetAdditionalProperties(data);
+                 return ret
+            end,
             order = 10
         },
         customTextUpdate = {
@@ -147,7 +155,7 @@ local function createOptions(id, data)
                     (
                         data.orientation:find("INVERSE")
                         and not v:find("INVERSE")
-                    ) 
+                    )
                     or (
                         v:find("INVERSE")
                         and not data.orientation:find("INVERSE")
@@ -155,7 +163,7 @@ local function createOptions(id, data)
                 ) then
                     data.icon_side = data.icon_side == "LEFT" and "RIGHT" or "LEFT";
                 end
-                
+
                 if(
                     (
                         data.orientation:find("HORIZONTAL")
@@ -170,14 +178,14 @@ local function createOptions(id, data)
                     data.width = data.height;
                     data.height = temp;
                     data.icon_side = data.icon_side == "LEFT" and "RIGHT" or "LEFT";
-                    
+
                     if(data.rotateText == "LEFT" or data.rotateText == "RIGHT") then
                         data.rotateText = "NONE";
                     elseif(data.rotateText == "NONE") then
                         data.rotateText = "LEFT"
                     end
                 end
-                
+
                 data.orientation = v;
                 WeakAuras.Add(data);
                 WeakAuras.SetThumbnail(data);
@@ -657,13 +665,13 @@ local function createOptions(id, data)
             order = 58
         },
     };
-    
+
 	-- Positioning options
 	options = WeakAuras.AddPositionOptions(options, id, data);
-	
+
 	-- Border options
 	options = WeakAuras.AddBorderOptions(options, id, data);
-    
+
 	-- Return options
     return options;
 end
@@ -674,32 +682,32 @@ local function createThumbnail(parent, fullCreate)
     local borderframe = CreateFrame("FRAME", nil, parent);
     borderframe:SetWidth(32);
     borderframe:SetHeight(32);
-    
+
 	-- Preview border
     local border = borderframe:CreateTexture(nil, "OVERLAY");
     border:SetAllPoints(borderframe);
     border:SetTexture("Interface\\BUTTONS\\UI-Quickslot2.blp");
     border:SetTexCoord(0.2, 0.8, 0.2, 0.8);
-    
+
 	-- Main region
     local region = CreateFrame("FRAME", nil, borderframe);
     borderframe.region = region;
     region:SetWidth(32);
     region:SetHeight(32);
-    
+
 	-- Status-bar frame
     local bar = CreateFrame("FRAME", nil, region);
     borderframe.bar = bar;
-    
+
 	-- Fake status-bar
     local texture = bar:CreateTexture(nil, "OVERLAY");
     borderframe.texture = texture;
-    
+
 	-- Fake icon
     local icon = region:CreateTexture();
     borderframe.icon = icon;
     icon:SetTexture("Interface\\Icons\\INV_Misc_QuestionMark");
-    
+
 	-- Return preview
     return borderframe;
 end
@@ -708,11 +716,11 @@ end
 local function modifyThumbnail(parent, borderframe, data, fullModify, width, height)
 	-- Localize
     local region, bar, texture, icon = borderframe.region, borderframe.bar, borderframe.texture, borderframe.icon;
-    
+
 	-- Defaut size
     width  = width or 26;
     height = height or 15;
-    
+
 	-- Fake orientation (main region)
     if(data.orientation:find("HORIZONTAL")) then
         region:SetWidth(width);
@@ -733,19 +741,19 @@ local function modifyThumbnail(parent, borderframe, data, fullModify, width, hei
             region:SetPoint("BOTTOM", borderframe, "BOTTOM", 0, 2);
         end
     end
-    
+
 	-- Fake bar alpha
     region:SetAlpha(data.alpha);
-    
+
 	-- Fake status-bar style
     texture:SetTexture(SharedMedia:Fetch("statusbar", data.texture));
     texture:SetVertexColor(data.barColor[1], data.barColor[2], data.barColor[3], data.barColor[4]);
-    
+
 	-- Fake icon size
     local iconsize = height;
     icon:SetWidth(iconsize);
     icon:SetHeight(iconsize);
-    
+
 	-- Fake layout variables
     local percent, length;
     if(data.icon) then
@@ -755,12 +763,12 @@ local function modifyThumbnail(parent, borderframe, data, fullModify, width, hei
         length = width;
         percent = 1 - (width / 100);
     end
-	
+
 	-- Reset region members
     icon:ClearAllPoints();
     bar:ClearAllPoints();
     texture:ClearAllPoints();
-	
+
 	-- Fake orientation (region members)
     if(data.orientation == "HORIZONTAL_INVERSE") then
         icon:SetPoint("LEFT", region, "LEFT");
@@ -811,7 +819,7 @@ local function modifyThumbnail(parent, borderframe, data, fullModify, width, hei
         texture:SetTexCoord(1, 0, percent, 0, 1, 1, percent, 1);
         texture:SetHeight(length);
     end
-    
+
 	-- Fake icon (code)
     if(data.icon) then
         function borderframe:SetIcon(path)
@@ -837,12 +845,12 @@ local function createIcon()
         alpha = 1.0,
         barColor = {1, 0, 0, 1}
     };
-    
+
 	-- Create and configure thumbnail
     local thumbnail = createThumbnail(UIParent);
     modifyThumbnail(UIParent, thumbnail, data, nil, 32, 18);
     thumbnail:SetIcon("Interface\\Icons\\INV_Sword_122");
-    
+
 	-- Return thumbnail
     return thumbnail;
 end

--- a/Options/RegionOptions/icon.lua
+++ b/Options/RegionOptions/icon.lua
@@ -45,7 +45,7 @@ local function createOptions(id, data)
             order = 18,
             func = function() WeakAuras.OpenIconPick(data, "displayIcon"); end
         },
-		
+
         desaturate = {
             type = "toggle",
             name = L["Desaturate"],
@@ -61,7 +61,11 @@ local function createOptions(id, data)
         displayStacks = {
             type = "input",
             name = L["Text"],
-            desc = L["Dynamic text tooltip"],
+            desc = function()
+                 local ret = L["Dynamic text tooltip"];
+                 ret = ret .. WeakAuras.GetAdditionalProperties(data);
+                 return ret
+            end,
             order = 40
         },
         textColor = {
@@ -204,21 +208,21 @@ local function createOptions(id, data)
         }
     };
     options = WeakAuras.AddPositionOptions(options, id, data);
-    
+
     return options;
 end
 
 local function createThumbnail(parent, fullCreate)
     local icon = parent:CreateTexture();
     icon:SetTexture("Interface\\Icons\\INV_Misc_QuestionMark");
-    
+
     return icon;
 end
 
 local function modifyThumbnail(parent, icon, data, fullModify)
     local texWidth = 0.25 * data.zoom;
     icon:SetTexCoord(texWidth, 1 - texWidth, texWidth, 1 - texWidth);
-    
+
     function icon:SetIcon(path)
         local success = icon:SetTexture(data.auto and path or data.displayIcon) and (data.auto and path or data.displayIcon);
         if not(success) then

--- a/Options/RegionOptions/text.lua
+++ b/Options/RegionOptions/text.lua
@@ -10,7 +10,11 @@ local function createOptions(id, data)
         displayText = {
             type = "input",
             width = "double",
-            desc = L["Dynamic text tooltip"],
+            desc = function()
+                 local ret = L["Dynamic text tooltip"];
+                 ret = ret .. WeakAuras.GetAdditionalProperties(data);
+                 return ret
+            end,
             multiline = true,
             name = L["Display Text"],
             order = 10,

--- a/Options/WeakAurasOptions.lua
+++ b/Options/WeakAurasOptions.lua
@@ -1055,6 +1055,7 @@ loadedFrame:SetScript("OnEvent", function(self, event, addon)
 
       odb.iconCache = odb.iconCache or {};
       iconCache = odb.iconCache;
+      WeakAuras.iconCache = odb.iconCache;
       odb.idCache = odb.idCache or {};
       idCache = odb.idCache;
       odb.talentCache = odb.talentCache or {};
@@ -1119,7 +1120,7 @@ function WeakAuras.DeleteOption(data)
     end
   end
 
-  WeakAuras.HideAllClones(id);
+  WeakAuras.CollapseAllClones(id);
 
   WeakAuras.Delete(data);
   frame:ClearPicks();
@@ -1252,19 +1253,16 @@ function WeakAuras.DoConfigUpdate()
           region:SetDurationInfo(12, rem);
         end
       end
-      WeakAuras.duration_cache:SetDurationInfo(id, 12, rem, nil, nil, cloneNum);
     elseif(type(WeakAuras.CanHaveDuration(data)) == "table") then
       local demoValues = WeakAuras.CanHaveDuration(data);
       local current, maximum = demoValues.current or 10, demoValues.maximum or 100;
       if(region.SetDurationInfo) then
         region:SetDurationInfo(current, maximum, true);
       end
-      WeakAuras.duration_cache:SetDurationInfo(id, current, maximum, nil, nil, cloneNum);
     else
       if(region.SetDurationInfo) then
         region:SetDurationInfo(0, math.huge);
       end
-      WeakAuras.duration_cache:SetDurationInfo(id, 0, math.huge, nil, nil, cloneNum);
     end
   end
 
@@ -1312,17 +1310,6 @@ end
 
 function WeakAuras.SetIconName(data, region)
   local name, icon = WeakAuras.GetNameAndIcon(data);
-  if(data.trigger.type == "aura" and not (data.trigger.inverse or WeakAuras.CanGroupShowWithZero(data))
-     and data.trigger.names) then
-    -- Try to get an icon from the icon cache
-    for index, checkname in pairs(data.trigger.names) do
-      if(iconCache[checkname]) then
-        name, icon = checkname, iconCache[checkname];
-        break;
-      end
-    end
-  end
-
   WeakAuras.transmitCache[data.id] = icon;
 
   if(region.SetIcon) then
@@ -3938,7 +3925,7 @@ function WeakAuras.ReloadTriggerOptions(data)
           WeakAuras.ShowCloneDialog(data);
           WeakAuras.UpdateCloneConfig(data);
         else
-          WeakAuras.HideAllClones(data.id);
+          WeakAuras.CollapseAllClones(data.id);
         end
         WeakAuras.Add(data);
       end,
@@ -4501,7 +4488,7 @@ function WeakAuras.ReloadTriggerOptions(data)
           WeakAuras.ShowCloneDialog(data);
           WeakAuras.UpdateCloneConfig(data);
         else
-          WeakAuras.HideAllClones(data.id);
+          WeakAuras.CollapseAllClones(data.id);
         end
         WeakAuras.Add(data);
       end,
@@ -4578,7 +4565,7 @@ function WeakAuras.ReloadTriggerOptions(data)
           WeakAuras.ShowCloneDialog(data);
           WeakAuras.UpdateCloneConfig(data);
         else
-          WeakAuras.HideAllClones(data.id);
+          WeakAuras.CollapseAllClones(data.id);
         end
         WeakAuras.Add(data);
       end,
@@ -4751,7 +4738,7 @@ function WeakAuras.ReloadTriggerOptions(data)
       order = 0,
       hidden = function() return not (data.additional_triggers and #data.additional_triggers > 0) end,
       values = WeakAuras.trigger_require_types,
-      get = function() return data.disjunctive end,
+      get = function() return data.disjunctive or "all" end,
       set = function(info, v) data.disjunctive = v end
     },
     custom_trigger_combination = {
@@ -4799,6 +4786,32 @@ function WeakAuras.ReloadTriggerOptions(data)
           end
         end
       end
+    },
+    activeTriggerMode = {
+      type = "select",
+      name = L["Dynamic information"],
+      width = "double",
+      order = 0.3,
+      values = function()
+        local vals = {};
+        vals[WeakAuras.trigger_modes.first_active] = L["Dynamic information from first Active Trigger"];
+        local numTriggers = data.additional_triggers and #data.additional_triggers or 0;
+        for i=0,numTriggers do
+          vals[i] = L["Dynamic information from Trigger %i"]:format(i + 1);
+        end
+        return vals;
+      end,
+      get = function()
+        return data.activeTriggerMode or WeakAuras.trigger_modes.first_active;
+      end,
+      set = function(info, v)
+        data.activeTriggerMode = v;
+        WeakAuras.Add(data);
+        WeakAuras.SetThumbnail(data);
+        WeakAuras.SetIconNames(data);
+        WeakAuras.UpdateDisplayButton(data);
+      end,
+      hidden = function() return data.numTriggers <= 1 end
     },
     addTrigger = {
       type = "execute",
@@ -8132,6 +8145,8 @@ function WeakAuras.CreateFrame()
           local data = {
             id = new_id,
             regionType = regionType,
+            activeTriggerMode = WeakAuras.trigger_modes.first_active,
+            disjunctive = "all",
             trigger = {
               type = "aura",
               unit = "player",

--- a/Options/WeakAurasOptions.lua
+++ b/Options/WeakAurasOptions.lua
@@ -5007,7 +5007,10 @@ function WeakAuras.ReloadTriggerOptions(data)
       name = L["Check On..."],
       order = 8,
       values = check_types,
-      hidden = function() return not (trigger.type == "custom" and trigger.custom_type == "status" and trigger.check ~= "update") end,
+      hidden = function() return not (trigger.type == "custom"
+          and (trigger.custom_type == "status" or trigger.custom_type == "stateupdate")
+          and trigger.check ~= "update")
+      end,
       get = function() return trigger.check end,
       set = function(info, v)
         trigger.check = v;
@@ -5023,7 +5026,10 @@ function WeakAuras.ReloadTriggerOptions(data)
       order = 8,
       width = "double",
       values = check_types,
-      hidden = function() return not (trigger.type == "custom" and trigger.custom_type == "status" and trigger.check == "update") end,
+      hidden = function() return not (trigger.type == "custom"
+          and (trigger.custom_type == "status" or trigger.custom_type == "stateupdate")
+          and trigger.check == "update")
+      end,
       get = function() return trigger.check end,
       set = function(info, v)
         trigger.check = v;
@@ -5038,7 +5044,9 @@ function WeakAuras.ReloadTriggerOptions(data)
       name = L["Event(s)"],
       desc = L["Custom trigger status tooltip"],
       order = 9,
-      hidden = function() return not (trigger.type == "custom" and trigger.custom_type == "status" and trigger.check ~= "update") end,
+      hidden = function() return not (trigger.type == "custom"
+        and (trigger.custom_type == "status" or trigger.custom_type == "stateupdate")
+        and trigger.check ~= "update") end,
       get = function() return trigger.events end,
       set = function(info, v)
         trigger.events = v;
@@ -5156,7 +5164,8 @@ function WeakAuras.ReloadTriggerOptions(data)
       order = 14,
       multiline = true,
       width = "normal",
-      hidden = function() return not (trigger.type == "custom" and (trigger.custom_type == "status" or trigger.custom_hide == "custom")) end,
+      hidden = function() return not (trigger.type == "custom"
+        and (trigger.custom_type == "status" or (trigger.custom_type == "event" and trigger.custom_hide == "custom"))) end,
       get = function() return untrigger and untrigger.custom end,
       set = function(info, v)
         if(untrigger) then
@@ -5175,7 +5184,8 @@ function WeakAuras.ReloadTriggerOptions(data)
       func = function()
         WeakAuras.TextEditor(data, appendToUntriggerPath("custom"))
       end,
-      hidden = function() return not (trigger.type == "custom" and (trigger.custom_type == "status" or trigger.custom_hide == "custom")) end,
+      hidden = function() return not (trigger.type == "custom"
+        and (trigger.custom_type == "status" or (trigger.custom_type == "event" and trigger.custom_hide == "custom"))) end,
     },
     custom_untrigger_error = {
       type = "description",
@@ -5189,7 +5199,7 @@ function WeakAuras.ReloadTriggerOptions(data)
       width = "double",
       order = 15,
       hidden = function()
-        if not(trigger.type == "custom" and (trigger.custom_type == "status" or trigger.custom_hide == "custom") and untrigger and untrigger.custom) then
+        if not(trigger.type == "custom" and (trigger.custom_type == "status" or (trigger.custom_type == "event" and trigger.custom_hide == "custom")) and untrigger and untrigger.custom) then
           return true;
         else
           local loadedFunction, errorString = loadstring("return "..(untrigger and untrigger.custom or ""));
@@ -5207,7 +5217,9 @@ function WeakAuras.ReloadTriggerOptions(data)
       order = 16,
       multiline = true,
       width = "normal",
-      hidden = function() return not (trigger.type == "custom" and (trigger.custom_type == "status" or trigger.custom_hide ~= "timed")) end,
+      hidden = function() return not (trigger.type == "custom"
+        and (trigger.custom_type == "status" or (trigger.custom_type == "event" and trigger.custom_hide ~= "timed")))
+      end,
       get = function() return trigger.customDuration end,
       set = function(info, v)
         trigger.customDuration = v;
@@ -5224,12 +5236,16 @@ function WeakAuras.ReloadTriggerOptions(data)
       func = function()
         WeakAuras.TextEditor(data, appendToTriggerPath("customDuration"))
       end,
-      hidden = function() return not (trigger.type == "custom" and (trigger.custom_type == "status" or trigger.custom_hide ~= "timed")) end,
+      hidden = function() return not (trigger.type == "custom"
+          and (trigger.custom_type == "status" or (trigger.custom_type == "event" and trigger.custom_hide ~= "timed")))
+      end,
     },
     custom_duration_error = {
       type = "description",
       name = function()
-        if not(trigger.type == "custom" and (trigger.custom_type == "status" or trigger.custom_hide ~= "timed") and trigger.customDuration and trigger.customDuration ~= "") then
+        if not(trigger.type == "custom"
+            and (trigger.custom_type == "status" or (trigger.custom_type == "event" and trigger.custom_hide ~= "timed"))
+            and trigger.customDuration and trigger.customDuration ~= "") then
           return "";
         end
         local _, errorString = loadstring("return "..(trigger.customDuration or ""));
@@ -5238,7 +5254,9 @@ function WeakAuras.ReloadTriggerOptions(data)
       width = "double",
       order = 17,
       hidden = function()
-        if not(trigger.type == "custom" and (trigger.custom_hide ~= "timed") and trigger.customDuration and trigger.customDuration ~= "") then
+        if not(trigger.type == "custom"
+            and (trigger.custom_type == "status" or (trigger.custom_type == "event" and trigger.custom_hide ~= "timed"))
+            and trigger.customDuration and trigger.customDuration ~= "") then
           return true;
         else
           local loadedFunction, errorString = loadstring("return "..(trigger.customDuration or ""));
@@ -5256,7 +5274,7 @@ function WeakAuras.ReloadTriggerOptions(data)
       order = 18,
       multiline = true,
       width = "normal",
-      hidden = function() return not (trigger.type == "custom") end,
+      hidden = function() return not (trigger.type == "custom" and trigger.custom_type ~= "stateupdate") end,
       get = function() return trigger.customName end,
       set = function(info, v)
         trigger.customName = v;
@@ -5273,7 +5291,7 @@ function WeakAuras.ReloadTriggerOptions(data)
       func = function()
         WeakAuras.TextEditor(data, appendToTriggerPath("customName"))
       end,
-      hidden = function() return not (trigger.type == "custom") end,
+      hidden = function() return not (trigger.type == "custom" and trigger.custom_type ~= "stateupdate") end,
     },
     custom_name_error = {
       type = "description",
@@ -5287,7 +5305,7 @@ function WeakAuras.ReloadTriggerOptions(data)
       width = "double",
       order = 19,
       hidden = function()
-        if not(trigger.type == "custom" and trigger.customName and trigger.customName ~= "") then
+        if not(trigger.type == "custom" and trigger.custom_type ~= "stateupdate" and trigger.customName and trigger.customName ~= "") then
           return true;
         else
           local loadedFunction, errorString = loadstring("return "..(trigger.customName or ""));
@@ -5305,7 +5323,7 @@ function WeakAuras.ReloadTriggerOptions(data)
       order = 20,
       multiline = true,
       width = "normal",
-      hidden = function() return not (trigger.type == "custom") end,
+      hidden = function() return not (trigger.type == "custom" and trigger.custom_type ~= "stateupdate") end,
       get = function() return trigger.customIcon end,
       set = function(info, v)
         trigger.customIcon = v;
@@ -5322,7 +5340,7 @@ function WeakAuras.ReloadTriggerOptions(data)
       func = function()
         WeakAuras.TextEditor(data, appendToTriggerPath("customIcon"))
       end,
-      hidden = function() return not (trigger.type == "custom") end,
+      hidden = function() return not (trigger.type == "custom" and trigger.custom_type ~= "stateupdate") end,
     },
     custom_icon_error = {
       type = "description",
@@ -5336,7 +5354,7 @@ function WeakAuras.ReloadTriggerOptions(data)
       width = "double",
       order = 21,
       hidden = function()
-        if not(trigger.type == "custom" and trigger.customIcon and trigger.customIcon ~= "") then
+        if not(trigger.type == "custom" and trigger.custom_type ~= "stateupdate" and trigger.customIcon and trigger.customIcon ~= "") then
           return true;
         else
           local loadedFunction, errorString = loadstring("return "..(trigger.customIcon or ""));
@@ -5354,7 +5372,7 @@ function WeakAuras.ReloadTriggerOptions(data)
       order = 21.5,
       multiline = true,
       width = "normal",
-      hidden = function() return not (trigger.type == "custom") end,
+      hidden = function() return not (trigger.type == "custom" and trigger.custom_type ~= "stateupdate") end,
       get = function() return trigger.customTexture end,
       set = function(info, v)
         trigger.customTexture = v;
@@ -5371,12 +5389,12 @@ function WeakAuras.ReloadTriggerOptions(data)
       func = function()
         WeakAuras.TextEditor(data, appendToTriggerPath("customTexture"))
       end,
-      hidden = function() return not (trigger.type == "custom") end,
+      hidden = function() return not (trigger.type == "custom" and trigger.custom_type ~= "stateupdate") end,
     },
     custom_texture_error = {
       type = "description",
       name = function()
-        if not(trigger.customTexture and trigger.customTexture ~= "") then
+        if not(trigger.customTexture and trigger.custom_type ~= "stateupdate" and trigger.customTexture ~= "") then
           return "";
         end
         local _, errorString = loadstring("return "..(trigger.customTexture or ""));
@@ -5385,7 +5403,7 @@ function WeakAuras.ReloadTriggerOptions(data)
       width = "double",
       order = 22.5,
       hidden = function()
-        if not(trigger.type == "custom" and trigger.customTexture and trigger.customTexture ~= "") then
+        if not(trigger.type == "custom" and trigger.custom_type ~= "stateupdate" and trigger.customTexture and trigger.customTexture ~= "") then
           return true;
         else
           local loadedFunction, errorString = loadstring("return "..(trigger.customTexture or ""));
@@ -5403,7 +5421,7 @@ function WeakAuras.ReloadTriggerOptions(data)
       order = 23,
       multiline = true,
       width = "normal",
-      hidden = function() return not (trigger.type == "custom") end,
+      hidden = function() return not (trigger.type == "custom" and trigger.custom_type ~= "stateupdate") end,
       get = function() return trigger.customStacks end,
       set = function(info, v)
         trigger.customStacks = v;
@@ -5420,12 +5438,12 @@ function WeakAuras.ReloadTriggerOptions(data)
       func = function()
         WeakAuras.TextEditor(data, appendToTriggerPath("customStacks"))
       end,
-      hidden = function() return not (trigger.type == "custom") end,
+      hidden = function() return not (trigger.type == "custom" and trigger.custom_type ~= "stateupdate") end,
     },
     custom_stacks_error = {
       type = "description",
       name = function()
-        if not(trigger.customStacks and trigger.customStacks ~= "") then
+        if not(trigger.customStacks and trigger.custom_type ~= "stateupdate" and trigger.customStacks ~= "") then
           return "";
         end
         local _, errorString = loadstring("return "..(trigger.customStacks or ""));

--- a/Prototypes.lua
+++ b/Prototypes.lua
@@ -2552,15 +2552,18 @@ WeakAuras.event_prototypes = {
     },
     name = L["Chat Message"],
     init = function(trigger)
-      return [[
+      local ret = [[
         if (event:find('LEADER')) then
           event = event:sub(0, -8);
         end
         if (event == 'CHAT_MSG_TEXT_EMOTE') then
           event = 'CHAT_MSG_EMOTE';
         end
+         local use_cloneId = %s;
       ]];
+      return ret:format(trigger.use_cloneId and "true" or "false");
     end,
+    statesParameter = "all",
     args = {
       {
         name = "messageType",
@@ -2573,14 +2576,23 @@ WeakAuras.event_prototypes = {
         name = "message",
         display = L["Message"],
         init = "arg",
-        type = "longstring"
+        type = "longstring",
+        store = true
       },
       {
         name = "sourceName",
         display = L["Source Name"],
         init = "arg",
-        type = "string"
-      }
+        type = "string",
+        store = true
+      },
+      {
+        name = "cloneId",
+        display = L["Clone per Event"],
+        type = "toggle",
+        test = "true",
+        init = "use_cloneId and WeakAuras.GetUniqueCloneId() or ''"
+      },
     }
   },
   ["Ready Check"] = {

--- a/Prototypes.lua
+++ b/Prototypes.lua
@@ -1200,7 +1200,7 @@ WeakAuras.event_prototypes = {
       {}, -- sourceGUID ignored with _ argument
       {}, -- hideCaster ignored with _ argument
       {
-        name = "sourceunit",
+        name = "sourceUnit",
         display = L["Source Unit"],
         type = "unit",
         test = "source and UnitIsUnit(source, '%s')",
@@ -1211,7 +1211,7 @@ WeakAuras.event_prototypes = {
         store = true
       },
       {
-        name = "source",
+        name = "sourceName",
         display = L["Source Name"],
         type = "string",
         init = "arg",
@@ -1226,10 +1226,11 @@ WeakAuras.event_prototypes = {
         name = "destGUID",
         init = "arg",
         hidden = "true",
-        test = "true"
+        test = "true",
+        store = true
       },
       {
-        name = "destunit",
+        name = "destUnit",
         display = L["Destination Unit"],
         type = "unit",
         test = "(destGUID or '') == (UnitGUID('%s') or '') and destGUID",
@@ -1240,7 +1241,7 @@ WeakAuras.event_prototypes = {
         store = true
       },
       {
-        name = "dest",
+        name = "destName",
         display = L["Destination Name"],
         type = "string",
         init = "arg",

--- a/Prototypes.lua
+++ b/Prototypes.lua
@@ -1484,7 +1484,7 @@ WeakAuras.event_prototypes = {
             WeakAuras.ScheduleCooldownScan(expirationTime - remainingCheck);
           end
         ]];
-        ret = ret..ret2:format(tonumber(trigger.remaining) or 0);
+        ret = ret..ret2:format(tonumber(trigger.remaining or 0) or 0);
       end
       return ret:format(spellName, (trigger.use_matchedRune and "true" or "false"),
                                    "\"" .. (trigger.showOn or "") .. "\"");
@@ -1617,7 +1617,7 @@ WeakAuras.event_prototypes = {
             WeakAuras.ScheduleCooldownScan(expirationTime - remainingCheck);
           end
         ]];
-        ret = ret..ret2:format(tonumber(trigger.remaining) or 0);
+        ret = ret..ret2:format(tonumber(trigger.remaining or 0) or 0);
       end
       return ret:format(itemName,  "\"" .. (trigger.showOn or "") .. "\"");
     end,
@@ -2198,7 +2198,7 @@ WeakAuras.event_prototypes = {
             WeakAuras.ScheduleCooldownScan(expirationTime - remainingCheck);
           end
         ]];
-        ret = ret..ret2:format(tonumber(trigger.remaining) or 0);
+        ret = ret..ret2:format(tonumber(trigger.remaining or 0) or 0);
     end
 
     if trigger.use_inverse then
@@ -2600,7 +2600,7 @@ WeakAuras.event_prototypes = {
           WeakAuras.ScheduleCooldownScan(expirationTime - remainingCheck);
         end
       ]];
-      ret = ret..ret2:format(tonumber(trigger.remaining) or 0);
+      ret = ret..ret2:format(tonumber(trigger.remaining or 0) or 0);
     end
     return ret:format(trigger.rune, (trigger.use_inverse and "true" or "false"), (trigger.use_deathRune == true and "true" or trigger.use_deathRune == false and "false" or "nil"), (trigger.use_includeDeath and "true" or "false"));
   end,

--- a/Prototypes.lua
+++ b/Prototypes.lua
@@ -678,6 +678,7 @@ WeakAuras.event_prototypes = {
 
     return ret:format(trigger.unit, trigger.unit);
     end,
+    statesParameter = "one",
     args = {
       {
         name = "unit",
@@ -691,14 +692,16 @@ WeakAuras.event_prototypes = {
         name = "name",
         display = L["Name"],
         type = "string",
-        init = "UnitName(concernedUnit)"
+        init = "UnitName(concernedUnit)",
+        store = true
       },
       {
         name = "class",
         display = L["Class"],
         type = "select",
         init = "select(2, UnitClass(unit))",
-        values = "class_types"
+        values = "class_types",
+        store = true
       },
       {
         name = "hostility",
@@ -718,7 +721,8 @@ WeakAuras.event_prototypes = {
         name = "level",
         display = L["Level"],
         type = "number",
-        init = "UnitLevel(concernedUnit)"
+        init = "UnitLevel(concernedUnit)",
+        store = true
       },
       {
         name = "attackable",
@@ -1181,7 +1185,15 @@ WeakAuras.event_prototypes = {
     events = {
       "COMBAT_LOG_EVENT_UNFILTERED"
     },
+    init = function(trigger)
+      local ret = [[
+        local use_cloneId = %s;
+      ]];
+      return ret:format(trigger.use_cloneId and "true" or "false");
+    end,
     name = L["Combat Log"],
+    canHaveAuto = true,
+    statesParameter = "all",
     args = {
       {}, -- timestamp ignored with _ argument
       {}, -- messageType ignored with _ argument (it is checked before the dynamic function)
@@ -1195,7 +1207,8 @@ WeakAuras.event_prototypes = {
         values = "actual_unit_types_with_specific",
         enable = function(trigger)
           return not (trigger.subeventPrefix == "ENVIRONMENTAL")
-        end
+        end,
+        store = true
       },
       {
         name = "source",
@@ -1204,7 +1217,8 @@ WeakAuras.event_prototypes = {
         init = "arg",
         enable = function(trigger)
           return not (trigger.subeventPrefix == "ENVIRONMENTAL")
-        end
+        end,
+        store = true
       },
       {}, -- sourceFlags ignored with _ argument
       {}, -- sourceRaidFlags ignored with _ argument
@@ -1222,7 +1236,8 @@ WeakAuras.event_prototypes = {
         values = "actual_unit_types_with_specific",
         enable = function(trigger)
           return not (trigger.subeventPrefix == "SPELL" and trigger.subeventSuffix == "_CAST_START");
-        end
+        end,
+        store = true
       },
       {
         name = "dest",
@@ -1231,7 +1246,9 @@ WeakAuras.event_prototypes = {
         init = "arg",
         enable = function(trigger)
           return not (trigger.subeventPrefix == "SPELL" and trigger.subeventSuffix == "_CAST_START");
-        end
+        end,
+        store = true
+
       },
       {
         enable = function(trigger)
@@ -1247,7 +1264,8 @@ WeakAuras.event_prototypes = {
         init = "arg",
         enable = function(trigger)
           return trigger.subeventPrefix and (trigger.subeventPrefix:find("SPELL") or trigger.subeventPrefix == "RANGE" or trigger.subeventPrefix:find("DAMAGE"))
-        end
+        end,
+        store = true
       },
       {
         name = "spellName",
@@ -1256,7 +1274,8 @@ WeakAuras.event_prototypes = {
         init = "arg",
         enable = function(trigger)
           return trigger.subeventPrefix and (trigger.subeventPrefix:find("SPELL") or trigger.subeventPrefix == "RANGE" or trigger.subeventPrefix:find("DAMAGE"))
-        end
+        end,
+        store = true
       },
       {
         enable = function(trigger)
@@ -1294,7 +1313,8 @@ WeakAuras.event_prototypes = {
         init = "arg",
         enable = function(trigger)
           return trigger.subeventSuffix and (trigger.subeventSuffix == "_INTERRUPT" or trigger.subeventSuffix == "_DISPEL" or trigger.subeventSuffix == "_DISPEL_FAILED" or trigger.subeventSuffix == "_STOLEN" or trigger.subeventSuffix == "_AURA_BROKEN_SPELL")
-        end
+        end,
+        store = true
       },
       {
         enable = function(trigger)
@@ -1318,7 +1338,8 @@ WeakAuras.event_prototypes = {
         init = "arg",
         enable = function(trigger)
           return trigger.subeventSuffix and trigger.subeventPrefix and (trigger.subeventSuffix == "_DAMAGE" or trigger.subeventSuffix == "_MISSED" or trigger.subeventSuffix == "_HEAL" or trigger.subeventSuffix == "_ENERGIZE" or trigger.subeventSuffix == "_DRAIN" or trigger.subeventSuffix == "_LEECH" or trigger.subeventPrefix:find("DAMAGE"))
-        end
+        end,
+        store = true
       },
       {
         name = "overkill",
@@ -1327,7 +1348,8 @@ WeakAuras.event_prototypes = {
         init = "arg",
         enable = function(trigger)
           return trigger.subeventSuffix and trigger.subeventPrefix and (trigger.subeventSuffix == "_DAMAGE" or trigger.subeventPrefix == "DAMAGE_SHIELD" or trigger.subeventPrefix == "DAMAGE_SPLIT")
-        end
+        end,
+        store = true
       },
       {
         name = "overhealing",
@@ -1336,7 +1358,8 @@ WeakAuras.event_prototypes = {
         init = "arg",
         enable = function(trigger)
           return trigger.subeventSuffix and trigger.subeventSuffix == "_HEAL"
-        end
+        end,
+        store = true
       },
       {
         enable = function(trigger)
@@ -1350,7 +1373,8 @@ WeakAuras.event_prototypes = {
         init = "arg",
         enable = function(trigger)
           return trigger.subeventSuffix and trigger.subeventPrefix and (trigger.subeventSuffix == "_DAMAGE" or trigger.subeventPrefix == "DAMAGE_SHIELD" or trigger.subeventPrefix == "DAMAGE_SPLIT")
-        end
+        end,
+        store = true
       },
       {
         name = "blocked",
@@ -1359,7 +1383,8 @@ WeakAuras.event_prototypes = {
         init = "arg",
         enable = function(trigger)
           return trigger.subeventSuffix and trigger.subeventPrefix and (trigger.subeventSuffix == "_DAMAGE" or trigger.subeventPrefix == "DAMAGE_SHIELD" or trigger.subeventPrefix == "DAMAGE_SPLIT")
-        end
+        end,
+        store = true
       },
       {
         name = "absorbed",
@@ -1368,7 +1393,8 @@ WeakAuras.event_prototypes = {
         init = "arg",
         enable = function(trigger)
           return trigger.subeventSuffix and trigger.subeventPrefix and (trigger.subeventSuffix == "_DAMAGE" or trigger.subeventPrefix == "DAMAGE_SHIELD" or trigger.subeventPrefix == "DAMAGE_SPLIT" or trigger.subeventSuffix == "_HEAL")
-        end
+        end,
+        store = true
       },
       {
         name = "critical",
@@ -1377,7 +1403,8 @@ WeakAuras.event_prototypes = {
         init = "arg",
         enable = function(trigger)
           return trigger.subeventSuffix and trigger.subeventPrefix and (trigger.subeventSuffix == "_DAMAGE" or trigger.subeventPrefix == "DAMAGE_SHIELD" or trigger.subeventPrefix == "DAMAGE_SPLIT" or trigger.subeventSuffix == "_HEAL")
-        end
+        end,
+        store = true
       },
       {
         name = "glancing",
@@ -1386,7 +1413,8 @@ WeakAuras.event_prototypes = {
         init = "arg",
         enable = function(trigger)
           return trigger.subeventSuffix and trigger.subeventPrefix and (trigger.subeventSuffix == "_DAMAGE" or trigger.subeventPrefix == "DAMAGE_SHIELD" or trigger.subeventPrefix == "DAMAGE_SPLIT")
-        end
+        end,
+        store = true
       },
       {
         name = "crushing",
@@ -1395,7 +1423,8 @@ WeakAuras.event_prototypes = {
         init = "arg",
         enable = function(trigger)
           return trigger.subeventSuffix and trigger.subeventPrefix and (trigger.subeventSuffix == "_DAMAGE" or trigger.subeventPrefix == "DAMAGE_SHIELD" or trigger.subeventPrefix == "DAMAGE_SPLIT")
-        end
+        end,
+        store = true
       },
       {
         name = "isOffHand",
@@ -1404,7 +1433,8 @@ WeakAuras.event_prototypes = {
         init = "arg",
         enable = function(trigger)
           return trigger.subeventSuffix and trigger.subeventPrefix and (trigger.subeventSuffix == "_DAMAGE" or trigger.subeventPrefix == "DAMAGE_SHIELD" or trigger.subeventPrefix == "DAMAGE_SPLIT")
-        end
+        end,
+        store = true
       },
       {
         name = "multistrike",
@@ -1413,7 +1443,8 @@ WeakAuras.event_prototypes = {
         init = "arg",
         enable = function(trigger)
           return trigger.subeventSuffix and trigger.subeventPrefix and (trigger.subeventSuffix == "_DAMAGE" or trigger.subeventPrefix == "DAMAGE_SHIELD" or trigger.subeventPrefix == "DAMAGE_SPLIT" or trigger.subeventSuffix == "_HEAL")
-        end
+        end,
+        store = true
       },
       {
         name = "number",
@@ -1422,7 +1453,8 @@ WeakAuras.event_prototypes = {
         init = "arg",
         enable = function(trigger)
           return trigger.subeventSuffix and (trigger.subeventSuffix == "_EXTRA_ATTACKS" or trigger.subeventSuffix:find("DOSE"))
-        end
+        end,
+        store = true
       },
       {
         name = "powerType",
@@ -1440,13 +1472,28 @@ WeakAuras.event_prototypes = {
         init = "arg",
         enable = function(trigger)
           return trigger.subeventSuffix and (trigger.subeventSuffix == "_ENERGIZE" or trigger.subeventSuffix == "_DRAIN" or trigger.subeventSuffix == "_LEECH")
-        end
+        end,
+        store = true
       },
       {
         enable = function(trigger)
           return trigger.subeventSuffix == "_CAST_FAILED"
         end
-      } -- failedType ignored with _ argument - theoretically this is not necessary because it is the last argument in the event, but it is added here for completeness
+      }, -- failedType ignored with _ argument - theoretically this is not necessary because it is the last argument in the event, but it is added here for completeness
+      {
+        name = "cloneId",
+        display = L["Clone per Event"],
+        type = "toggle",
+        test = "true",
+        init = "use_cloneId and WeakAuras.GetUniqueCloneId() or ''"
+      },
+      {
+        hidden = true,
+        name = "icon",
+        init = "spellId and select(3, GetSpellInfo(spellId)) or 'Interface\\\\Icons\\\\INV_Misc_QuestionMark'",
+        store = true,
+        test = "true"
+      }
     }
   },
   ["Cooldown Progress (Spell)"] = {

--- a/RegionTypes/aurabar.lua
+++ b/RegionTypes/aurabar.lua
@@ -1012,7 +1012,7 @@ local function modify(parent, region, data)
         region.tooltipFrame:SetAllPoints(icon);
         region.tooltipFrame:EnableMouse(true);
         region.tooltipFrame:SetScript("OnEnter", function()
-            WeakAuras.ShowMouseoverTooltip(data, region, region.tooltipFrame, tooltipType);
+            WeakAuras.ShowMouseoverTooltip(region, region.tooltipFrame);
         end);
         region.tooltipFrame:SetScript("OnLeave", WeakAuras.HideTooltip);
 
@@ -1033,8 +1033,9 @@ local function modify(parent, region, data)
     -- Save custom text function
         region.UpdateCustomText = function()
       -- Evaluate and update text
-            WeakAuras.ActivateAuraEnvironment(data.id);
-            local custom = customTextFunc(region.expirationTime, region.duration, values.progress, values.duration, values.name, values.icon, values.stacks);
+            WeakAuras.ActivateAuraEnvironment(region.id, region.cloneId, region.state);
+            local custom = customTextFunc(region.expirationTime, region.duration,
+              values.progress, values.duration, values.name, values.icon, values.stacks);
             WeakAuras.ActivateAuraEnvironment(nil);
             custom = WeakAuras.EnsureString(custom);
             if custom ~= values.custom then
@@ -1140,6 +1141,13 @@ local function modify(parent, region, data)
     end
 --  region:SetName("");
 
+    function region:OnUpdateHandler()
+        local value, total = self.customValueFunc(self.state.trigger);
+        value = type(value) == "number" and value or 0
+        total = type(value) == "number" and total or 0
+        UpdateValue(self, data, value, total);
+    end
+
   -- Duration update function
     function region:SetDurationInfo(duration, expirationTime, customValue, inverse)
     -- Update duration/expiration values
@@ -1152,21 +1160,15 @@ local function modify(parent, region, data)
         if customValue then
       -- Update via custom OnUpdate handler
             if type(customValue) == "function" then
-                local value, total = customValue(data.trigger);
+                local value, total = customValue(region.state.trigger);
                 value = type(value) == "number" and value or 0
                 total = type(value) == "number" and total or 0
                 if total > 0 and value < total then
-                    self.customValueFunc = customValue;
-                    self:SetScript("OnUpdate", function()
-            -- Relay
-            local value, total = self.customValueFunc(data.trigger);
-            value = type(value) == "number" and value or 0
-            total = type(value) == "number" and total or 0
-            UpdateValue(self, data, value, total);
-          end);
+                  self.customValueFunc = customValue;
+                  self:SetScript("OnUpdate", region.OnUpdateHandler);
                 else
-                    UpdateValue(self, data, duration, expirationTime);
-                    self:SetScript("OnUpdate", nil);
+                  UpdateValue(self, data, duration, expirationTime);
+                  self:SetScript("OnUpdate", nil);
                 end
       -- Remove OnUpdate handler, call update once
             else

--- a/RegionTypes/aurabar.lua
+++ b/RegionTypes/aurabar.lua
@@ -686,7 +686,7 @@ local function UpdateText(region, data)
 
   -- Replace %-marks
   textStr = data.displayTextLeft or "";
-  textStr = WeakAuras.ReplacePlaceHolders(textStr, region.values);
+  textStr = WeakAuras.ReplacePlaceHolders(textStr, region.values, region.state);
 
   -- Update left text
   if not text.displayTextLeft or #text.displayTextLeft ~= #textStr then
@@ -699,7 +699,7 @@ local function UpdateText(region, data)
 
   -- Replace %-marks
   textStr = data.displayTextRight or "";
-  textStr = WeakAuras.ReplacePlaceHolders(textStr, region.values);
+  textStr = WeakAuras.ReplacePlaceHolders(textStr, region.values, region.state);
 
   -- Update right text
   if not timer.displayTextRight or #timer.displayTextRight ~= #textStr then

--- a/RegionTypes/dynamicgroup.lua
+++ b/RegionTypes/dynamicgroup.lua
@@ -169,34 +169,38 @@ local function modify(parent, region, data)
         end
 
         if(data.sort == "ascending") then
-            table.sort(region.controlledRegions, function(a, b)
-                return (
-                    a.region
-                    and a.region.expirationTime
-                    and a.region.expirationTime > 0
-                    and a.region.expirationTime
-                    or math.huge
-                ) < (
-                    b.region
-                    and b.region.expirationTime
-                    and b.region.expirationTime > 0
-                    and b.region.expirationTime
-                    or math.huge
-                )
+          table.sort(region.controlledRegions, function(a, b)
+            return (
+                a.region
+                    and a.region.state
+                    and a.region.state.expirationTime
+                    and a.region.state.expirationTime > 0
+                    and a.region.state.expirationTime
+                or math.huge
+            ) < (
+                b.region
+                    and b.region.state
+                    and b.region.state.expirationTime
+                    and b.region.state.expirationTime > 0
+                    and b.region.state.expirationTime
+                or math.huge
+              )
             end);
         elseif(data.sort == "descending") then
             table.sort(region.controlledRegions, function(a, b)
                 return (
                     a.region
-                    and a.region.expirationTime
-                    and a.region.expirationTime > 0
-                    and a.region.expirationTime
+                    and a.region.state
+                    and a.region.state.expirationTime
+                    and a.region.state.expirationTime > 0
+                    and a.region.state.expirationTime
                     or math.huge
                 ) > (
                     b.region
-                    and b.region.expirationTime
-                    and b.region.expirationTime > 0
-                    and b.region.expirationTime
+                    and b.region.state
+                    and b.region.state.expirationTime
+                    and b.region.state.expirationTime > 0
+                    and b.region.state.expirationTime
                     or math.huge
                 )
             end);
@@ -207,15 +211,17 @@ local function modify(parent, region, data)
                 if (data.sortHybridTable and data.sortHybridTable[a.dataIndex]) then
                     aTime = a.dataIndex - 1000;
                 else
-                    aTime = a.region and a.region.expirationTime and a.region.expirationTime > 0
-                        and a.region.expirationTime or math.huge
+                    aTime = a.region and a.region.state
+                        and a.region.state.expirationTime and a.region.state.expirationTime > 0
+                        and a.region.state.expirationTime or math.huge
                 end;
 
                 if (data.sortHybridTable and data.sortHybridTable[b.dataIndex]) then
                     bTime = b.dataIndex - 1000;
                 else
-                    bTime = b.region and b.region.expirationTime and b.region.expirationTime > 0
-                        and b.region.expirationTime or math.huge
+                    bTime = b.region and b.region.state
+                        and b.region.state.expirationTime and b.region.state.expirationTime > 0
+                        and b.region.state.expirationTime or math.huge
                 end
                 return (
                     (aTime) > (bTime)
@@ -231,7 +237,7 @@ local function modify(parent, region, data)
                 return (
                     (
                         a.dataIndex == b.dataIndex
-                        and (a.region.index or 0) < (b.region.index or 0)
+                        and (a.region.state.index or 0) < (b.region.state.index or 0)
                     )
                     or (a.dataIndex or 0) < (b.dataIndex or 0)
                 )

--- a/RegionTypes/icon.lua
+++ b/RegionTypes/icon.lua
@@ -185,7 +185,7 @@ local function modify(parent, region, data)
     if(tooltipType and data.useTooltip) then
         region:EnableMouse(true);
         region:SetScript("OnEnter", function()
-            WeakAuras.ShowMouseoverTooltip(data, region, region, tooltipType);
+            WeakAuras.ShowMouseoverTooltip(region, region);
         end);
         region:SetScript("OnLeave", WeakAuras.HideTooltip);
     else
@@ -232,8 +232,9 @@ local function modify(parent, region, data)
     if (customTextFunc) then
         local values = region.values;
         region.UpdateCustomText = function()
-            WeakAuras.ActivateAuraEnvironment(data.id);
-            local custom = customTextFunc(region.expirationTime, region.duration, values.progress, values.duration, values.name, values.icon, values.stacks);
+            WeakAuras.ActivateAuraEnvironment(region.id, region.cloneId, region.state);
+            local custom = customTextFunc(region.expirationTime, region.duration,
+              values.progress, values.duration, values.name, values.icon, values.stacks);
             WeakAuras.ActivateAuraEnvironment(nil);
             custom = WeakAuras.EnsureString(custom);
             if(custom ~= values.custom) then
@@ -273,7 +274,6 @@ local function modify(parent, region, data)
         region.values.icon = "|T"..iconPath..":12:12:0:0:64:64:4:60:4:60|t";
         UpdateText();
     end
-    region:SetIcon()
 
     function region:SetName(name)
         region.values.name = name or data.id;
@@ -345,7 +345,7 @@ local function modify(parent, region, data)
     end
 
     local function UpdateCustom()
-        UpdateValue(region.customValueFunc(data.trigger));
+        UpdateValue(region.customValueFunc(region.state.trigger));
     end
 
     local function UpdateDurationInfo(duration, expirationTime, customValue)
@@ -356,7 +356,7 @@ local function modify(parent, region, data)
 
         if(customValue) then
             if(type(customValue) == "function") then
-                local value, total = customValue(data.trigger);
+                local value, total = customValue(region.state.trigger);
                 if(total > 0 and value < total) then
                     region.customValueFunc = customValue;
                     region:SetScript("OnUpdate", UpdateCustom);

--- a/RegionTypes/icon.lua
+++ b/RegionTypes/icon.lua
@@ -215,7 +215,7 @@ local function modify(parent, region, data)
     local textStr;
     local function UpdateText()
         textStr = data.displayStacks or "";
-        textStr = WeakAuras.ReplacePlaceHolders(textStr, region.values);
+        textStr = WeakAuras.ReplacePlaceHolders(textStr, region.values, region.state);
 
         if(stacks.displayStacks ~= textStr) then
             if stacks:GetFont() then

--- a/RegionTypes/progresstexture.lua
+++ b/RegionTypes/progresstexture.lua
@@ -698,7 +698,7 @@ local function modify(parent, region, data)
     end
 
     local function UpdateCustom()
-        UpdateValue(region.customValueFunc(data.trigger));
+        UpdateValue(region.customValueFunc(region.state.trigger));
     end
 
     function region:SetDurationInfo(duration, expirationTime, customValue, inverse)
@@ -709,7 +709,7 @@ local function modify(parent, region, data)
 
         if(customValue) then
             if(type(customValue) == "function") then
-                local value, total = customValue(data.trigger);
+                local value, total = customValue(region.id, region.cloneId);
                 if(total > 0 and value < total) then
                     region.customValueFunc = customValue;
                     region:SetScript("OnUpdate", UpdateCustom);

--- a/RegionTypes/text.lua
+++ b/RegionTypes/text.lua
@@ -70,7 +70,7 @@ local function modify(parent, region, data)
 
     local function UpdateText()
         local textStr = data.displayText;
-        textStr = WeakAuras.ReplacePlaceHolders(textStr, region.values);
+        textStr = WeakAuras.ReplacePlaceHolders(textStr, region.values, region.state);
 
         if(textStr ~= text.displayText) then
             if text:GetFont() then text:SetText(textStr); end

--- a/RegionTypes/text.lua
+++ b/RegionTypes/text.lua
@@ -54,7 +54,7 @@ local function modify(parent, region, data)
 
     text:ClearAllPoints();
     text:SetPoint("CENTER", UIParent, "CENTER");
-    
+
     data.width = text:GetWidth();
     data.height = text:GetHeight();
     region:SetWidth(data.width);
@@ -97,8 +97,9 @@ local function modify(parent, region, data)
     if (customTextFunc) then
         local values = region.values;
         region.UpdateCustomText = function()
-            WeakAuras.ActivateAuraEnvironment(data.id);
-            local custom = customTextFunc(region.expirationTime, region.duration, values.progress, values.duration, values.name, values.icon, values.stacks);
+            WeakAuras.ActivateAuraEnvironment(region.id, region.cloneId, region.state);
+            local custom = customTextFunc(region.expirationTime, region.duration,
+              values.progress, values.duration, values.name, values.icon, values.stacks);
             WeakAuras.ActivateAuraEnvironment(nil);
             custom = WeakAuras.EnsureString(custom);
             if(custom ~= values.custom) then
@@ -178,7 +179,7 @@ local function modify(parent, region, data)
     end
 
     local function UpdateCustom()
-        UpdateValue(region.customValueFunc(data.trigger));
+        UpdateValue(region.customValueFunc(region.state.trigger));
     end
 
     function region:SetDurationInfo(duration, expirationTime, customValue)
@@ -189,7 +190,7 @@ local function modify(parent, region, data)
 
         if(customValue) then
             if(type(customValue) == "function") then
-                local value, total = customValue(data.trigger);
+                local value, total = customValue(region.state.trigger);
                 if(total > 0 and value < total) then
                     region.customValueFunc = customValue;
                     region:SetScript("OnUpdate", UpdateCustom);

--- a/Transmission.lua
+++ b/Transmission.lua
@@ -1021,7 +1021,9 @@ local function checkTrigger(codes, id, trigger, untrigger)
         elseif(WeakAuras.transmitCache and WeakAuras.transmitCache[data.id]) then
           i = WeakAuras.transmitCache[data.id];
         end
-        thumbnail:SetIcon(i);
+        if (i) then
+          thumbnail:SetIcon(i);
+        end
       end
       thumbnail_frame:Show();
 

--- a/Types.lua
+++ b/Types.lua
@@ -943,7 +943,8 @@ WeakAuras.rune_specific_types = {
 };
 WeakAuras.custom_trigger_types = {
   ["event"] = L["Event"],
-  ["status"] = L["Status"]
+  ["status"] = L["Status"],
+  ["stateupdate"] = L["Trigger State Updater"]
 };
 WeakAuras.eventend_types = {
   ["timed"] = L["Timed"],

--- a/Types.lua
+++ b/Types.lua
@@ -57,6 +57,9 @@ WeakAuras.trigger_require_types = {
   all = L["All Triggers"],
   custom = L["Custom Function"]
 };
+WeakAuras.trigger_modes = {
+  ["first_active"] = -10,
+};
 WeakAuras.trigger_types = {
   aura = L["Aura"],
   status = L["Status"],

--- a/WeakAuras.lua
+++ b/WeakAuras.lua
@@ -3270,29 +3270,20 @@ function WeakAuras.UpdatedTriggerState(id)
   end
 end
 
-local toReplace = {};
+local replaceStringCache = {};
 function WeakAuras.ReplacePlaceHolders(textStr, regionValues, regionState)
-  for symbol, v in pairs(WeakAuras.dynamic_texts) do
-    textStr = textStr:gsub(symbol, regionValues[v.value] or "");
-  end
   if (regionState) then
-    wipe(toReplace);
-    -- Find all patterns that are used, don't modify the string while we search
-
-    local startI = textStr:find("#");
-    while (startI) do
-      local endI = textStr:find("#", startI + 1);
-      if (not endI) then break; end
-
-      tinsert(toReplace, textStr:sub(startI + 1, endI - 1));
-      startI = textStr:find("#", endI + 1);
-    end
-
-    for _, pattern in ipairs(toReplace) do
-      if (regionState[pattern]) then
-        textStr = textStr:gsub("#" .. pattern .. "#", regionState[pattern]);
+    for key, value in pairs(regionState) do
+      if (type(value) == "string" or type(value) == "number") then
+        if (not replaceStringCache[key]) then
+          replaceStringCache[key] = "%%" .. key;
+        end
+        textStr = textStr:gsub(replaceStringCache[key], tostring(value) or "");
       end
     end
+  end
+  for symbol, v in pairs(WeakAuras.dynamic_texts) do
+    textStr = textStr:gsub(symbol, regionValues[v.value] or "");
   end
   return textStr;
 end

--- a/WeakAuras.lua
+++ b/WeakAuras.lua
@@ -82,9 +82,6 @@ local squelch_actions = true;
 -- Load functions, keyed on id
 local loadFuncs = {}
 
---custom trigger logic functions, keyed on id
-local triggerLogicFuncs = {}
-
 -- All regions keyed on id, has properties: region, regionType, also see clones
 WeakAuras.regions = {};
 local regions = WeakAuras.regions;
@@ -121,6 +118,37 @@ local regionOptions = WeakAuras.regionOptions;
 WeakAuras.triggerTypes = {};
 local triggerTypes = WeakAuras.triggerTypes;
 
+-- Trigger State, updated by trigger systems, then applied to regions by UpdatedTriggerState
+-- keyed on id, triggernum, cloneid
+-- cloneid can be a empty string
+
+-- Noteable properties:
+--  changed: Whether this trigger state was recently changed and its properties
+--           need to be applied to a region. The glue code resets this
+--           after syncing the region to the trigger state
+--  show: Whether the region for this trigger state should be shown
+--  progressType: Either "timed", "static"
+--    duration: The duration if the progressType is timed
+--    expirationTime: The expirationTime if the progressType is timed
+--    resort: Should be set to true by the trigger system the parent needs
+--            to be resorted. The glue code resets this.
+--    autoHide: If the aura should be hidden on expiring
+--    value: The value if the progressType is static
+--    total: The total if the progressType is static
+--    inverse: The static values should be interpreted inversely
+--  name: The name information
+--  icon: The icon information
+--  texture: The texture information
+--  stacks: The stacks information
+--  index: The index of the buff/debuff for the buff trigger system, used to set the tooltip
+--  spellId: spellId of the buff/debuff, used to set the tooltip
+
+WeakAuras.triggerState = {}
+local triggerState = WeakAuras.triggerState;
+
+-- Fallback states
+local fallbacksStates = {};
+
 -- List of all trigger systems, contains each system once
 WeakAuras.triggerSystems = {}
 local triggerSystems = WeakAuras.triggerSystems;
@@ -129,7 +157,7 @@ WeakAuras.forceable_events = {};
 
 local from_files = {};
 
-local timers = {};
+local timers = {}; -- Timers for autohiding, keyed on id, triggernum, cloneid
 WeakAuras.timers = timers;
 
 local loaded_events = {};
@@ -307,7 +335,7 @@ local overrideFunctions = {
 local aura_environments = {};
 local current_aura_env = nil;
 local aura_env_stack = {}; -- Stack of of aura environments, allows use of recursive aura activations through calls to WeakAuras.ScanEvents().
-function WeakAuras.ActivateAuraEnvironment(id)
+function WeakAuras.ActivateAuraEnvironment(id, cloneId, state)
   if(not id or not db.displays[id]) then
     -- Pop the last aura_env from the stack, and update current_aura_env appropriately.
     tremove(aura_env_stack);
@@ -318,6 +346,8 @@ function WeakAuras.ActivateAuraEnvironment(id)
       -- Point the current environment to the correct table
       aura_environments[id] = aura_environments[id] or {};
       current_aura_env = aura_environments[id];
+      current_aura_env.cloneId = cloneId;
+      current_aura_env.state = state;
       -- Push the new environment onto the stack
       tinsert(aura_env_stack, current_aura_env);
     else
@@ -382,54 +412,6 @@ function WeakAuras.LoadFunction(string)
     end
   end
 end
-
-local duration_cache = {};
-WeakAuras.duration_cache = duration_cache;
-local clone_duration_cache = {};
-function duration_cache:SetDurationInfo(id, duration, expirationTime, isValue, inverse, cloneId)
-  local cache;
-  if(cloneId) then
-    clone_duration_cache[id] = clone_duration_cache[id] or {};
-    clone_duration_cache[id][cloneId] = clone_duration_cache[id][cloneId] or {};
-    cache = clone_duration_cache[id][cloneId];
-  else
-    duration_cache[id] = duration_cache[id] or {};
-    cache = duration_cache[id];
-  end
-  cache.duration = duration;
-  cache.expirationTime = expirationTime;
-  cache.isValue = isValue;
-end
-
-function duration_cache:GetDurationInfo(id, cloneId)
-  local cache;
-  if(cloneId) then
-    --print("GetDurationInfo", id, cloneId);
-    --print(clone_duration_cache[id] and clone_duration_cache[id][cloneId]);
-    if(clone_duration_cache[id] and clone_duration_cache[id][cloneId]) then
-      cache = clone_duration_cache[id][cloneId];
-      if(type(cache.isValue) == "function") then
-        local value, maxValue = cache.isValue(WeakAuras.GetData(id).trigger);
-        return value, maxValue, true;
-      else
-        return cache.duration, cache.expirationTime, cache.isValue, cache.inverse;
-      end
-    else
-      return 0, math.huge;
-    end
-    elseif(duration_cache[id]) then
-      cache = duration_cache[id]
-      if(type(cache.isValue) == "function") then
-        local value, maxValue = cache.isValue(WeakAuras.GetData(id).trigger);
-        return value, maxValue, true;
-      else
-        return cache.duration, cache.expirationTime, cache.isValue, cache.inverse;
-      end
-    else
-      return 0, math.huge;
-  end
-end
-WeakAuras.duration_cache = duration_cache;
 
 function WeakAuras.ParseNumber(numString)
   if not(numString and type(numString) == "string") then
@@ -696,17 +678,11 @@ function WeakAuras.Pause()
   -- Forcibly hide all displays, and clear all trigger information (it will be restored on .Resume() due to forced events)
   for id, region in pairs(regions) do
     region.region:Collapse(); -- ticket 366
-    region.region.trigger_count = 0;
-    region.region.triggers = region.region.triggers or {};
-    wipe(region.region.triggers);
   end
 
   for id, cloneList in pairs(clones) do
     for cloneId, clone in pairs(cloneList) do
       clone:Collapse();
-      clone.trigger_count = 0;
-      clone.triggers = clone.triggers or {};
-      wipe(clone.triggers);
     end
   end
 end
@@ -729,17 +705,11 @@ end
 function WeakAuras.ScanAll()
   for id, region in pairs(regions) do
     region.region:Collapse();
-    region.region.trigger_count = 0;
-    region.region.triggers = region.region.triggers or {};
-    wipe(region.region.triggers);
   end
 
   for id, cloneList in pairs(clones) do
     for cloneId, clone in pairs(cloneList) do
       clone:Collapse();
-      clone.trigger_count = 0;
-      clone.triggers = clone.triggers or {};
-      wipe(clone.triggers);
     end
   end
 
@@ -748,156 +718,6 @@ function WeakAuras.ScanAll()
   for _, triggerSystem in pairs(triggerSystems) do
     triggerSystem.ScanAll();
    end
-end
-
-function WeakAuras.SetEventDynamics(id, triggernum, data, ending)
-  local trigger;
-  if(triggernum == 0) then
-    trigger = db.displays[id] and db.displays[id].trigger;
-  else
-  trigger = db.displays[id] and db.displays[id].additional_triggers
-    and db.displays[id].additional_triggers[triggernum]
-    and db.displays[id].additional_triggers[triggernum].trigger;
-  end
-  if(trigger) then
-    WeakAuras.ActivateAuraEnvironment(id);
-    if(data.duration) then
-      if not(ending) then
-        WeakAuras.ActivateEventTimer(id, triggernum, data.duration);
-      end
-      if(triggernum == 0) then
-        if(data.region.SetDurationInfo) then
-          local expirationTime = GetTime() + data.duration;
-          local resort = data.region.expirationTime ~= expirationTime;
-          data.region:SetDurationInfo(data.duration, expirationTime);
-
-          local parent = db.displays[id].parent;
-          if (resort and parent and db.displays[parent] and db.displays[parent].regionType == "dynamicgroup") then
-            regions[parent].region.ControlChildren();
-          end
-        end
-
-        duration_cache:SetDurationInfo(id, data.duration, GetTime() + data.duration);
-      end
-    else
-      if(data.durationFunc) then
-        local duration, expirationTime, static, inverse = data.durationFunc(trigger);
-        duration = type(duration) == "number" and duration or 0;
-        expirationTime = type(expirationTime) == "number" and expirationTime or 0;
-        if(type(static) == "string") then
-          static = data.durationFunc;
-        end
-        if(duration > 0.01 and not static) then
-          local hideOnExpire = true;
-          if(data.expiredHideFunc) then
-            hideOnExpire = data.expiredHideFunc(trigger);
-          end
-          if(hideOnExpire and not ending) then
-            WeakAuras.ActivateEventTimer(id, triggernum, expirationTime - GetTime());
-          end
-        end
-        if(triggernum == 0) then
-          if(data.region.SetDurationInfo) then
-            local resort = data.region.expirationTime ~= expirationTime;
-            data.region:SetDurationInfo(duration, expirationTime, static, inverse);
-            local parent = db.displays[id].parent;
-            if (resort and parent and db.displays[parent] and db.displays[parent].regionType == "dynamicgroup") then
-              regions[parent].region.ControlChildren();
-            end
-          end
-
-          duration_cache:SetDurationInfo(id, duration, expirationTime, static, inverse);
-        end
-      elseif(triggernum == 0) then
-        if(data.region.SetDurationInfo) then
-          local resort = data.region.expirationTime ~= math.huge;
-          data.region:SetDurationInfo(0, math.huge);
-
-          local parent = db.displays[id].parent;
-          if (resort and parent and db.displays[parent] and db.displays[parent].regionType == "dynamicgroup") then
-            regions[parent].region.ControlChildren();
-          end
-        end
-
-        duration_cache:SetDurationInfo(id, 0, math.huge);
-      end
-    end
-    if(triggernum == 0) then
-      if(data.region.SetName) then
-        if(data.nameFunc) then
-          data.region:SetName(data.nameFunc(trigger));
-        else
-          data.region:SetName();
-        end
-      end
-      if(data.region.SetIcon) then
-        if(data.iconFunc) then
-          data.region:SetIcon(data.iconFunc(trigger));
-        else
-          data.region:SetIcon();
-        end
-      end
-      if(data.region.SetTexture) then
-        if(data.textureFunc) then
-          data.region:SetTexture(data.textureFunc(trigger));
-        end
-      end
-      if(data.region.SetStacks) then
-        if(data.stacksFunc) then
-          data.region:SetStacks(data.stacksFunc(trigger));
-        else
-          data.region:SetStacks();
-        end
-      end
-      if(data.region.UpdateCustomText and not WeakAuras.IsRegisteredForCustomTextUpdates(data.region)) then
-        data.region.UpdateCustomText();
-      end
-      WeakAuras.UpdateMouseoverTooltip(data.region)
-    end
-    WeakAuras.ActivateAuraEnvironment(nil);
-  else
-  error("Event with id \""..id.." and trigger number "..triggernum.." tried to activate, but does not exist");
-  end
-end
-
-function WeakAuras.ActivateEventTimer(id, triggernum, duration)
-  if not(paused) then
-    local trigger;
-    if(triggernum == 0) then
-      trigger = db.displays[id] and db.displays[id].trigger;
-    else
-      trigger = db.displays[id] and db.displays[id].additional_triggers
-      and db.displays[id].additional_triggers[triggernum]
-      and db.displays[id].additional_triggers[triggernum].trigger;
-    end
-    if(trigger and trigger.type == "event" or trigger.type == "custom") then
-      local expirationTime = GetTime() + duration;
-      local doTimer;
-      if(timers[id] and timers[id][triggernum]) then
-        if(timers[id][triggernum].expirationTime ~= expirationTime) then
-          timer:CancelTimer(timers[id][triggernum].handle);
-          doTimer = "change";
-        else
-          debug("Timer for "..id.." ("..triggernum..") did not change");
-        end
-      else
-        doTimer = "new";
-      end
-
-      if(doTimer) then
-        timers[id] = timers[id] or {};
-        timers[id][triggernum] = timers[id][triggernum] or {};
-        local record = timers[id][triggernum];
-        if(doTimer == "change") then
-          debug("Timer for "..id.." ("..triggernum..") changed from "..(record.expirationTime or "none").." to "..expirationTime);
-        elseif(doTimer == "new") then
-          debug("Timer for "..id.." ("..triggernum..") will end at "..expirationTime.." ("..duration..")");
-        end
-        record.handle = timer:ScheduleTimer(function() WeakAuras.EndEvent(id, triggernum, true) end, duration);
-        record.expirationTime = expirationTime;
-      end
-    end
-  end
 end
 
 -- encounter stuff
@@ -1115,7 +935,7 @@ function WeakAuras.ScanForLoads(self, event, arg1)
   local changed = 0;
   local shouldBeLoaded, couldBeLoaded;
   for id, data in pairs(db.displays) do
-    if (data and data.trigger) then
+    if (data and not data.controlledChildren) then
       local loadFunc = loadFuncs[id];
       shouldBeLoaded = loadFunc and loadFunc("ScanForLoads_Auras", incombat, inpetbattle, vehicle, vehicleUi, player, realm, class, spec, race, faction, playerLevel, zone, zoneId, encounter_id, size, difficulty, role);
       couldBeLoaded = loadFunc and loadFunc("ScanForLoads_Auras", true, true, vehicle, vehicleUi, player, realm, class, spec, race, faction, playerLevel, zone, zoneId, encounter_id, size, difficulty, role);
@@ -1128,12 +948,9 @@ function WeakAuras.ScanForLoads(self, event, arg1)
       if(loaded[id] and not shouldBeLoaded) then
         WeakAuras.UnloadDisplay(id);
         local region = WeakAuras.regions[id].region;
-        region.trigger_count = 0;
-        region.triggers = region.triggers or {};
-        wipe(region.triggers);
         if not(paused) then
           region:Collapse();
-          WeakAuras.HideAllClones(id);
+          WeakAuras.CollapseAllClones(id);
         end
       end
       if(shouldBeLoaded) then
@@ -1204,6 +1021,25 @@ function WeakAuras.ReloadAll()
 end
 
 function WeakAuras.UnloadAll()
+  for _, v in pairs(triggerState) do
+    for i = 0, v.numTriggers - 1 do
+      if (v[i]) then
+        wipe(v[i]);
+      end
+    end
+  end
+
+  for _, aura in pairs(timers) do
+    for _, trigger in pairs(aura) do
+      for _, record in pairs(trigger) do
+        if (record.handle) then
+          timer:CancelTimer(record.handle);
+        end
+      end
+    end
+  end
+  wipe(timers);
+
   for _, triggerSystem in pairs(triggerSystems) do
     triggerSystem.UnloadAll();
   end
@@ -1212,16 +1048,39 @@ end
 
 do
   function WeakAuras.LoadDisplay(id)
+    triggerState[id].triggers = {};
+    triggerState[id].triggerCount = 0;
+    triggerState[id].show = false;
+    triggerState[id].activeTrigger = nil;
     for _, triggerSystem in pairs(triggerSystems) do
       triggerSystem.LoadDisplay(id);
     end
   end
 
   function WeakAuras.UnloadDisplay(id)
+    for i = 0, triggerState[id].numTriggers - 1 do
+      if (triggerState[id][i]) then
+        wipe(triggerState[id][i]);
+      end
+    end
+    triggerState[id].show = nil;
+    triggerState[id].activeTrigger = nil;
+
+    if (timers[id]) then
+      for _, trigger in pairs(timers[id]) do
+        for _, record in pairs(trigger) do
+          if (record.handle) then
+            timer:CancelTimer(record.handle);
+          end
+        end
+      end
+      timers[id] = nil;
+    end
     for _, triggerSystem in pairs(triggerSystems) do
       triggerSystem.UnloadDisplay(id);
     end
   end
+
 end
 
 function WeakAuras.Delete(data)
@@ -1255,7 +1114,7 @@ function WeakAuras.Delete(data)
   regions[id].region:SetScript("OnHide", nil);
   regions[id].region:Hide();
 
-  WeakAuras.HideAllClones(id);
+  WeakAuras.CollapseAllClones(id);
 
   db.registered[id] = nil;
   if(WeakAuras.importDisplayButtons and WeakAuras.importDisplayButtons[id]) then
@@ -1274,11 +1133,11 @@ function WeakAuras.Delete(data)
   regions[id] = nil;
   loaded[id] = nil;
   loadFuncs[id] = nil;
-  triggerLogicFuncs[id] = nil;
 
   db.displays[id] = nil;
 
   aura_environments[id] = nil;
+  triggerState[id] = nil;
 end
 
 function WeakAuras.Rename(data, newid)
@@ -1296,6 +1155,7 @@ function WeakAuras.Rename(data, newid)
 
   regions[newid] = regions[oldid];
   regions[oldid] = nil;
+  regions[newid].region.id = newid;
 
   for _, triggerSystem in pairs(triggerSystems) do
     triggerSystem.Rename(oldid, newid);
@@ -1305,8 +1165,13 @@ function WeakAuras.Rename(data, newid)
   loaded[oldid] = nil;
   loadFuncs[newid] = loadFuncs[oldid];
   loadFuncs[oldid] = nil;
-  triggerLogicFuncs[newid] = triggerLogicFuncs[oldid];
-  triggerLogicFuncs[oldid] = nil;
+
+  timers[newid] = timers[oldid];
+  timers[oldid] = nil;
+
+  triggerState[newid] = triggerState[oldid];
+  triggerState[oldid] = nil;
+
 
   db.displays[newid] = db.displays[oldid];
   db.displays[oldid] = nil;
@@ -1314,6 +1179,9 @@ function WeakAuras.Rename(data, newid)
   if(clones[oldid]) then
     clones[newid] = clones[oldid];
     clones[oldid] = nil;
+    for cloneid, clone in pairs(clones[newid]) do
+      clone.id = newid;
+    end
   end
 
   db.displays[newid].id = newid;
@@ -1718,6 +1586,10 @@ function WeakAuras.Modernize(data)
     end
 
   end
+
+  if (not data.activeTriggerMode) then
+    data.activeTriggerMode = 0;
+  end
 end
 
 function WeakAuras.SyncParentChildRelationships(silent)
@@ -1854,15 +1726,14 @@ function WeakAuras.pAdd(data)
   elseif (data.controlledChildren) then
     WeakAuras.SetRegion(data);
   else
+    for _, triggerSystem in pairs(triggerSystems) do
+      triggerSystem.Add(data);
+    end
     local region = WeakAuras.SetRegion(data);
     if (WeakAuras.clones[id]) then
       for cloneId, _ in pairs(WeakAuras.clones[id]) do
         WeakAuras.SetRegion(data, cloneId);
       end
-    end
-
-    for _, triggerSystem in pairs(triggerSystems) do
-      triggerSystem.Add(data, region);
     end
 
     data.init_completed = nil;
@@ -1878,11 +1749,25 @@ function WeakAuras.pAdd(data)
     WeakAuras.debug(loadFuncStr);
 
     loadFuncs[id] = loadFunc;
-    triggerLogicFuncs[id] = triggerLogicFunc;
+    clones[id] = clones[id] or {};
 
-    if(WeakAuras.CanHaveClones(data)) then
-      clones[id] = clones[id] or {};
+    if (timers[id]) then
+      for _, trigger in pairs(timers[id]) do
+        for _, record in pairs(trigger) do
+          if (record.handle) then
+            timer:CancelTimer(record.handle);
+          end
+        end
+      end
+      timers[id] = nil;
     end
+
+    triggerState[id] = {};
+    triggerState[id].disjunctive = data.numTriggers > 1 and data.disjunctive or "all";
+    triggerState[id].numTriggers = data.numTriggers;
+    triggerState[id].activeTriggerMode = data.activeTriggerMode or 0;
+    triggerState[id].triggerLogicFunc = triggerLogicFunc;
+    triggerState[id].triggers = {};
 
     WeakAuras.LoadEncounterInitScripts(id)
 
@@ -1924,6 +1809,8 @@ function WeakAuras.SetRegion(data, cloneId)
         else
           region = regions[id].region;
         end
+        region.id = id;
+        region.cloneId = "";
       end
       WeakAuras.validate(data, regionTypes[regionType].default);
 
@@ -1993,7 +1880,7 @@ function WeakAuras.SetRegion(data, cloneId)
           end
           region.toShow = false;
 
-          WeakAuras.PerformActions(data, "finish");
+          WeakAuras.PerformActions(data, "finish", region);
           WeakAuras.Animate("display", data, "finish", data.animation.finish, region, false, hideRegion, nil, cloneId);
           parent:ControlChildren();
         end
@@ -2009,7 +1896,7 @@ function WeakAuras.SetRegion(data, cloneId)
 
           parent:EnsureTrays();
           region.justCreated = nil;
-          WeakAuras.PerformActions(data, "start");
+          WeakAuras.PerformActions(data, "start", region);
           if not(WeakAuras.Animate("display", data, "start", data.animation.start, region, true, startMainAnimation, nil, cloneId)) then
             startMainAnimation();
           end
@@ -2022,7 +1909,7 @@ function WeakAuras.SetRegion(data, cloneId)
           end
           region.toShow = false;
 
-          WeakAuras.PerformActions(data, "finish");
+          WeakAuras.PerformActions(data, "finish", region);
           if (not WeakAuras.Animate("display", data, "finish", data.animation.finish, region, false, hideRegion, nil, cloneId)) then
             region:Hide();
           end
@@ -2042,7 +1929,7 @@ function WeakAuras.SetRegion(data, cloneId)
             region:PreShow();
           end
           region:Show();
-          WeakAuras.PerformActions(data, "start");
+          WeakAuras.PerformActions(data, "start", region);
           if not(WeakAuras.Animate("display", data, "start", data.animation.start, region, true, startMainAnimation, nil, cloneId)) then
             startMainAnimation();
           end
@@ -2064,61 +1951,6 @@ function WeakAuras.SetRegion(data, cloneId)
         clonePool[regionType] = clonePool[regionType] or {};
       end
 
-      if(data.additional_triggers and #data.additional_triggers > 0) then
-        region.trigger_count = region.trigger_count or 0;
-        region.triggers = region.triggers or {};
-
-        function region:TestTriggers(triggers, trigger_count)
-          if(data.disjunctive == "custom") then
-            local customFunc = triggerLogicFuncs[data.id];
-            if customFunc then
-              if(customFunc(triggers)) then
-                region:Expand();
-                return true;
-              else
-                region:Collapse();
-                return false;
-              end
-            end
-          elseif(trigger_count > (((data.disjunctive == "any") and 0) or #data.additional_triggers)) then
-            region:Expand();
-            return true;
-          else
-            region:Collapse();
-            return false;
-          end
-        end
-
-        function region:EnableTrigger(triggernum)
-          if not(region.triggers[triggernum+1]) then
-            region.triggers[triggernum+1] = true;
-            region.trigger_count = region.trigger_count + 1;
-            return region:TestTriggers(region.triggers, region.trigger_count);
-          else
-            return nil;
-          end
-        end
-
-        function region:DisableTrigger(triggernum)
-          if(region.triggers[triggernum+1]) then
-            region.triggers[triggernum+1] = nil;
-            region.trigger_count = region.trigger_count - 1;
-            return not region:TestTriggers(region.triggers, region.trigger_count);
-          else
-            return nil;
-          end
-        end
-      else
-        function region:EnableTrigger()
-          region:Expand();
-          return true;
-        end
-        function region:DisableTrigger()
-          region:Collapse();
-          return true;
-        end
-      end
-
       if(anim_cancelled) then
         startMainAnimation();
       end
@@ -2134,16 +1966,26 @@ function WeakAuras.EnsureClone(id, cloneId)
     if(clonePool[data.regionType] and clonePool[data.regionType][1]) then
       clones[id][cloneId] = tremove(clonePool[data.regionType]);
     else
-      clones[id][cloneId] = regionTypes[data.regionType].create(frame, data);
-      clones[id][cloneId]:Hide();
+      local clone = regionTypes[data.regionType].create(frame, data);
+      clone:Hide();
+      clones[id][cloneId] = clone;
     end
     WeakAuras.SetRegion(data, cloneId);
     clones[id][cloneId].justCreated = true;
+    clones[id][cloneId].id = id;
+    clones[id][cloneId].cloneId = cloneId;
   end
   return clones[id][cloneId];
 end
 
-function WeakAuras.HideAllClones(id)
+function WeakAuras.GetRegion(id, cloneId)
+  if(cloneId and cloneId ~= "") then
+    return WeakAuras.EnsureClone(id, cloneId);
+   end
+  return WeakAuras.regions[id].region;
+end
+
+function WeakAuras.CollapseAllClones(id, triggernum)
   if(clones[id]) then
     for i,v in pairs(clones[id]) do
       v:Collapse();
@@ -2151,12 +1993,20 @@ function WeakAuras.HideAllClones(id)
   end
 end
 
-function WeakAuras.HideAllClonesExcept(id, list)
-  if(clones[id]) then
-    for i,v in pairs(clones[id]) do
-      if not(list[i]) then
-      v:Collapse();
-      end
+function WeakAuras.SetAllStatesHidden(id, triggernum)
+  local triggerState = WeakAuras.GetTriggerStateForTrigger(id, triggernum);
+  for id, state in pairs(triggerState) do
+    state.show = false;
+    state.change = true;
+  end
+end
+
+function WeakAuras.SetAllStatesHiddenExcept(id, triggernum, list)
+  local triggerState = WeakAuras.GetTriggerStateForTrigger(id, triggernum);
+  for cloneId, state in  pairs(triggerState) do
+    if (not (list[cloneId])) then
+      state.show = false;
+      state.changed = true;
     end
   end
 end
@@ -2180,7 +2030,7 @@ function WeakAuras.Announce(message, output, _, extra, id, type)
   end
 end
 
-function WeakAuras.PerformActions(data, type)
+function WeakAuras.PerformActions(data, type, region)
   if not(paused or squelch_actions) then
   local actions;
   if(type == "start") then
@@ -2243,7 +2093,7 @@ function WeakAuras.PerformActions(data, type)
   if(actions.do_custom and actions.custom) then
     local func = WeakAuras.LoadFunction("return function() "..(actions.custom).." end");
     if func then
-      WeakAuras.ActivateAuraEnvironment(data.id);
+      WeakAuras.ActivateAuraEnvironment(region.id, region.cloneId, region.state);
       func();
       WeakAuras.ActivateAuraEnvironment(nil);
     end
@@ -2296,35 +2146,37 @@ function WeakAuras.UpdateAnimations()
     finished = true;
     end
   elseif(anim.duration_type == "relative") then
-    local duration, expirationTime, isValue, inverse = duration_cache:GetDurationInfo(anim.name, anim.cloneId);
-    if(duration < 0.01) then
-    anim.progress = 0;
-    if(anim.type == "start" or anim.type == "finish") then
-      finished = true;
-    end
+    local state = anim.region.state;
+
+    if ((state.progressType == "timed" and state.duration < 0.01)
+        or (state.progressType == "static" and state.value < 0.01)) then
+      anim.progress = 0;
+      if(anim.type == "start" or anim.type == "finish") then
+        finished = true;
+      end
     else
-    local relativeProgress;
-    if(isValue) then
-      relativeProgress = duration / expirationTime;
-    else
-      relativeProgress = 1 - ((expirationTime - time) / duration);
-    end
-    relativeProgress = inverse and (1 - relativeProgress) or relativeProgress;
-    anim.progress = relativeProgress / anim.duration
-    local iteration = math.floor(anim.progress);
-    --anim.progress = anim.progress - iteration;
-    if not(anim.iteration) then
-      anim.iteration = iteration;
-    elseif(anim.iteration ~= iteration) then
-      anim.iteration = nil;
-      finished = true;
-    end
+      local relativeProgress;
+      if(state.progressType == "static") then
+        relativeProgress = state.value / state.total;
+      else
+        relativeProgress = 1 - ((state.expirationTime - time) / state.duration);
+      end
+      relativeProgress = state.inverseDirection and (1 - relativeProgress) or relativeProgress;
+      anim.progress = relativeProgress / anim.duration
+      local iteration = math.floor(anim.progress);
+      --anim.progress = anim.progress - iteration;
+      if not(anim.iteration) then
+        anim.iteration = iteration;
+      elseif(anim.iteration ~= iteration) then
+        anim.iteration = nil;
+        finished = true;
+      end
     end
   else
     anim.progress = 1;
   end
   local progress = anim.inverse and (1 - anim.progress) or anim.progress;
-  WeakAuras.ActivateAuraEnvironment(anim.name);
+  WeakAuras.ActivateAuraEnvironment(anim.name, anim.cloneId, anim.region.state);
   if(anim.translateFunc) then
     anim.region:ClearAllPoints();
     anim.region:SetPoint(anim.selfPoint, anim.anchor, anim.anchorPoint, anim.translateFunc(progress, anim.startX, anim.startY, anim.dX, anim.dY));
@@ -2560,7 +2412,7 @@ function WeakAuras.Animate(namespace, data, type, anim, region, inverse, onFinis
   animations[key].loop = loop
   animations[key].onFinished = onFinished
   animations[key].name = id
-  animations[key].cloneId = cloneId
+  animations[key].cloneId = cloneId or ""
 
   if not(updatingAnimations) then
     frame:SetScript("OnUpdate", WeakAuras.UpdateAnimations);
@@ -2628,37 +2480,88 @@ function WeakAuras.GetData(id)
   return id and db.displays[id];
 end
 
-function WeakAuras.CanHaveDuration(data)
-  local trigger = data.trigger;
-  local triggerSystem = triggerTypes[trigger.type];
+function WeakAuras.GetTriggerSystem(data, triggernum)
+  if (triggernum == 0) then
+    return triggerTypes[data.trigger.type];
+  elseif (data.additional_triggers and data.additional_triggers[triggernum]) then
+    return triggerTypes[data.additional_triggers[triggernum].trigger.type];
+  end
+  return nil;
+end
 
+local function wrapTriggerSystemFunction(functionName, mode)
+  local func;
+  func = function(data, triggernum)
+    if (not triggernum) then
+      return func(data, data.activeTriggerMode);
+    elseif (triggernum < 0) then
+      local result;
+      if (mode == "or") then
+        result = false;
+        for i = 0, data.numTriggers - 1 do
+          result = result or func(data, i);
+        end
+      elseif (mode == "and") then
+        result = true;
+        for i = 0, data.numTriggers - 1 do
+          result = result and func(data, i);
+        end
+      elseif (mode == "duration") then
+        result = false;
+        for i = 0, data.numTriggers - 1 do
+          local tmp = func(data, i);
+          if (tmp) then
+            result = tmp;
+            break;
+          end
+        end
+      elseif (mode == "nameAndIcon") then
+        for i = 0, data.numTriggers - 1 do
+          local tmp1, tmp2 = func(data, i);
+          if (tmp1) then
+            return tmp1, tmp2;
+          end
+        end
+      end
+      return result;
+    else -- triggernum >= 0
+      local triggerSystem = WeakAuras.GetTriggerSystem(data, triggernum);
+      if (not triggerSystem) then
+        return false;
+      end
+      return triggerSystem[functionName](data, triggernum);
+    end
+    return false;
+  end
+  return func;
+end
+
+WeakAuras.CanHaveDuration = wrapTriggerSystemFunction("CanHaveDuration", "duration");
+WeakAuras.CanHaveAuto = wrapTriggerSystemFunction("CanHaveAuto", "or");
+WeakAuras.CanGroupShowWithZero = wrapTriggerSystemFunction("CanGroupShowWithZero", "or");
+WeakAuras.CanHaveClones = wrapTriggerSystemFunction("CanHaveClones", "or");
+WeakAuras.CanHaveTooltip = wrapTriggerSystemFunction("CanHaveTooltip", "or");
+WeakAuras.GetNameAndIcon = wrapTriggerSystemFunction("GetNameAndIcon", "nameAndIcon");
+
+function WeakAuras.CreateFallbackState(id, triggernum, state)
+  local data = db.displays[id];
+  local triggerSystem = WeakAuras.GetTriggerSystem(data, triggernum);
   if (not triggerSystem) then
     return false;
   end
-  return triggerSystem.CanHaveDuration(data);
-end
 
-function WeakAuras.CanHaveAuto(data)
-  local trigger = data.trigger;
-  local triggerSystem = triggerTypes[trigger.type];
-
-  if (not triggerSystem) then
-    return false;
+  triggerSystem.CreateFallbackState(data, triggernum, state);
+  if (triggernum == 0) then
+    state.trigger = data.trigger;
+    state.triggernum = 0;
+    state.id = id;
+  else
+    state.trigger = data.additional_triggers[triggernum];
+    state.triggernum = triggernum;
+    state.id = id;
   end
-
-  return triggerSystem.CanHaveAuto(data)
 end
 
-function WeakAuras.CanGroupShowWithZero(data)
-  local trigger = data.trigger;
-  local triggerSystem = triggerTypes[trigger.type];
-
-  if (not triggerSystem) then
-    return false;
-  end
-
-  return triggerSystem.CanGroupShowWithZero(data);
-end
 
 function WeakAuras.CanShowNameInfo(data)
   if(data.regionType == "aurabar" or data.regionType == "icon" or data.regionType == "text") then
@@ -2674,39 +2577,6 @@ function WeakAuras.CanShowStackInfo(data)
   else
     return false;
   end
-end
-
- function WeakAuras.CanHaveClones(data)
-  local trigger = data.trigger;
-  local triggerSystem = triggerTypes[trigger.type];
-
-  if (not triggerSystem) then
-    return false;
-  end
-
-  return triggerSystem.CanHaveClones(data);
-end
-
-function WeakAuras.CanHaveTooltip(data)
-  local trigger = data.trigger;
-  local triggerSystem = triggerTypes[trigger.type];
-
-  if (not triggerSystem) then
-    return false;
-  end
-
-  return triggerSystem.CanHaveTooltip(data);
-end
-
-function WeakAuras.GetNameAndIcon(data)
-  local trigger = data.trigger;
-  local triggerSystem = triggerTypes[trigger.type];
-
-  if (not triggerSystem) then
-    return nil, nil;
-  end
-
-  return triggerSystem.GetNameAndIcon(data);
 end
 
 function WeakAuras.CorrectSpellName(input)
@@ -2755,17 +2625,15 @@ function WeakAuras.CorrectItemName(input)
 end
 
 
-local currentTooltipData;
 local currentTooltipRegion;
 local currentTooltipOwner;
 function WeakAuras.UpdateMouseoverTooltip(region)
   if(region == currentTooltipRegion) then
-    WeakAuras.ShowMouseoverTooltip(currentTooltipData, currentTooltipRegion, currentTooltipOwner);
+    WeakAuras.ShowMouseoverTooltip(currentTooltipRegion, currentTooltipOwner);
   end
 end
 
-function WeakAuras.ShowMouseoverTooltip(data, region, owner)
-  currentTooltipData = data;
+function WeakAuras.ShowMouseoverTooltip(region, owner)
   currentTooltipRegion = region;
   currentTooltipOwner = owner;
 
@@ -2773,18 +2641,21 @@ function WeakAuras.ShowMouseoverTooltip(data, region, owner)
   GameTooltip:SetPoint("LEFT", owner, "RIGHT");
   GameTooltip:ClearLines();
 
-  local trigger = data.trigger;
-  local triggerSystem = triggerTypes[trigger.type];
+  local triggerType;
+  if (region.state) then
+   triggerType = region.state.trigger.type;
+  end
+
+  local triggerSystem = triggerType and triggerTypes[triggerType];
   if (not triggerSystem) then
     return;
   end
 
-  triggerSystem.SetToolTip(data, region);
+  triggerSystem.SetToolTip(region.state.trigger, region.state);
   GameTooltip:Show();
 end
 
 function WeakAuras.HideTooltip()
-  currentTooltipData = nil;
   currentTooltipRegion = nil;
   currentTooltipOwner = nil;
   GameTooltip:Hide();
@@ -3134,9 +3005,278 @@ function WeakAuras.RegisterTriggerSystem(types, triggerSystem)
   tinsert(triggerSystems, triggerSystem);
 end
 
+function WeakAuras.GetTriggerStateForTrigger(id, triggernum)
+  triggerState[id][triggernum] = triggerState[id][triggernum] or {}
+  return triggerState[id][triggernum];
+end
+
+local function startStopTimers(id, cloneId, triggernum, state)
+  if (state.show) then
+    if (state.autoHide and state.duration) then -- autohide, update timer
+      timers[id] = timers[id] or {};
+      timers[id][triggernum] = timers[id][triggernum] or {};
+      timers[id][triggernum][cloneId] = timers[id][triggernum][cloneId] or {};
+      local record = timers[id][triggernum][cloneId];
+      local createTimer = false;
+      if (state.expirationTime == nil) then
+        state.expirationTime = GetTime() + state.duration;
+        state.resort = true;
+      end
+      if (record.expirationTime ~= state.expirationTime) then
+        if (record.handle ~= nil) then
+          timer:CancelTimer(record.handle);
+        end
+
+        record.handle = timer:ScheduleTimer(
+          function()
+            if (state.show ~= false and state.show ~= nil) then
+              state.show = false;
+              state.changed = true;
+              WeakAuras.UpdatedTriggerState(id);
+            end
+          end,
+          state.expirationTime - GetTime() + 0.01);
+        record.expirationTime = state.expirationTime;
+      end
+    else -- no auto hide, delete timer
+      if (timers[id] and timers[id][triggernum] and timers[id][triggernum][cloneId]) then
+        local record = timers[id][triggernum][cloneId];
+        if (record.handle) then
+          timer:CancelTimer(record.handle);
+        end
+        record.handle = nil;
+        record.expirationTime = nil;
+      end
+    end
+  else -- not shown
+    if(timers[id] and timers[id][triggernum] and timers[id][triggernum][cloneId]) then
+      local record = timers[id][triggernum][cloneId];
+      if (record.handle) then
+        timer:CancelTimer(record.handle);
+      end
+      record.handle = nil;
+      record.expirationTime = nil;
+    end
+  end
+end
+
+local function ApplyStateToRegion(id, region, state)
+  region.state = state;
+  if(region.SetDurationInfo) then
+    if (state.progressType == "timed") then
+      local now = GetTime();
+      local value = math.huge - now;
+      if (state.expirationTime and state.expirationTime > 0) then
+        value = state.expirationTime - now;
+      end
+      local total = state.duration or 0
+      local func = nil;
+
+      region:SetDurationInfo(total,
+                             now + value,
+                             func,
+                             state.inverseDirection);
+    elseif (state.progressType == "static") then
+      local value = state.value or 0;
+      local total = state.total or 0;
+      local durationFunc = state.durationFunc or true;
+
+      region:SetDurationInfo(value, total, durationFunc or true, state.inverseDirection);
+    else
+      -- Do nothing, should ideally clear duration info on region
+    end
+  end
+  if (state.resort) then
+    WeakAuras.ControlChildren(region.id);
+    state.resort = false;
+  end
+  if(region.SetName) then
+    region:SetName(state.name);
+  end
+  if(region.SetIcon) then
+    region:SetIcon(state.icon or "Interface\\Icons\\INV_Misc_QuestionMark");
+  end
+  if(region.SetStacks) then
+    region:SetStacks(state.stacks);
+  end
+  if(region.UpdateCustomText and not WeakAuras.IsRegisteredForCustomTextUpdates(region)) then
+    region.UpdateCustomText();
+  end
+  WeakAuras.UpdateMouseoverTooltip(region);
+  region:Expand();
+end
+
+-- Fallbacks if the states are empty
+local emptyState = {};
+emptyState[""] = {};
+
+local function applyToTriggerStateTriggers(stateShown, id, triggernum)
+  if (stateShown and not triggerState[id].triggers[triggernum + 1]) then
+    triggerState[id].triggers[triggernum + 1] = true;
+    triggerState[id].triggerCount = triggerState[id].triggerCount + 1;
+    return true;
+  elseif (not stateShown and triggerState[id].triggers[triggernum + 1]) then
+    -- Check if any other clone is shown
+    local anyCloneShown = false;
+    for _, state in pairs(triggerState[id][triggernum]) do
+      if (state.show) then
+        anyCloneShown = true;
+        break;
+      end
+    end
+    if (not anyCloneShown) then
+      triggerState[id].triggers[triggernum + 1] = false;
+      triggerState[id].triggerCount = triggerState[id].triggerCount - 1;
+      return true;
+    end
+  end
+  return false;
+end
+
+local function evaluateTriggerStateTriggers(id)
+  if(triggerState[id].disjunctive == "any" and triggerState[id].triggerCount > 0
+      or (triggerState[id].disjunctive == "all" and triggerState[id].triggerCount == triggerState[id].numTriggers)
+      or (triggerState[id].disjunctive == "custom"
+          and triggerState[id].triggerLogicFunc
+          and triggerState[id].triggerLogicFunc(triggerState[id].triggers))
+    ) then
+    return true;
+  end
+  return false;
+end
+
+local function ApplyStatesToRegions(id, triggernum, states)
+  -- Show new clones
+  local visibleRegion = false;
+  for cloneId, state in pairs(states) do
+    if (state.show) then
+      visibleRegion = true;
+      local region = WeakAuras.GetRegion(id, cloneId);
+      if (not region.toShow or state.changed or region.state ~= state) then
+        ApplyStateToRegion(id, region, state);
+      end
+    end
+  end
+
+  if (visibleRegion) then
+    if (not states[""] or not states[""].show) then
+      WeakAuras.regions[id].region:Collapse();
+    end
+  else
+    -- no visible region, fallback to a fallback state
+    fallbacksStates[id] = fallbacksStates[id] or {};
+    fallbacksStates[id][triggernum] =  fallbacksStates[id][triggernum] or {};
+    WeakAuras.CreateFallbackState(id, triggernum, fallbacksStates[id][triggernum])
+    ApplyStateToRegion(id, WeakAuras.regions[id].region, fallbacksStates[id][triggernum]);
+  end
+end
+
+local toRemove = {};
+function WeakAuras.UpdatedTriggerState(id)
+  if (not triggerState[id]) then
+    return;
+  end
+
+  local changed = false;
+  for triggernum = 0, triggerState[id].numTriggers - 1 do
+    triggerState[id][triggernum] = triggerState[id][triggernum] or {};
+    for cloneId, state in pairs(triggerState[id][triggernum]) do
+      if (triggernum == 0) then
+        state.trigger = db.displays[id].trigger;
+        state.triggernum = 0;
+        state.id = id;
+      else
+        state.trigger = db.displays[id].additional_triggers[triggernum];
+        state.triggernum = triggernum;
+        state.id = id;
+      end
+
+      if (state.changed) then
+        startStopTimers(id, cloneId, triggernum, state);
+        local stateShown = triggerState[id][triggernum][cloneId] and triggerState[id][triggernum][cloneId].show;
+        -- Update triggerState.triggers
+        changed = applyToTriggerStateTriggers(stateShown, id, triggernum) or changed;
+      end
+    end
+  end
+
+-- Figure out whether we should be shown or not
+  local show = triggerState[id].show;
+  if (changed or show == nil) then
+    show = evaluateTriggerStateTriggers(id);
+  end
+
+  -- Figure out which subtrigger is active, and if it changed
+  local newActiveTrigger = triggerState[id].activeTriggerMode;
+  if (newActiveTrigger == WeakAuras.trigger_modes.first_active) then
+    -- Mode is first active trigger, so find a active trigger
+    for i = 0, triggerState[id].numTriggers - 1 do
+      if (triggerState[id].triggers[i + 1]) then
+        newActiveTrigger = i;
+        break;
+      end
+    end
+  end
+
+  local oldShow = triggerState[id].show;
+  triggerState[id].activeTrigger = newActiveTrigger;
+  triggerState[id].show = show;
+
+  local activeTriggerState = WeakAuras.GetTriggerStateForTrigger(id, newActiveTrigger);
+  if (not next(activeTriggerState)) then
+    activeTriggerState = emptyState;
+  end
+
+  local region;
+  -- Now apply
+  if (show and not oldShow) then -- Hide => Show
+    ApplyStatesToRegions(id, newActiveTrigger, activeTriggerState);
+  elseif (not show and oldShow) then -- Show => Hide
+    WeakAuras.CollapseAllClones(id);
+    WeakAuras.regions[id].region:Collapse();
+  elseif (show and oldShow) then -- Already shown, update regions
+    -- Hide old clones
+    for cloneId, clone in pairs(clones[id]) do
+      if (not activeTriggerState[cloneId] or not activeTriggerState[cloneId].show) then
+        clone:Collapse();
+      end
+    end
+    -- Show new states
+    ApplyStatesToRegions(id, newActiveTrigger, activeTriggerState);
+  end
+
+
+  for triggernum = 0, triggerState[id].numTriggers - 1 do
+    triggerState[id][triggernum] = triggerState[id][triggernum] or {};
+    for cloneId, state in pairs(triggerState[id][triggernum]) do
+      if (not state.show) then
+        if (cloneId ~= "") then -- Keep "" state around, it's likely to be reused
+          tinsert(toRemove, cloneId)
+        else
+          for k, v in pairs(state) do
+            if (k ~= "trigger" and k ~= "triggernum" and k ~= "id") then
+              state[k] = nil;
+            end
+          end
+        end
+      end
+      state.changed = false;
+    end
+    for _, cloneId in ipairs(toRemove) do
+      triggerState[id][triggernum][cloneId] = nil;
+    end
+    wipe(toRemove);
+  end
+end
+
 function WeakAuras.ReplacePlaceHolders(textStr, regionValues)
   for symbol, v in pairs(WeakAuras.dynamic_texts) do
     textStr = textStr:gsub(symbol, regionValues[v.value] or "");
   end
   return textStr;
+end
+
+function WeakAuras.IsTriggerActive(id)
+  local active = triggerState[id];
+  return active and active.show;
 end


### PR DESCRIPTION
Those store all information of the triggers, e.g. duration, icons.
This allows for e.g. showing the information of the second trigger if the
first trigger is not active.

This is the basis of more to come.

Also first evaluate all triggers before applying change, fixing:
Ticket-Nr: 501