### PR TITLE
Make gigantic dynamic groups editable in the options

### DIFF
--- a/Options/AceGUI-Widgets/AceGUIWidget-WeakAurasDisplayButton.lua
+++ b/Options/AceGUI-Widgets/AceGUIWidget-WeakAurasDisplayButton.lua
@@ -224,6 +224,12 @@ local methods = {
         function self.callbacks.OnDeleteAllClick()
             if (WeakAuras.IsImporting()) then return end;
             if(data.controlledChildren) then
+
+                local region = WeakAuras.regions[data.id];
+                if (region.ControlChildren) then
+                  region:Pause();
+                end
+
                 local toDelete = {};
                 for index, id in pairs(data.controlledChildren) do
                     toDelete[index] = WeakAuras.GetData(id);
@@ -335,6 +341,8 @@ local methods = {
         end
 
         function self.callbacks.OnViewClick()
+            WeakAuras.PauseAllDynamicGroups();
+
             if(self.view.func() == 2) then
                 for index, childId in ipairs(data.controlledChildren) do
                     WeakAuras.GetDisplayButton(childId):PriorityHide(2);
@@ -344,6 +352,8 @@ local methods = {
                     WeakAuras.GetDisplayButton(childId):PriorityShow(2);
                 end
             end
+
+            WeakAuras.ResumeAllDynamicGroups();
         end
 
         function self.callbacks.ViewTest()
@@ -613,7 +623,7 @@ local methods = {
         end
         tinsert(namestable, {" ", "|cFF00FFFF"..L["Shift-click to create chat link"]});
         local regionData = WeakAuras.regionOptions[data.regionType or ""]
-        local displayName = regionData and regionData.displayName or regionType or "";
+        local displayName = regionData and regionData.displayName or "";
         self:SetDescription({data.id, displayName}, unpack(namestable));
     end,
     ["ReloadTooltip"] = function(self)if(

--- a/Options/WeakAurasOptions.lua
+++ b/Options/WeakAurasOptions.lua
@@ -1266,9 +1266,14 @@ function WeakAuras.HideOptions()
     tutFrame:Hide();
   end
 
+  WeakAuras.PauseAllDynamicGroups();
+
   for id, data in pairs(WeakAuras.regions) do
     data.region:Collapse();
   end
+
+  WeakAuras.ResumeAllDynamicGroups();
+
   WeakAuras.ReloadAll();
   WeakAuras.Resume();
 end
@@ -8218,6 +8223,8 @@ function WeakAuras.CreateFrame()
   end
 
   frame.ClearPicks = function(self, except)
+    WeakAuras.PauseAllDynamicGroups();
+
     frame.pickedDisplay = nil;
     frame.pickedOption = nil;
     wipe(tempGroup.controlledChildren);
@@ -8232,6 +8239,8 @@ function WeakAuras.CreateFrame()
     unloadedButton:ClearPick();
     container:ReleaseChildren();
     self.moversizer:Hide();
+
+    WeakAuras.ResumeAllDynamicGroups();
   end
 
   frame.PickOption = function(self, option)
@@ -8363,6 +8372,7 @@ tXmdmY4fDE5]];
           displayButtons[childId]:PriorityShow(1);
         end
       end
+      WeakAuras.ResumeAllDynamicGroups();
     end
 
     local list = {};
@@ -8377,8 +8387,10 @@ tXmdmY4fDE5]];
     end
     WeakAuras.EnsureOptions(id);
     if(num > 1) then
+      WeakAuras.PauseAllDynamicGroups();
       WeakAuras.BuildOptions(list, finishPicking);
     else
+      WeakAuras.PauseAllDynamicGroups();
       finishPicking();
     end
   end

--- a/WeakAuras.lua
+++ b/WeakAuras.lua
@@ -739,7 +739,26 @@ function WeakAuras.Toggle()
   end
 end
 
+function WeakAuras.PauseAllDynamicGroups()
+  for id, region in pairs(regions) do
+    if (region.region.ControlChildren) then
+      region.region:Suspend();
+    end
+  end
+end
+
+function WeakAuras.ResumeAllDynamicGroups()
+  for id, region in pairs(regions) do
+    if (region.region.ControlChildren) then
+      region.region:Resume();
+    end
+  end
+end
+
 function WeakAuras.ScanAll()
+
+  WeakAuras.PauseAllDynamicGroups();
+
   for id, region in pairs(regions) do
     region.region:Collapse();
   end
@@ -749,6 +768,8 @@ function WeakAuras.ScanAll()
       clone:Collapse();
     end
   end
+
+  WeakAuras.ResumeAllDynamicGroups();
 
   WeakAuras.ReloadAll();
 
@@ -3018,7 +3039,7 @@ WeakAuras.dynFrame = dynFrame;
 function WeakAuras.ControlChildren(childid)
   local parent = db.displays[childid].parent;
   if (parent and db.displays[parent] and db.displays[parent].regionType == "dynamicgroup") then
-    regions[parent].region.ControlChildren();
+    regions[parent].region:ControlChildren();
   end
 end
 


### PR DESCRIPTION
Add a PauseAllDynamicGroups() and ResumeAllDynamicGroups() which
temporarily delays all ControlChildren calls.

The dynamic groups are paused before mass editing, such as importing,
clicking the view icon, deleting the group. This makes it significantly
faster to edit those auars.

Ticket-Nr: 581