### PR TITLE
Fix setAll for colors

### DIFF
--- a/Options/WeakAurasOptions.lua
+++ b/Options/WeakAurasOptions.lua
@@ -1662,7 +1662,11 @@ local function setAll(data, info, ...)
       end
       for i=#childOptionTable,0,-1 do
         if(childOptionTable[i].set) then
-          childOptionTable[i].set(info, ..., not before);
+          if (childOptionTable[i].type == "multiselect") then
+            childOptionTable[i].set(info, ..., not before);
+          else
+            childOptionTable[i].set(info, ...);
+          end
           break;
         end
       end
@@ -1981,7 +1985,7 @@ local function replaceNameDescFuncs(intable, data)
                       local display = key and selectValues[key] or L["None"];
                       tinsert(values, "|cFFE0E000"..childId..": |r"..display);
                     elseif(intable.type == "multiselect") then
-                      local selectedValues = nil;
+                      local selectedValues = "";
                       for k, v in pairs(combinedKeys) do
                         if (childOptionTable[i].get(info, k)) then
                           if (not selectedValues) then


### PR DESCRIPTION
In a recent commit to correct how groups and multiselection work,
I broke that by calling set(info, ..., not before), set gets passed
only the first value of in ...., but for colors 3 values need to be
passed.

So special case multiselection, and only pass the third value in
for multiselection.

The reason we need to pass in the third value for multiselection,
is that the set functions for multiselections by default only toggle
a value. If different auras in a group had different initial values,
toggling them leads to interesting behaviour.