### PR TITLE
activating aura environment when aura triggers custom logic

### DIFF
--- a/WeakAuras.lua
+++ b/WeakAuras.lua
@@ -3230,15 +3230,18 @@ local function applyToTriggerStateTriggers(stateShown, id, triggernum)
 end
 
 local function evaluateTriggerStateTriggers(id)
+  local result = false;
+  WeakAuras.ActivateAuraEnvironment(id);
   if(triggerState[id].disjunctive == "any" and triggerState[id].triggerCount > 0
       or (triggerState[id].disjunctive == "all" and triggerState[id].triggerCount == triggerState[id].numTriggers)
       or (triggerState[id].disjunctive == "custom"
           and triggerState[id].triggerLogicFunc
           and triggerState[id].triggerLogicFunc(triggerState[id].triggers))
     ) then
-    return true;
+    result = true;
   end
-  return false;
+  WeakAuras.ActivateAuraEnvironment(nil);
+  return result;
 end
 
 local function ApplyStatesToRegions(id, triggernum, states)


### PR DESCRIPTION
Something like this custom trigger currently only works when none of the triggers used are of the 'aura' type:
```
function(values)
    if values[2] and values[3] and values[4] then
        ActionButton_ShowOverlayGlow(WeakAuras.regions[aura_env.id].region)
    else
        ActionButton_HideOverlayGlow(WeakAuras.regions[aura_env.id].region)
    end
    
    return values[1]
end
```

My patch fixes this by activating the environment in evaluateTriggerStateTriggers. I tested it for my broken case and everything seems to be working: https://wago.io/EkwSOOpKW