### PR TITLE
Drag'n'Drop implementation for DisplayButtons

### DIFF
--- a/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasDisplayButton.lua
+++ b/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasDisplayButton.lua
@@ -63,10 +63,10 @@ local methods = {
             elseif(IsShiftKeyDown()) then
                 local editbox = GetCurrentKeyBoardFocus();
                 if(editbox) then
-				    if (not fullName) then
-				      local name, realm = UnitFullName("player")
-					  fullName = name.."-"..realm
-					end
+                    if (not fullName) then
+                      local name, realm = UnitFullName("player")
+                      fullName = name.."-"..realm
+                    end
                     editbox:Insert("[WeakAuras: "..fullName.." - "..data.id.."]");
                 end
             else

--- a/WeakAurasOptions/WeakAurasOptions.lua
+++ b/WeakAurasOptions/WeakAurasOptions.lua
@@ -370,7 +370,7 @@ AceGUI:RegisterLayout("ButtonsScrollLayout", function(content, children)
     local child = children[i]
     local frame = child.frame;
 
-    if not frame.isDragged then
+    if not child.dragging then
       local frameHeight = (frame.height or frame:GetHeight() or 0);
       frame:ClearAllPoints();
       if (-yOffset + frameHeight > scrollTop and -yOffset - frameHeight < scrollBottom) then
@@ -1281,6 +1281,7 @@ end
 function WeakAuras.HideOptions()
   -- dynFrame:SetScript("OnUpdate", nil);
   WeakAuras.UnlockUpdateInfo();
+  WeakAuras.SetDragging()
 
   if(frame) then
     frame:Hide();
@@ -9427,10 +9428,10 @@ function WeakAuras.SetGrouping(data)
   end
 end
 
-function WeakAuras.SetDragging(data)
+function WeakAuras.SetDragging(data, drop)
   WeakAuras_DropDownMenu:Hide()
   for id, button in pairs(displayButtons) do
-    button:SetDragging(data);
+    button:SetDragging(data, drop)
   end
 end
 
@@ -9440,14 +9441,20 @@ function WeakAuras.DropIndicator()
     indicator = CreateFrame("Frame", "WeakAuras_DropIndicator")
     indicator:SetHeight(4)
     indicator:SetFrameStrata("FULLSCREEN")
-    indicator:Hide()
-    frame.dropIndicator = indicator
 
     local texture = indicator:CreateTexture(nil, "FULLSCREEN")
     texture:SetBlendMode("ADD")
     texture:SetAllPoints(indicator)
     texture:SetTexture("Interface\\PaperDollInfoFrame\\UI-Character-Tab-Highlight")
+
+    local icon = indicator:CreateTexture(nil, "OVERLAY")
+    icon:SetSize(16,16)
+    icon:SetPoint("CENTER", indicator)
+
+    indicator.icon = icon
     indicator.texture = texture
+    frame.dropIndicator = indicator
+    indicator:Hide()
   end
   return indicator
 end

--- a/WeakAurasOptions/WeakAurasOptions.lua
+++ b/WeakAurasOptions/WeakAurasOptions.lua
@@ -28,7 +28,7 @@ local WeakAuras = WeakAuras
 local L = WeakAuras.L
 local ADDON_NAME = "WeakAurasOptions";
 
--- GLOBALS: WeakAuras WeakAurasSaved WeakAurasOptionsSaved WeakAuras_DropDownMenu AceGUIWidgetLSMlists
+-- GLOBALS: WeakAuras WeakAurasSaved WeakAurasOptionsSaved WeakAuras_DropDownMenu WeakAuras_DropIndicator AceGUIWidgetLSMlists
 -- GLOBALS: GameTooltip GameTooltip_Hide UIParent FONT_COLOR_CODE_CLOSE RED_FONT_COLOR_CODE
 -- GLOBALS: STATICPOPUP_NUMDIALOGS StaticPopupDialogs StaticPopup_Show GetAddOnEnableState
 
@@ -9425,6 +9425,31 @@ function WeakAuras.SetGrouping(data)
   for id, button in pairs(displayButtons) do
     button:SetGrouping(data);
   end
+end
+
+function WeakAuras.SetDragging(data)
+  WeakAuras_DropDownMenu:Hide()
+  for id, button in pairs(displayButtons) do
+    button:SetDragging(data);
+  end
+end
+
+function WeakAuras.DropIndicator()
+  local indicator = frame.dropIndicator
+  if not indicator then
+    indicator = CreateFrame("Frame", "WeakAuras_DropIndicator")
+    indicator:SetHeight(4)
+    indicator:SetFrameStrata("FULLSCREEN")
+    indicator:Hide()
+    frame.dropIndicator = indicator
+
+    local texture = indicator:CreateTexture(nil, "FULLSCREEN")
+    texture:SetBlendMode("ADD")
+    texture:SetAllPoints(indicator)
+    texture:SetTexture("Interface\\PaperDollInfoFrame\\UI-Character-Tab-Highlight")
+    indicator.texture = texture
+  end
+  return indicator
 end
 
 function WeakAuras.UpdateDisplayButton(data)

--- a/WeakAurasOptions/WeakAurasOptions.lua
+++ b/WeakAurasOptions/WeakAurasOptions.lua
@@ -369,24 +369,26 @@ AceGUI:RegisterLayout("ButtonsScrollLayout", function(content, children)
   for i = 1, #children do
     local child = children[i]
     local frame = child.frame;
-    local frameHeight = (frame.height or frame:GetHeight() or 0);
 
-    frame:ClearAllPoints();
-    if (-yOffset + frameHeight > scrollTop and -yOffset - frameHeight < scrollBottom) then
-        frame:Show();
-        frame:SetPoint("LEFT", content);
-        frame:SetPoint("RIGHT", content);
-        frame:SetPoint("TOP", content, "TOP", 0, yOffset)
-    else
-        frame:Hide();
-        frame.yOffset = yOffset
+    if not frame.isDragged then
+      local frameHeight = (frame.height or frame:GetHeight() or 0);
+      frame:ClearAllPoints();
+      if (-yOffset + frameHeight > scrollTop and -yOffset - frameHeight < scrollBottom) then
+          frame:Show();
+          frame:SetPoint("LEFT", content);
+          frame:SetPoint("RIGHT", content);
+          frame:SetPoint("TOP", content, "TOP", 0, yOffset)
+      else
+          frame:Hide();
+          frame.yOffset = yOffset
+      end
+      yOffset = yOffset - (frameHeight + 2);
     end
 
     if child.DoLayout then
         child:DoLayout()
     end
 
-    yOffset = yOffset - (frameHeight + 2);
   end
   if(content.obj.LayoutFinished) then
     content.obj:LayoutFinished(nil, yOffset * -1);
@@ -9183,6 +9185,11 @@ function WeakAuras.UpdateGroupOrders(data)
       button:SetGroupOrder(index, total);
     end
   end
+end
+
+function WeakAuras.UpdateButtonsScroll()
+  if WeakAuras.IsOptionsProcessingPaused() then return end
+  frame.buttonsScroll:DoLayout()
 end
 
 local previousFilter;


### PR DESCRIPTION
## Overview
This PR implements ~~rudamentary~~ drag'n'drop support to the `DisplayButton`s in the Options.
Feature and Design is descripted in some [sketches](https://drive.google.com/drive/folders/0BzaKJginnJcgM3dHWUdDQlNRZGM?usp=sharing).

The implemented features make several `DisplayButton` controls in their current form obsolete.
Chiefly the side control of grouped  buttons (up, down, ungroup) which also distinguish grouped buttons from ungrouped one. 
(see https://www.wowace.com/projects/weakauras-2/issues/790 )

### Issues
-    ~~If the `DisplayButtonList` is *not* scrolled to the top, the `DisplayButton` is not __*visually*__ dragged, but dropping it still works at the __cursor__ location.~~
-    ~~If the `DisplayButtonList` is being scrolled while dragging, the dragged element is shown in its original poistion.  Dropping it still works at the __cursor__ location.~~
-    ~~`OnDragStop` is not called correctly when entering combat while dragging a `DisplayButton`. This results in a hidden element until reloading.~~
-    Dropping a element below the list of `DisplayButton` into the scroll frame or onto a category rider undos the drag action. This behavior might be unexpexted.