### PR TITLE
fix wrong argument order in GetBigWigsTimer

### DIFF
--- a/WeakAuras/GenericTrigger.lua
+++ b/WeakAuras/GenericTrigger.lua
@@ -2106,10 +2106,10 @@ do
     return bars[id];
   end
 
-  function WeakAuras.GetBigWigsTimer(addon, spellId, text, operator)
+  function WeakAuras.GetBigWigsTimer(addon, spellId, operator, text)
     local bestMatch
     for id, bar in pairs(bars) do
-      if (WeakAuras.BigWigsTimerMatches(id, addon, spellId, text, operator)) then
+      if (WeakAuras.BigWigsTimerMatches(id, addon, spellId, operator, text)) then
         if (bestMatch == nil or bar.expirationTime < bestMatch.expirationTime) then
           bestMatch = bar;
         end


### PR DESCRIPTION
This is a non-breaking change that fixes the argument order in WeakAuras.GetBigWigsTimer.