### PR TITLE
Modernize: Remove old conditions modernize code

### DIFF
--- a/WeakAuras/RegionTypes/DynamicGroup.lua
+++ b/WeakAuras/RegionTypes/DynamicGroup.lua
@@ -134,7 +134,7 @@ local function modify(parent, region, data)
                 region.controlledRegions[regionIndex].data = childData;
                 region.controlledRegions[regionIndex].region = childRegion;
                 region.controlledRegions[regionIndex].key = tostring(region.controlledRegions[regionIndex].region);
-                anyIndexInfo = anyIndexInfo or childRegion.index;
+                anyIndexInfo = anyIndexInfo or childRegion.state and childRegion.state.index;
                 region.controlledRegions[regionIndex].dataIndex = dataIndex;
                 dataIndex = dataIndex + 1;
                 regionIndex = regionIndex + 1;
@@ -148,7 +148,7 @@ local function modify(parent, region, data)
                         region.controlledRegions[regionIndex].cloneId = cloneId;
                         region.controlledRegions[regionIndex].region = cloneRegion;
                         region.controlledRegions[regionIndex].key = tostring(region.controlledRegions[regionIndex].region);
-                        anyIndexInfo = anyIndexInfo or cloneRegion.index;
+                        anyIndexInfo = anyIndexInfo or cloneRegion.state and cloneRegion.state.index;
                         region.controlledRegions[regionIndex].dataIndex = dataIndex;
                         regionIndex = regionIndex + 1;
                     end

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -1563,33 +1563,6 @@ function WeakAuras.Modernize(data)
     end
   end
 
-  -- Delete conditions fields and convert them to additional triggers
-  if(data.conditions) then
-    data.additional_triggers = data.additional_triggers or {};
-    local condition_trigger = {
-      trigger = {
-        type = "status",
-        unevent = "auto",
-        event = "Conditions"
-      },
-      untrigger = {
-      }
-    }
-    local num = 0;
-    for i,v in pairs(data.conditions) do
-      if(i == "combat") then
-        data.load.use_combat = v;
-      else
-        condition_trigger.trigger["use_"..i] = v;
-        num = num + 1;
-      end
-    end
-    if(num > 0) then
-      tinsert(data.additional_triggers, condition_trigger);
-    end
-    data.conditions = nil;
-  end
-
   -- Add dynamic text info to Progress Bars
   -- Also convert custom displayText to new displayText
   if(data.regionType == "aurabar") then


### PR DESCRIPTION
A long time ago, WeakAuras 1 had a conditions field for each
aura. That got replaced by a separate conditions trigger.

In my upcoming conditions feature I want to add a .conditions field
to auras.

Removing this Modernize code let's me switch to master without the
old Modernize code breaking my new conditions