### PR TITLE
Add a sound RegionType

### DIFF
--- a/WeakAuras/RegionTypes/Sound.lua
+++ b/WeakAuras/RegionTypes/Sound.lua
@@ -1,0 +1,101 @@
+local SharedMedia = LibStub("LibSharedMedia-3.0");
+
+local default = {
+  selfPoint = "BOTTOM",
+  anchorPoint = "CENTER",
+  anchorFrameType = "SCREEN",
+  xOffset = 0,
+  yOffset = 0,
+  frameStrata = 1,
+  
+  sound = "",
+  sound_channel = "Master",
+  sound_path = "",
+  sound_kit_id = "",
+  
+  shouldRepeat = false,
+  repeatTime = 1,
+}
+
+local function create(parent)
+  local region = CreateFrame("FRAME", nil, parent);
+  region:SetMovable(true);
+  
+  return region;
+end
+
+local function modify(parent, region, data)
+  data.width = 16;
+  data.height = 16;
+  region:SetWidth(data.width);
+  region:SetHeight(data.height);
+  
+  WeakAuras.AnchorFrame(data, region, parent);
+  
+  local function killTicker()
+    if (region.ticker) then
+      region.ticker:Cancel();
+      region.ticker = nil;
+      region.tickerCallback = nil;
+    end
+  end
+  
+  killTicker();
+  
+  local function playSound()
+    if (not WeakAuras.IsOptionsOpen()) then
+      if(data.sound == " custom") then
+        if(data.sound_path) then
+          local _, soundHandle = PlaySoundFile(data.sound_path, data.sound_channel or "Master");
+          region.soundHandle = soundHandle;
+        end
+      elseif(data.sound == " KitID") then
+        if(data.sound_kit_id) then
+          local _, soundHandle = PlaySoundKitID(data.sound_kit_id, data.sound_channel or "Master");
+          region.soundHandle = soundHandle;
+        end
+      else
+        local _, soundHandle = PlaySoundFile(data.sound, data.sound_channel or "Master");
+        region.soundHandle = soundHandle;
+      end
+    end
+  end
+
+  local function stopSound()
+    if (region.soundHandle) then
+      StopSound(region.soundHandle);
+      region.soundHandle = nil;
+    end
+  end
+  
+  local function OnShow()
+    if (region.toShow) then
+      -- immediately play the sound
+      playSound();
+      
+      -- setup a callback every 'repeatTime' seconds if repeating
+      if (data.shouldRepeat) then
+        region.tickerCallback = function()
+          stopSound();
+          playSound();
+        end
+        
+        region.ticker = C_Timer.NewTicker(data.repeatTime, region.tickerCallback);
+      end
+    end
+  end
+  
+  region:SetScript("OnShow", OnShow);
+  
+  local function OnHide()
+    -- immediately stop playing sound
+    stopSound();
+    
+    -- kill our ticker if it exists
+    killTicker();
+  end
+  
+  region:SetScript("OnHide", OnHide);
+end
+
+WeakAuras.RegisterRegionType("sound", create, modify, default);

--- a/WeakAuras/WeakAuras.toc
+++ b/WeakAuras/WeakAuras.toc
@@ -35,3 +35,4 @@ RegionTypes\Text.lua
 RegionTypes\Group.lua
 RegionTypes\DynamicGroup.lua
 RegionTypes\Model.lua
+RegionTypes\Sound.lua

--- a/WeakAurasOptions/RegionOptions/Sound.lua
+++ b/WeakAurasOptions/RegionOptions/Sound.lua
@@ -37,19 +37,35 @@ local function createOptions(id, data)
         width = "double",
         hidden = function() return data.sound ~= " KitID" end,
       },
-      shouldRepeat = {
+      
+      shouldDelay = {
         type = "toggle",
         order = 3,
-        name = "Repeat",
+        name = "Delay",
+      },
+      delayTime = {
+        type = "range",
+        name = "Delay Time",
+        order = 3.5,
+        min = 0,
+        softMax = 5,
+        step = .05,
+        disabled = function() return not data.shouldDelay end,
+      },
+      
+      shouldRepeat = {
+        type = "toggle",
+        order = 4,
+        name = "Repeat/Loop",
       },
       repeatTime = {
         type = "range",
         name = "Repeat Time",
-        order = 3.5,
+        order = 4.5,
         min = 0.1,
-        softMax = 5,
-        step = .05,
-        hidden = function() return not data.shouldRepeat end,
+        softMax = 20,
+        step = .25,
+        disabled = function() return not data.shouldRepeat end,
       },
   };
   

--- a/WeakAurasOptions/RegionOptions/Sound.lua
+++ b/WeakAurasOptions/RegionOptions/Sound.lua
@@ -1,0 +1,92 @@
+local SharedMedia = LibStub("LibSharedMedia-3.0");
+local L = WeakAuras.L;
+
+local function createOptions(id, data)
+  local options = {
+      sound = {
+        type = "select",
+        name = L["Sound"],
+        order = 1,
+        values = WeakAuras.sound_types,
+        control = "WeakAurasSortedDropdown",
+        set = function(_, val)
+          data.sound = val;
+          if (value ~= "" and val ~= " custom" and val ~= " KitID") then
+            -- play the sound immediately if we've selected one
+            PlaySoundFile(val, data.sound_channel or "Master");
+          end
+        end,
+      },
+      sound_channel = {
+        type = "select",
+        name = L["Sound Channel"],
+        order = 1.5,
+        values = WeakAuras.sound_channel_types,
+      },
+      sound_path = {
+        type = "input",
+        name = L["Sound File Path"],
+        order = 2,
+        width = "double",
+        hidden = function() return data.sound ~= " custom" end,
+      },
+      sound_kit_id = {
+        type = "input",
+        name = L["Sound Kit ID"],
+        order = 2,
+        width = "double",
+        hidden = function() return data.sound ~= " KitID" end,
+      },
+      shouldRepeat = {
+        type = "toggle",
+        order = 3,
+        name = "Repeat",
+      },
+      repeatTime = {
+        type = "range",
+        name = "Repeat Time",
+        order = 3.5,
+        min = 0.1,
+        softMax = 5,
+        step = .05,
+        hidden = function() return not data.shouldRepeat end,
+      },
+  };
+  
+  return options;
+end
+
+local function createThumbnail(parent)
+  local borderframe = CreateFrame("FRAME", nil, parent);
+  borderframe:SetWidth(32);
+  borderframe:SetHeight(32);
+
+  local border = borderframe:CreateTexture(nil, "OVERLAY");
+  border:SetAllPoints(borderframe);
+  border:SetTexture("Interface\\BUTTONS\\UI-Quickslot2.blp");
+  border:SetTexCoord(0.2, 0.8, 0.2, 0.8);
+
+  local speakerTexture = borderframe:CreateTexture();
+  borderframe.speakerTexture = speakerTexture;
+  speakerTexture:SetPoint("CENTER", borderframe, "CENTER");
+  speakerTexture:SetTexture("Interface\\Common\\VoiceChat-Speaker");
+  
+  local soundTexture = borderframe:CreateTexture();
+  borderframe.soundTexture = soundTexture;
+  soundTexture:SetPoint("CENTER", borderframe, "CENTER");
+  soundTexture:SetTexture("Interface\\Common\\VoiceChat-On");
+
+  return borderframe;
+end
+
+local function modifyThumbnail(parent, borderframe, data, fullModify, size)
+end
+
+local function createIcon()
+  local thumbnail = createThumbnail(UIParent);
+  modifyThumbnail(UIParent, thumbnail);
+
+  return thumbnail;
+end
+
+WeakAuras.RegisterRegionOptions("sound", createOptions, createIcon, "Sound", createThumbnail, modifyThumbnail, "Plays sounds with optional repeating");

--- a/WeakAurasOptions/WeakAurasOptions.toc
+++ b/WeakAurasOptions/WeakAurasOptions.toc
@@ -26,6 +26,7 @@ RegionOptions\Group.lua
 RegionOptions\DynamicGroup.lua
 RegionOptions\Model.lua
 RegionOptions\ProgressTexture.lua
+RegionOptions\Sound.lua
 
 Cache.lua
 


### PR DESCRIPTION
Currently, the support of sounds in WeakAuras is fairly barebones; sounds can be played either when an aura is shown or when an aura is hidden, and the sound will always play all the way through, ignoring the current state of the containing aura. For many people, including myself, this means that they have many empty text displays (that is that the display text is a space: ' ') that use the sound actions and that solutions to common desires, like canceling sounds, looping, and countdowns are out-of-reach without custom-code solutions or many, many duplicate auras. I believe that an introduction of a "Sound" display type/`RegionType` can alleviate most of these issues.

In this pull-request, I have implemented a basic "Sound" `RegionType` that allows for sounds to be played and optionally looped while the region is 'active', and interrupted/canceled when the region is 'hidden'. All of the changes are self-contained and were originally implemented as a plugin.

This type of implementation has a drawback, however. As this is effectively a display-less display type, it presents the same issue that empty text displays have, in that the position of the display doesn't matter and inclusion into a `DynamicGroup` doesn't make much sense. While moving using the `MoverSizer` is possible, I've excluded the standard positioning menu because it doesn't affect the display at all. Some modifications could be made to underlying systems to better support this type of 'display'.

EXAMPLE AURAS:
---

Using a custom-code trigger for `IsSpellInRange` along with some extra triggers for ensuring the target is hostile, alive, and attackable. The 'display' is configured to play a sonar ping sound on repeat. In effect, while the player is targeting a valid target and out of range, the sound keeps going off. When I come into range, the sound immediately shuts off.

Using a spell cooldown trigger, a sound can be made to play on repeat while an important rotational button on a medium cooldown is available.

A long sound, such as a song, can be played while a longish buff is active. The song will be shut off as soon as the cooldown is over. Suggestion: Miley Cyrus' The Climb while Surrender to Madness is triggered.


FURTHER IMPROVEMENTS
---

As this is kind of a proof-of-concept, there is sizable room for additional improvements and features. Countdown sounds, such as those in DBM or Bigwigs could be implemented tying into Duration Info. Additional options, such as a ramp up/down repeating time (i.e. the longer it goes off, the faster/slower it goes off). Properties (such as repeat time) could be exposed to the Conditions feature.