### PR TITLE
Model Aura: Work around Blizzard bug with cameras

### DIFF
--- a/WeakAuras/RegionTypes/Model.lua
+++ b/WeakAuras/RegionTypes/Model.lua
@@ -5,7 +5,7 @@ local L = WeakAuras.L;
 local default = {
   model_path = "Creature/Arthaslichking/arthaslichking.m2",
   modelIsUnit = false,
-  api = true, -- false ==> SetPosition + SetFacing; true ==> SetTransform
+  api = false, -- false ==> SetPosition + SetFacing; true ==> SetTransform
   model_x = 0,
   model_y = 0,
   model_z = 0,
@@ -62,6 +62,8 @@ local properties = {
 
 WeakAuras.regionPrototype.AddProperties(properties);
 
+
+
 -- Called when first creating a new region/display
 local function create(parent)
   -- Main region
@@ -78,6 +80,7 @@ local function create(parent)
   local model = CreateFrame("PlayerModel", nil, region);
   model:SetAllPoints(region);
   model:SetCamera(1);
+
   region.model = model;
 
   WeakAuras.regionPrototype.create(region);
@@ -228,8 +231,9 @@ local function modify(parent, region, data)
     return region.rotation;
   end
 
-  -- Ensure using correct model
   function region:PreShow()
+    model:ClearTransform();
+
     if tonumber(data.model_path) then
       model:SetDisplayInfo(tonumber(data.model_path))
     else
@@ -241,6 +245,8 @@ local function modify(parent, region, data)
     end
     model:SetPortraitZoom(data.portraitZoom and 1 or 0);
     if (data.api) then
+      model:ClearTransform();
+      model:SetPosition(0, 0, 0);
       model:SetTransform(data.model_st_tx / 1000, data.model_st_ty / 1000, data.model_st_tz / 1000,
         rad(data.model_st_rx), rad(data.model_st_ry), rad(data.model_st_rz),
         data.model_st_us / 1000);
@@ -256,7 +262,12 @@ WeakAuras.RegisterRegionType("model", create, modify, default, properties);
 
 -- Work around for movies and world map hiding all models
 do
-  local function preShowModels()
+  local function preShowModels(self, event)
+    if (event == "PLAYER_LOGIN") then
+      C_Timer.After(2, preShowModels);
+      return;
+    end
+
     for id, isLoaded in pairs(WeakAuras.loaded) do
       if (isLoaded) then
         local data = WeakAuras.regions[id];
@@ -270,6 +281,7 @@ do
   local movieWatchFrame;
   movieWatchFrame = CreateFrame("frame");
   movieWatchFrame:RegisterEvent("PLAY_MOVIE");
+  movieWatchFrame:RegisterEvent("PLAYER_LOGIN");
 
   movieWatchFrame:SetScript("OnEvent", preShowModels);
   WeakAuras.frames["Movie Watch Frame"] = movieWatchFrame;

--- a/WeakAurasOptions/RegionOptions/Model.lua
+++ b/WeakAurasOptions/RegionOptions/Model.lua
@@ -51,9 +51,9 @@ local function createOptions(id, data)
     },
     api = {
       type = "toggle",
-      name = L["Use SetTransform() API"],
+      name = L["Use SetTransform (will change behaviour in 7.3)"],
       order = 7,
-
+      width = "double"
     },
     -- old settings
     model_z = {


### PR DESCRIPTION
SetTransform is supposed to overwrite the camera that is set on
the model. But instead it apparently uses a random camera.
TheDanW promised a fix in 7.3, which unfortunately will change
the behaviour of models.

Thus, warn against using SetTransform in the option text, and
change the default for models to not use the SetTransform option.

Also reset the model transformation and others 2s after login, as
apparently the camera is different while still loading.

This fixes the aura attached to Ticket 968, and also works with
the aura in ticket 964.

Ticket-Nr: 968