### PR TITLE
Custom Progress options for displays that show progress

### DIFF
--- a/WeakAuras/RegionTypes/AuraBar.lua
+++ b/WeakAuras/RegionTypes/AuraBar.lua
@@ -66,6 +66,8 @@ local default = {
   zoom = 0,
 };
 
+WeakAuras.regionPrototype.AddAdjustedDurationToDefault(default);
+
 local screenWidth, screenHeight = math.ceil(GetScreenWidth() / 20) * 20, math.ceil(GetScreenHeight() / 20) * 20;
 
 local properties = {
@@ -851,6 +853,8 @@ end
 
 -- Modify a given region/display
 local function modify(parent, region, data)
+
+  WeakAuras.regionPrototype.modify(parent, region, data);
   -- Localize
   local bar, border, timer, text, iconFrame, icon, stacks = region.bar, region.border, region.timer, region.text, region.iconFrame, region.icon, region.stacks;
 
@@ -1202,7 +1206,8 @@ local function modify(parent, region, data)
   end
 
   function region:TimerTick()
-    self:SetTime(region.duration, region.expirationTime, region.inverse);
+    local adjustMin = region.adjustedMin or 0;
+    self:SetTime( (region.adjustedMax or region.duration) - adjustMin, region.expirationTime - adjustMin, region.inverse);
   end
 
   function region:SetIconColor(r, g, b, a)

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -3560,67 +3560,6 @@ local function startStopTimers(id, cloneId, triggernum, state)
   end
 end
 
-function WeakAuras.SetProgressValue(region, value, total)
-  region.values.progress = value;
-  region.values.duration = total;
-  region:SetValue(value, total);
-end
-
-function WeakAuras.UpateRegionValues(region)
-  local remaining  = region.expirationTime - GetTime();
-  local duration  = region.duration;
-
-  local remainingStr     = "";
-  if remaining == math.huge then
-    remainingStr     = " ";
-  elseif remaining > 60 then
-    remainingStr     = string.format("%i:", math.floor(remaining / 60));
-    remaining       = remaining % 60;
-    remainingStr     = remainingStr..string.format("%02i", remaining);
-  elseif remaining > 0 then
-    -- remainingStr = remainingStr..string.format("%."..(data.progressPrecision or 1).."f", remaining);
-    if region.progressPrecision == 4 and remaining <= 3 then
-      remainingStr = remainingStr..string.format("%.1f", remaining);
-    elseif region.progressPrecision == 5 and remaining <= 3 then
-      remainingStr = remainingStr..string.format("%.2f", remaining);
-    elseif (region.progressPrecision == 4 or region.progressPrecision == 5) and remaining > 3 then
-      remainingStr = remainingStr..string.format("%d", remaining);
-    else
-      remainingStr = remainingStr..string.format("%."..(region.progressPrecision or 1).."f", remaining);
-    end
-  else
-    remainingStr     = " ";
-  end
-  region.values.progress   = remainingStr;
-
-  -- Format a duration time string
-  local durationStr     = "";
-  if duration > 60 then
-    durationStr     = string.format("%i:", math.floor(duration / 60));
-    duration       = duration % 60;
-    durationStr     = durationStr..string.format("%02i", duration);
-  elseif duration > 0 then
-    -- durationStr = durationStr..string.format("%."..(data.totalPrecision or 1).."f", duration);
-    if region.totalPrecision == 4 and duration <= 3 then
-      durationStr = durationStr..string.format("%.1f", duration);
-    elseif region.totalPrecision == 5 and duration <= 3 then
-      durationStr = durationStr..string.format("%.2f", duration);
-    elseif (region.totalPrecision == 4 or region.totalPrecision == 5) and duration > 3 then
-      durationStr = durationStr..string.format("%d", duration);
-    else
-      durationStr = durationStr..string.format("%."..(region.totalPrecision or 1).."f", duration);
-    end
-  else
-    durationStr     = " ";
-  end
-  region.values.duration   = durationStr;
-end
-
-function WeakAuras.TimerTick(region)
-  WeakAuras.UpateRegionValues(region);
-  region:TimerTick();
-end
-
 local function ApplyStateToRegion(id, region, state)
   region.state = state;
   if(region.SetDurationInfo) then

--- a/WeakAurasOptions/Locales/enUS.lua
+++ b/WeakAurasOptions/Locales/enUS.lua
@@ -398,6 +398,3 @@ L["Z Offset"] = "Z Offset"
 L["Zoom"] = "Zoom"
 L["Zoom In"] = "Zoom In"
 L["Zoom Out"] = "Zoom Out"
-
-
-

--- a/WeakAurasOptions/RegionOptions/AuraBar.lua
+++ b/WeakAurasOptions/RegionOptions/AuraBar.lua
@@ -660,6 +660,8 @@ local function createOptions(id, data)
     },
   };
 
+  options = WeakAuras.regionPrototype.AddAdjustedDurationOptions(options, data, 36.5);
+
   -- Positioning options
   options = WeakAuras.AddPositionOptions(options, id, data);
 

--- a/WeakAurasOptions/RegionOptions/ProgressTexture.lua
+++ b/WeakAurasOptions/RegionOptions/ProgressTexture.lua
@@ -242,6 +242,7 @@ local function createOptions(id, data)
       order = 60
     }
   };
+  options = WeakAuras.regionPrototype.AddAdjustedDurationOptions(options, data, 54);
   options = WeakAuras.AddPositionOptions(options, id, data);
 
   return options;


### PR DESCRIPTION
Add a way to clamp progress for the display. Values below a user
set minimum are displayed as empty progress. Progress above
a maximum are displayed as full progress.

Usefull when several displays have the same size and should move
with the same speed but their triggers have different durations.