### PR TITLE
Editor bracket matching, ctrl+s saving and esc cancelclosing, editor color themes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,5 +16,5 @@ indent_style = space
 indent_size = 4
 
 [.luacheckrc]
-indent_style = tabs
+indent_style = tab
 indent_size = 4

--- a/.editorconfig
+++ b/.editorconfig
@@ -14,3 +14,7 @@ trim_trailing_whitespace = false
 [{babelfish.lua,ForAllIndentsAndPurposes.lua}]
 indent_style = space
 indent_size = 4
+
+[.luacheckrc]
+indent_style = tabs
+indent_size = 4

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -57,6 +57,8 @@ globals = {
 	"STATICPOPUP_NUMDIALOGS",
 	"SlashCmdList",
 	"ChatFrame_AddMessageEventFilter",
+  "UIDropDownMenu_AddButton",
+  "UIDropDownMenu_Initialize",
 
 	-- framexml frames
 	"GameTooltip",

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -44,7 +44,7 @@ globals = {
 	"WeakAuras_DropIndicator",
 	"IndentationLib",
 
-	-- framexml misc
+	-- FrameXML misc
 	"C_Timer",
 	"CooldownFrame_Set",
 	"DEFAULT_CHAT_FRAME",
@@ -57,10 +57,10 @@ globals = {
 	"STATICPOPUP_NUMDIALOGS",
 	"SlashCmdList",
 	"ChatFrame_AddMessageEventFilter",
-    "UIDropDownMenu_AddButton",
-    "UIDropDownMenu_Initialize",
+	"UIDropDownMenu_AddButton",
+	"UIDropDownMenu_Initialize",
 
-	-- framexml frames
+	-- FrameXML frames
 	"GameTooltip",
 	"ItemRefTooltip",
 	"UIErrorsFrame",
@@ -69,7 +69,7 @@ globals = {
 	"WorldFrame",
 	"WorldMapFrame",
 
-	-- framexml globals
+	-- FrameXML globals
 	"MAX_TALENT_TIERS",
 	"NUM_TALENT_COLUMNS",
 	"MAX_PVP_TALENT_TIERS",
@@ -83,7 +83,7 @@ globals = {
 	"LOWER_RIGHT_VERTEX",
 	"LOWER_LEFT_VERTEX",
 
-	-- api functions
+	-- API functions
 	"AbandonQuest",
 	"AbandonSkill",
 	"AcceptAreaSpiritHeal",

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -57,8 +57,8 @@ globals = {
 	"STATICPOPUP_NUMDIALOGS",
 	"SlashCmdList",
 	"ChatFrame_AddMessageEventFilter",
-  "UIDropDownMenu_AddButton",
-  "UIDropDownMenu_Initialize",
+    "UIDropDownMenu_AddButton",
+    "UIDropDownMenu_Initialize",
 
 	-- framexml frames
 	"GameTooltip",

--- a/WeakAurasOptions/OptionsFrames/ImportExport.lua
+++ b/WeakAurasOptions/OptionsFrames/ImportExport.lua
@@ -28,6 +28,7 @@ local function ConstructImportExport(frame)
   local close = CreateFrame("Button", nil, group.frame, "UIPanelButtonTemplate");
   close:SetScript("OnClick", function() group:Close() end);
   close:SetPoint("BOTTOMRIGHT", -27, 13);
+  close:SetFrameLevel(close:GetFrameLevel() + 1)
   close:SetHeight(20);
   close:SetWidth(100);
   close:SetText(L["Done"])

--- a/WeakAurasOptions/OptionsFrames/TextEditor.lua
+++ b/WeakAurasOptions/OptionsFrames/TextEditor.lua
@@ -155,7 +155,7 @@ local function ConstructTextEditor(frame)
   settings_frame:SetHeight(20)
   settings_frame:SetWidth(100)
   settings_frame:SetText("Settings")
-  settings_frame:EnableMouse(true)
+  settings_frame:RegisterForClicks("LeftButtonUp")
 
   local menu_frame = CreateFrame("Frame", "SettingsMenuFrame", settings_frame, "UIDropDownMenuTemplate")
   menu_frame:SetPoint("CENTER", settings_frame, "Center")
@@ -165,20 +165,16 @@ local function ConstructTextEditor(frame)
   ToggleDropDownMenu(1, nil, menu_frame, settings_frame, 0, 0, menu, nil, 0)
 
   settings_frame:SetScript("OnClick", function(self, button, down)
-    if button == "LeftButton" then
-      ToggleDropDownMenu(1, nil, menu_frame, settings_frame, 0, 0, menu, nil, 27)
-    end
+    ToggleDropDownMenu(1, nil, menu_frame, settings_frame, 0, 0, menu, nil, 27)
   end)
 
   -- CTRL + S saves and closes, ESC cancels and closes
   editor.editBox:HookScript("OnKeyDown", function(_, key)
     if IsControlKeyDown() and key == "S" then
-      close:Click("LeftButton", true)
-      close:Click("LeftButton", false)
+      group:Close()
     end
     if key == "ESCAPE" then
-      cancel:Click("LeftButton", true)
-      cancel:Click("LeftButton", false)
+      group:CancelClose()
     end
   end)
 

--- a/WeakAurasOptions/OptionsFrames/TextEditor.lua
+++ b/WeakAurasOptions/OptionsFrames/TextEditor.lua
@@ -83,6 +83,39 @@ local function get_scheme(theme_name)
   return color_scheme
 end
 
+local menu = {}
+-- themes options
+for k, v in pairs(editor_themes) do
+  local item = {
+    text = k,
+    isNotRadio = false,
+    checked = function()
+      if WeakAurasSaved.editor_themes.selected == k then
+        return true
+      end
+    end,
+    func = function()
+      WeakAurasSaved.editor_themes.selected = k
+      IndentationLib.enable(WeakAuras.editor.editBox, get_scheme(k), 4)
+      WeakAuras.editor.editBox:SetText(WeakAuras.editor.editBox:GetText())
+    end
+}
+  table.insert(menu, item)
+end
+-- bracket matching option
+table.insert(menu, {
+  text = "Bracket Matching",
+  isNotRadio = true,
+  checked = function()
+    if WeakAurasSaved.editor_bracket_matching then
+      return true
+    end
+  end,
+  func = function()
+    WeakAurasSaved.editor_bracket_matching = not WeakAurasSaved.editor_bracket_matching
+  end
+})
+
 local function ConstructTextEditor(frame)
   local group = AceGUI:Create("InlineGroup");
   group.frame:SetParent(frame);
@@ -133,40 +166,12 @@ local function ConstructTextEditor(frame)
   menu_frame:SetPoint("CENTER", settings_frame, "Center")
   menu_frame:Hide()
 
-  local function settings_menu()
-    local menu = {}
-    -- themes options
-    for k, v in pairs(editor_themes) do
-      local item = {
-        text = k,
-        isNotRadio = false,
-        checked = WeakAurasSaved.editor_themes.selected == k,
-        func = function()
-          WeakAurasSaved.editor_themes.selected = k
-          IndentationLib.enable(editor.editBox, get_scheme(k), 4)
-          editor.editBox:SetText(editor.editBox:GetText())
-        end
-    }
-    table.insert(menu, item)
-    end
-    -- bracket matching option
-    table.insert(menu, {
-      text = "Bracket Matching",
-      isNotRadio = true,
-      checked = WeakAurasSaved.editor_bracket_matching,
-      func = function()
-        WeakAurasSaved.editor_bracket_matching = not WeakAurasSaved.editor_bracket_matching
-      end
-    })
-    return menu
-  end
-  EasyMenu(settings_menu(), menu_frame, settings_frame, 0, 0, "MENU")
-  ToggleDropDownMenu(1, nil, menu_frame, settings_frame, 0, 0, settings_menu(), nil, 0)
-
+  EasyMenu(menu, menu_frame, settings_frame, 0, 0, "MENU")
+  ToggleDropDownMenu(1, nil, menu_frame, settings_frame, 0, 0, menu, nil, 0)
 
   settings_frame:SetScript("OnClick", function(self, button, down)
     if button == "LeftButton" then
-        ToggleDropDownMenu(1, nil, menu_frame, settings_frame, 0, 0, settings_menu(), nil, 27)
+        ToggleDropDownMenu(1, nil, menu_frame, settings_frame, 0, 0, menu, nil, 27)
     end
   end)
 
@@ -381,6 +386,7 @@ local function ConstructTextEditor(frame)
 
     frame:RefreshPick();
   end
+  WeakAuras.editor = editor
 
   return group
 end

--- a/WeakAurasOptions/OptionsFrames/TextEditor.lua
+++ b/WeakAurasOptions/OptionsFrames/TextEditor.lua
@@ -124,6 +124,29 @@ local function ConstructTextEditor(frame)
     editorLine:SetNumber(line);
   end);
 
+  -- autocomplete for brackets and strings
+  local autocomplete_scripted = false
+  editor.editBox:SetScript("OnChar", function(_, char)
+    if autocomplete_scripted then
+      autocomplete_scripted = false
+      return
+    end
+    if char == "(" then
+      editor.editBox:Insert(")")
+      editor.editBox:SetCursorPosition(editor.editBox:GetCursorPosition()-1)
+    elseif char == "{" then
+      editor.editBox:Insert("}")
+      editor.editBox:SetCursorPosition(editor.editBox:GetCursorPosition()-1)
+    elseif char == "[" then
+      editor.editBox:Insert("]")
+      editor.editBox:SetCursorPosition(editor.editBox:GetCursorPosition()-1)
+    elseif char == "\"" or char == "\'" then
+      autocomplete_scripted = true
+      editor.editBox:Insert(char)
+      editor.editBox:SetCursorPosition(editor.editBox:GetCursorPosition()-1)
+    end
+  end)
+
   editorLine:SetScript("OnEnterPressed", function()
     local newLine = editorLine:GetNumber();
     local newPosition = 0;

--- a/WeakAurasOptions/OptionsFrames/TextEditor.lua
+++ b/WeakAurasOptions/OptionsFrames/TextEditor.lua
@@ -209,33 +209,6 @@ local function ConstructTextEditor(frame)
     end
   end)
 
-  -- bracket mathcing, saving (ctrl + s) and closing (esc)
-  editor.editBox:HookScript("OnKeyDown", function(_, key)
-    if IsControlKeyDown() and key == "S" then
-      close:Click("LeftButton", true)
-      close:Click("LeftButton", false)
-    end
-    if key == "ESCAPE" then
-      cancel:Click("LeftButton", true)
-      cancel:Click("LeftButton", false)
-    end
-  end)
-
-  editor.editBox:HookScript("OnChar", function(_, char)
-    if not IsControlKeyDown() then
-      if char == "(" then
-        editor.editBox:Insert(")")
-        editor.editBox:SetCursorPosition(editor.editBox:GetCursorPosition() - 1)
-      elseif char == "{" then
-        editor.editBox:Insert("}")
-        editor.editBox:SetCursorPosition(editor.editBox:GetCursorPosition() - 1)
-      elseif char == "[" then
-        editor.editBox:Insert("]")
-        editor.editBox:SetCursorPosition(editor.editBox:GetCursorPosition() - 1)
-      end
-    end
-  end)
-
   local editorError = group.frame:CreateFontString(nil, "OVERLAY");
   editorError:SetFont("Fonts\\FRIZQT__.TTF", 10)
   editorError:SetJustifyH("LEFT");

--- a/WeakAurasOptions/OptionsFrames/TextEditor.lua
+++ b/WeakAurasOptions/OptionsFrames/TextEditor.lua
@@ -148,6 +148,33 @@ local function ConstructTextEditor(frame)
     end
   end)
 
+  -- bracket mathcing
+  local ctrl_down = false
+  editor.editBox:HookScript("OnKeyDown", function(_, key)
+    if key == "LCTRL" or key == "RCTRL" then
+      ctrl_down = true
+    end
+  end)
+  editor.editBox:HookScript("OnKeyUp", function(_, key)
+    if key == "LCTRL" or key == "RCTRL" then
+      ctrl_down = false
+    end
+  end)
+  editor.editBox:HookScript("OnChar", function(_, char)
+    if not ctrl_down then
+      if char == "(" then
+        editor.editBox:Insert(")")
+        editor.editBox:SetCursorPosition(editor.editBox:GetCursorPosition() - 1)
+      elseif char == "{" then
+        editor.editBox:Insert("}")
+        editor.editBox:SetCursorPosition(editor.editBox:GetCursorPosition() - 1)
+      elseif char == "[" then
+        editor.editBox:Insert("]")
+        editor.editBox:SetCursorPosition(editor.editBox:GetCursorPosition() - 1)
+      end
+    end
+  end)
+
   local editorError = group.frame:CreateFontString(nil, "OVERLAY");
   editorError:SetFont("Fonts\\FRIZQT__.TTF", 10)
   editorError:SetJustifyH("LEFT");

--- a/WeakAurasOptions/OptionsFrames/TextEditor.lua
+++ b/WeakAurasOptions/OptionsFrames/TextEditor.lua
@@ -175,18 +175,28 @@ local function ConstructTextEditor(frame)
     end
   end)
 
-  -- bracket mathcing
+  -- bracket mathcing, saving (ctrl + s) and closing (esc)
   local ctrl_down = false
   editor.editBox:HookScript("OnKeyDown", function(_, key)
+    if ctrl_down and key == "S" then
+      close:Click("LeftButton", true)
+      close:Click("LeftButton", false)
+    end
+    if key == "ESCAPE" then
+      cancel:Click("LeftButton", true)
+      cancel:Click("LeftButton", false)
+    end
     if key == "LCTRL" or key == "RCTRL" then
       ctrl_down = true
     end
   end)
+
   editor.editBox:HookScript("OnKeyUp", function(_, key)
     if key == "LCTRL" or key == "RCTRL" then
       ctrl_down = false
     end
   end)
+
   editor.editBox:HookScript("OnChar", function(_, char)
     if not ctrl_down then
       if char == "(" then
@@ -201,7 +211,7 @@ local function ConstructTextEditor(frame)
       end
     end
   end)
-
+  
   local editorError = group.frame:CreateFontString(nil, "OVERLAY");
   editorError:SetFont("Fonts\\FRIZQT__.TTF", 10)
   editorError:SetJustifyH("LEFT");

--- a/WeakAurasOptions/OptionsFrames/TextEditor.lua
+++ b/WeakAurasOptions/OptionsFrames/TextEditor.lua
@@ -109,6 +109,7 @@ local function ConstructTextEditor(frame)
   local cancel = CreateFrame("Button", nil, group.frame, "UIPanelButtonTemplate");
   cancel:SetScript("OnClick", function() group:CancelClose() end);
   cancel:SetPoint("BOTTOMRIGHT", -27, 13);
+  cancel:SetFrameLevel(cancel:GetFrameLevel() + 1)
   cancel:SetHeight(20);
   cancel:SetWidth(100);
   cancel:SetText(L["Cancel"]);
@@ -116,6 +117,7 @@ local function ConstructTextEditor(frame)
   local close = CreateFrame("Button", nil, group.frame, "UIPanelButtonTemplate");
   close:SetScript("OnClick", function() group:Close() end);
   close:SetPoint("RIGHT", cancel, "LEFT", -10, 0)
+  close:SetFrameLevel(close:GetFrameLevel() + 1)
   close:SetHeight(20);
   close:SetWidth(100);
   close:SetText(L["Done"]);

--- a/WeakAurasOptions/OptionsFrames/TextEditor.lua
+++ b/WeakAurasOptions/OptionsFrames/TextEditor.lua
@@ -77,43 +77,32 @@ local function set_scheme(theme_name)
   color_scheme["not"] = theme["Logical"]
 end
 
-local menu = {}
--- themes option
-for k, v in pairs(editor_themes) do
-  local item = {
-    text = k,
-    isNotRadio = false,
+local function settings_dropdown_initialize(frame, level, menu)
+  for k, v in pairs(editor_themes) do
+    local item = {
+      text = k,
+      isNotRadio = false,
+      checked = function()
+        return WeakAurasSaved.editor_theme == k
+      end,
+      func = function()
+        WeakAurasSaved.editor_theme = k
+        set_scheme(k)
+        WeakAuras.editor.editBox:SetText(WeakAuras.editor.editBox:GetText())
+      end
+    }
+    UIDropDownMenu_AddButton(item)
+  end
+  UIDropDownMenu_AddButton({
+    text = "Bracket Matching",
+    isNotRadio = true,
     checked = function()
-      return WeakAurasSaved.editor_theme == k
+      return WeakAurasSaved.editor_bracket_matching
     end,
     func = function()
-      WeakAurasSaved.editor_theme = k
-      set_scheme(k)
-      WeakAuras.editor.editBox:SetText(WeakAuras.editor.editBox:GetText())
+      WeakAurasSaved.editor_bracket_matching = not WeakAurasSaved.editor_bracket_matching
     end
-  }
-  table.insert(menu, item)
-end
--- bracket matching option
-table.insert(menu, {
-  text = "Bracket Matching",
-  isNotRadio = true,
-  checked = function()
-    return WeakAurasSaved.editor_bracket_matching
-  end,
-  func = function()
-    WeakAurasSaved.editor_bracket_matching = not WeakAurasSaved.editor_bracket_matching
-  end
-})
-
-local function settings_dropdown_initialize(frame, level, menu)
-  for index = 1, #menu do
-    local value = menu[index]
-    if (value.text) then
-      value.index = index
-      UIDropDownMenu_AddButton(value, level)
-    end
-  end
+  })
 end
 
 local function ConstructTextEditor(frame)

--- a/WeakAurasOptions/OptionsFrames/TextEditor.lua
+++ b/WeakAurasOptions/OptionsFrames/TextEditor.lua
@@ -153,9 +153,9 @@ local function ConstructTextEditor(frame)
     table.insert(menu, {
       text = "Bracket Matching",
       isNotRadio = true,
-      checked = WeakAurasSaved.editor_bracket_mathcing,
+      checked = WeakAurasSaved.editor_bracket_matching,
       func = function()
-        WeakAurasSaved.editor_bracket_mathcing = not WeakAurasSaved.editor_bracket_mathcing
+        WeakAurasSaved.editor_bracket_matching = not WeakAurasSaved.editor_bracket_matching
       end
     })
     return menu
@@ -170,7 +170,7 @@ local function ConstructTextEditor(frame)
     end
   end)
 
-  -- bracket mathcing, saving (ctrl + s) and closing (esc)
+  -- bracket matching, saving (ctrl + s) and closing (esc)
   editor.editBox:HookScript("OnKeyDown", function(_, key)
     if IsControlKeyDown() and key == "S" then
       close:Click("LeftButton", true)
@@ -183,7 +183,7 @@ local function ConstructTextEditor(frame)
   end)
 
   editor.editBox:HookScript("OnChar", function(_, char)
-    if not IsControlKeyDown() and WeakAurasSaved.editor_bracket_mathcing then
+    if not IsControlKeyDown() and WeakAurasSaved.editor_bracket_matching then
       if char == "(" then
         editor.editBox:Insert(")")
         editor.editBox:SetCursorPosition(editor.editBox:GetCursorPosition() - 1)

--- a/WeakAurasOptions/OptionsFrames/TextEditor.lua
+++ b/WeakAurasOptions/OptionsFrames/TextEditor.lua
@@ -17,63 +17,68 @@ local textEditor
 local valueFromPath = WeakAuras.ValueFromPath;
 local valueToPath = WeakAuras.ValueToPath;
 
-local editor_themes = {
-  ["Standard"] = {
-    ["Table"] = "|c00ff3333",
-    ["Arithmetic"] = "|c00ff3333",
-    ["Relational"] = "|c00ff3333",
-    ["Logical"] = "|c004444ff",
-    ["Special"] = "|c00ff3333",
-    ["Keyword"] =  "|c004444ff",
-    ["Comment"] = "|c0000aa00",
-    ["Number"] = "|c00ff9900",
-    ["String"] = "|c00999999"
-  },
-  ["Monokai"] = {
-    ["Table"] = "|c00ffffff",
-    ["Arithmetic"] = "|c00f92672",
-    ["Relational"] = "|c00ff3333",
-    ["Logical"] = "|c00f92672",
-    ["Special"] = "|c0066d9ef",
-    ["Keyword"] =  "|c00f92672",
-    ["Comment"] = "|c0075715e",
-    ["Number"] = "|c00ae81ff",
-    ["String"] = "|c00e6db74"
+if not WeakAurasSaved["editor_themes"] then
+WeakAurasSaved["editor_themes"] = {
+    ["selected"] = "Monokai",
+    ["themes"] = {
+      ["Standard"] = {
+        ["Table"] = "|c00ff3333",
+        ["Arithmetic"] = "|c00ff3333",
+        ["Relational"] = "|c00ff3333",
+        ["Logical"] = "|c004444ff",
+        ["Special"] = "|c00ff3333",
+        ["Keyword"] =  "|c004444ff",
+        ["Comment"] = "|c0000aa00",
+        ["Number"] = "|c00ff9900",
+        ["String"] = "|c00999999"
+      },
+      ["Monokai"] = {
+        ["Table"] = "|c00ffffff",
+        ["Arithmetic"] = "|c00f92672",
+        ["Relational"] = "|c00ff3333",
+        ["Logical"] = "|c00f92672",
+        ["Special"] = "|c0066d9ef",
+        ["Keyword"] =  "|c00f92672",
+        ["Comment"] = "|c0075715e",
+        ["Number"] = "|c00ae81ff",
+        ["String"] = "|c00e6db74"
+      }
+    }
   }
-}
+end
 
 local function get_scheme(theme_name)
   local color_scheme = {
-    [IndentationLib.tokens.TOKEN_SPECIAL] = editor_themes[theme_name]["Special"],
-    [IndentationLib.tokens.TOKEN_KEYWORD] = editor_themes[theme_name]["Keyword"],
-    [IndentationLib.tokens.TOKEN_COMMENT_SHORT] = editor_themes[theme_name]["Comment"],
-    [IndentationLib.tokens.TOKEN_COMMENT_LONG] = editor_themes[theme_name]["Comment"],
-    [IndentationLib.tokens.TOKEN_NUMBER] = editor_themes[theme_name]["Number"],
+    [IndentationLib.tokens.TOKEN_SPECIAL] = WeakAurasSaved["editor_themes"]["themes"][theme_name]["Special"],
+    [IndentationLib.tokens.TOKEN_KEYWORD] = WeakAurasSaved["editor_themes"]["themes"][theme_name]["Keyword"],
+    [IndentationLib.tokens.TOKEN_COMMENT_SHORT] = WeakAurasSaved["editor_themes"]["themes"][theme_name]["Comment"],
+    [IndentationLib.tokens.TOKEN_COMMENT_LONG] = WeakAurasSaved["editor_themes"]["themes"][theme_name]["Comment"],
+    [IndentationLib.tokens.TOKEN_NUMBER] = WeakAurasSaved["editor_themes"]["themes"][theme_name]["Number"],
 
-    [IndentationLib.tokens.TOKEN_STRING] = editor_themes[theme_name]["String"],
-    [".."] = editor_themes[theme_name]["String"],
+    [IndentationLib.tokens.TOKEN_STRING] = WeakAurasSaved["editor_themes"]["themes"][theme_name]["String"],
+    [".."] = WeakAurasSaved["editor_themes"]["themes"][theme_name]["String"],
 
-    ["..."] = editor_themes[theme_name]["Table"],
-    ["{"] = editor_themes[theme_name]["Table"],
-    ["}"] = editor_themes[theme_name]["Table"],
-    ["["] = editor_themes[theme_name]["Table"],
-    ["]"] = editor_themes[theme_name]["Table"],
+    ["..."] = WeakAurasSaved["editor_themes"]["themes"][theme_name]["Table"],
+    ["{"] = WeakAurasSaved["editor_themes"]["themes"][theme_name]["Table"],
+    ["}"] = WeakAurasSaved["editor_themes"]["themes"][theme_name]["Table"],
+    ["["] = WeakAurasSaved["editor_themes"]["themes"][theme_name]["Table"],
+    ["]"] = WeakAurasSaved["editor_themes"]["themes"][theme_name]["Table"],
 
-    ["+"] = editor_themes[theme_name]["Arithmetic"],
-    ["-"] = editor_themes[theme_name]["Arithmetic"],
-    ["/"] = editor_themes[theme_name]["Arithmetic"],
-    ["*"] = editor_themes[theme_name]["Arithmetic"],
+    ["+"] = WeakAurasSaved["editor_themes"]["themes"][theme_name]["Arithmetic"],
+    ["-"] = WeakAurasSaved["editor_themes"]["themes"][theme_name]["Arithmetic"],
+    ["/"] = WeakAurasSaved["editor_themes"]["themes"][theme_name]["Arithmetic"],
+    ["*"] = WeakAurasSaved["editor_themes"]["themes"][theme_name]["Arithmetic"],
 
-    ["=="] = editor_themes[theme_name]["Relational"],
-    ["<"] = editor_themes[theme_name]["Relational"],
-    ["<="] = editor_themes[theme_name]["Relational"],
-    [">"] = editor_themes[theme_name]["Relational"],
-    [">="] = editor_themes[theme_name]["Relational"],
-    ["~="] = editor_themes[theme_name]["Relational"],
+    ["=="] = WeakAurasSaved["editor_themes"]["themes"][theme_name]["Relational"],
+    ["<"] = WeakAurasSaved["editor_themes"]["themes"][theme_name]["Relational"],
+    ["<="] = WeakAurasSaved["editor_themes"]["themes"][theme_name]["Relational"],
+    [">"] = WeakAurasSaved["editor_themes"]["themes"][theme_name]["Relational"],
+    [">="] = WeakAurasSaved["editor_themes"]["themes"][theme_name]["Relational"],
+    ["~="] = WeakAurasSaved["editor_themes"]["themes"][theme_name]["Relational"],
 
-    ["and"] = editor_themes[theme_name]["Logical"],
-    ["or"] = editor_themes[theme_name]["Logical"],
-    ["not"] = editor_themes[theme_name]["Logical"],
+    ["and"] = WeakAurasSaved["editor_themes"]["themes"][theme_name]["Logical"],
+    ["or"] = WeakAurasSaved["editor_themes"]["themes"][theme_name]["Logical"],
+    ["not"] = WeakAurasSaved["editor_themes"]["themes"][theme_name]["Logical"],
     [0] = "|r",
   }
   return color_scheme
@@ -115,10 +120,7 @@ local function ConstructTextEditor(frame)
   close:SetWidth(100);
   close:SetText(L["Done"]);
 
-  if not WeakAurasSaved["editor_theme"] then
-    WeakAurasSaved["editor_theme"] = "Monokai"
-  end
-  IndentationLib.enable(editor.editBox, get_scheme(WeakAurasSaved["editor_theme"]), 4)
+  IndentationLib.enable(editor.editBox, get_scheme(WeakAurasSaved["editor_themes"]["selected"]), 4)
   local theme_frame = CreateFrame("Button", "WAThemeButton", close, "UIPanelButtonTemplate")
   theme_frame:SetPoint("RIGHT", close, "LEFT", -10, 0)
   theme_frame:SetHeight(20)
@@ -129,13 +131,13 @@ local function ConstructTextEditor(frame)
   theme_frame:SetScript("OnClick", function(self, button, down)
     if button == "LeftButton" then
       local menu = {}
-      for k, v in pairs(editor_themes) do
+      for k, v in pairs(WeakAurasSaved["editor_themes"]["themes"]) do
         local item = {
           text = k,
           isNotRadio = false,
-          checked = (WeakAurasSaved["editor_theme"] == k and true) or false,
+          checked = (WeakAurasSaved["editor_themes"]["selected"] == k and true) or false,
           func = function()
-            WeakAurasSaved["editor_theme"] = k
+            WeakAurasSaved["editor_themes"]["selected"] = k
             -- Caused mentioned overflow bug, the codeeditor text now has to be changed for the given theme to appear
             --IndentationLib.disable(editor.editBox)
             IndentationLib.enable(editor.editBox, get_scheme(k), 4)

--- a/WeakAurasOptions/OptionsFrames/TextEditor.lua
+++ b/WeakAurasOptions/OptionsFrames/TextEditor.lua
@@ -115,8 +115,10 @@ local function ConstructTextEditor(frame)
   close:SetWidth(100);
   close:SetText(L["Done"]);
 
-  local selected_theme = "Monokai"
-  IndentationLib.enable(editor.editBox, get_scheme(selected_theme), 4)
+  if not WeakAurasSaved["editor_theme"] then
+    WeakAurasSaved["editor_theme"] = "Monokai"
+  end
+  IndentationLib.enable(editor.editBox, get_scheme(WeakAurasSaved["editor_theme"]), 4)
   local theme_frame = CreateFrame("Button", "WAThemeButton", close, "UIPanelButtonTemplate")
   theme_frame:SetPoint("RIGHT", close, "LEFT", -10, 0)
   theme_frame:SetHeight(20)
@@ -131,13 +133,12 @@ local function ConstructTextEditor(frame)
         local item = {
           text = k,
           isNotRadio = false,
-          checked = k == selected_theme,
+          checked = (WeakAurasSaved["editor_theme"] == k and true) or false,
           func = function()
-            selected_theme = k
+            WeakAurasSaved["editor_theme"] = k
             -- Caused mentioned overflow bug, the codeeditor text now has to be changed for the given theme to appear
             --IndentationLib.disable(editor.editBox)
-            IndentationLib.enable(editor.editBox, get_scheme(selected_theme), 4)
-            -- switches directly to the new color scheme
+            IndentationLib.enable(editor.editBox, get_scheme(k), 4)
             editor.editBox:SetText(editor.editBox:GetText())
           end
         }

--- a/WeakAurasOptions/OptionsFrames/TextEditor.lua
+++ b/WeakAurasOptions/OptionsFrames/TextEditor.lua
@@ -134,7 +134,8 @@ local function ConstructTextEditor(frame)
           checked = k == selected_theme,
           func = function()
             selected_theme = k
-            IndentationLib.disable(editor.editBox)
+            -- Caused mentioned overflow bug, the codeeditor text now has to be changed for the given theme to appear
+            --IndentationLib.disable(editor.editBox)
             IndentationLib.enable(editor.editBox, get_scheme(selected_theme), 4)
           end
         }

--- a/WeakAurasOptions/OptionsFrames/TextEditor.lua
+++ b/WeakAurasOptions/OptionsFrames/TextEditor.lua
@@ -90,9 +90,7 @@ for k, v in pairs(editor_themes) do
     text = k,
     isNotRadio = false,
     checked = function()
-      if WeakAurasSaved.editor_themes.selected == k then
-        return true
-      end
+      return WeakAurasSaved.editor_themes.selected == k
     end,
     func = function()
       WeakAurasSaved.editor_themes.selected = k
@@ -107,9 +105,7 @@ table.insert(menu, {
   text = "Bracket Matching",
   isNotRadio = true,
   checked = function()
-    if WeakAurasSaved.editor_bracket_matching then
-      return true
-    end
+    return WeakAurasSaved.editor_bracket_matching
   end,
   func = function()
     WeakAurasSaved.editor_bracket_matching = not WeakAurasSaved.editor_bracket_matching

--- a/WeakAurasOptions/OptionsFrames/TextEditor.lua
+++ b/WeakAurasOptions/OptionsFrames/TextEditor.lua
@@ -43,8 +43,11 @@ local editor_themes = {
 }
 
 local color_scheme = { [0] = "|r" }
-local function set_scheme(theme_name)
-  local theme = editor_themes[theme_name]
+local function set_scheme()
+  if not WeakAurasSaved.editor_theme then
+    WeakAurasSaved.editor_theme = "Monokai"
+  end
+  local theme = editor_themes[WeakAurasSaved.editor_theme]
   color_scheme[IndentationLib.tokens.TOKEN_SPECIAL] = theme["Special"]
   color_scheme[IndentationLib.tokens.TOKEN_KEYWORD] = theme["Keyword"]
   color_scheme[IndentationLib.tokens.TOKEN_COMMENT_SHORT] = theme["Comment"]
@@ -87,7 +90,7 @@ local function settings_dropdown_initialize(frame, level, menu)
       end,
       func = function()
         WeakAurasSaved.editor_theme = k
-        set_scheme(k)
+        set_scheme()
         WeakAuras.editor.editBox:SetText(WeakAuras.editor.editBox:GetText())
       end
     }
@@ -123,14 +126,10 @@ local function ConstructTextEditor(frame)
   group:AddChild(editor);
   editor.frame:SetClipsChildren(true);
 
-  if not WeakAurasSaved.editor_theme then
-    WeakAurasSaved.editor_theme = "Monokai"
-  end
-  set_scheme(WeakAurasSaved.editor_theme)
-
   -- The indention lib overrides GetText, but for the line number
   -- display we ned the original, so save it here.
   local originalGetText = editor.editBox.GetText;
+  set_scheme()
   IndentationLib.enable(editor.editBox, color_scheme, 4)
 
   local cancel = CreateFrame("Button", nil, group.frame, "UIPanelButtonTemplate");

--- a/WeakAurasOptions/OptionsFrames/TextEditor.lua
+++ b/WeakAurasOptions/OptionsFrames/TextEditor.lua
@@ -139,35 +139,46 @@ local function ConstructTextEditor(frame)
   menu_frame:SetPoint("CENTER", settings_frame, "Center")
   menu_frame:Hide()
 
+  local function settings_menu()
+    local menu = {}
+    -- themes options
+    for k, v in pairs(WeakAurasSaved["editor_themes"]["themes"]) do
+      local item = {
+        text = k,
+        isNotRadio = false,
+        checked = (WeakAurasSaved["editor_themes"]["selected"] == k and true) or false,
+        func = function()
+          WeakAurasSaved["editor_themes"]["selected"] = k
+          -- Caused mentioned overflow bug, the codeeditor text now has to be changed for the given theme to appear
+          --IndentationLib.disable(editor.editBox)
+          IndentationLib.enable(editor.editBox, get_scheme(k), 4)
+          editor.editBox:SetText(editor.editBox:GetText())
+        end
+    }
+    table.insert(menu, item)
+    end
+    -- bracket matching option
+    table.insert(menu, {
+      text = "Bracket Matching",
+      isNotRadio = true,
+      checked = WeakAurasSaved["bracket_matching"],
+      func = function()
+        WeakAurasSaved["bracket_matching"] = not WeakAurasSaved["bracket_matching"]
+      end
+    })
+    return menu
+  end
+
+  local is_settings_open = false
   settings_frame:SetScript("OnClick", function(self, button, down)
     if button == "LeftButton" then
-      local menu = {}
-      -- themes options
-      for k, v in pairs(WeakAurasSaved["editor_themes"]["themes"]) do
-        local item = {
-          text = k,
-          isNotRadio = false,
-          checked = (WeakAurasSaved["editor_themes"]["selected"] == k and true) or false,
-          func = function()
-            WeakAurasSaved["editor_themes"]["selected"] = k
-            -- Caused mentioned overflow bug, the codeeditor text now has to be changed for the given theme to appear
-            --IndentationLib.disable(editor.editBox)
-            IndentationLib.enable(editor.editBox, get_scheme(k), 4)
-            editor.editBox:SetText(editor.editBox:GetText())
-          end
-        }
-        table.insert(menu, item)
+        if is_settings_open then
+          ToggleDropDownMenu(1, nil, menu_frame, settings_frame, 0, 0, settings_menu(), nil, 0)
+          is_settings_open = false
+        else
+          EasyMenu(settings_menu(), menu_frame, settings_frame, 0, 0, "MENU")
+          is_settings_open = true
       end
-      -- bracket matching option
-      table.insert(menu, {
-        text = "Bracket Matching",
-        isNotRadio = true,
-        checked = WeakAurasSaved["bracket_matching"],
-        func = function()
-          WeakAurasSaved["bracket_matching"] = not WeakAurasSaved["bracket_matching"]
-        end
-      })
-      EasyMenu(menu, menu_frame, settings_frame, 0, 0, "MENU")
     end
   end)
 

--- a/WeakAurasOptions/OptionsFrames/TextEditor.lua
+++ b/WeakAurasOptions/OptionsFrames/TextEditor.lua
@@ -126,7 +126,7 @@ local function ConstructTextEditor(frame)
   close:SetText(L["Done"]);
 
   IndentationLib.enable(editor.editBox, get_scheme(WeakAurasSaved["editor_themes"]["selected"]), 4)
-
+  local is_settings_open = false
   local settings_frame = CreateFrame("Button", "WASettingsButton", close, "UIPanelButtonTemplate")
   settings_frame:SetPoint("RIGHT", close, "LEFT", -10, 0)
   settings_frame:SetHeight(20)
@@ -148,6 +148,7 @@ local function ConstructTextEditor(frame)
         isNotRadio = false,
         checked = (WeakAurasSaved["editor_themes"]["selected"] == k and true) or false,
         func = function()
+          is_settings_open = false
           WeakAurasSaved["editor_themes"]["selected"] = k
           -- Caused mentioned overflow bug, the codeeditor text now has to be changed for the given theme to appear
           --IndentationLib.disable(editor.editBox)
@@ -169,7 +170,7 @@ local function ConstructTextEditor(frame)
     return menu
   end
 
-  local is_settings_open = false
+
   settings_frame:SetScript("OnClick", function(self, button, down)
     if button == "LeftButton" then
         if is_settings_open then

--- a/WeakAurasOptions/OptionsFrames/TextEditor.lua
+++ b/WeakAurasOptions/OptionsFrames/TextEditor.lua
@@ -17,44 +17,67 @@ local textEditor
 local valueFromPath = WeakAuras.ValueFromPath;
 local valueToPath = WeakAuras.ValueToPath;
 
-local tableColor = "|c00ff3333"
-local arithmeticColor = "|c00ff3333"
-local relationColor = "|c00ff3333"
-local logicColor = "|c004444ff"
-
-local colorScheme = {
-  [IndentationLib.tokens.TOKEN_SPECIAL] = "|c00ff3333",
-  [IndentationLib.tokens.TOKEN_KEYWORD] = "|c004444ff",
-  [IndentationLib.tokens.TOKEN_COMMENT_SHORT] = "|c0000aa00",
-  [IndentationLib.tokens.TOKEN_COMMENT_LONG] = "|c0000aa00",
-  [IndentationLib.tokens.TOKEN_NUMBER] = "|c00ff9900",
-  [IndentationLib.tokens.TOKEN_STRING] = "|c00999999",
-  -- ellipsis, curly braces, table acces
-  ["..."] = tableColor,
-  ["{"] = tableColor,
-  ["}"] = tableColor,
-  ["["] = tableColor,
-  ["]"] = tableColor,
-  -- arithmetic operators
-  ["+"] = arithmeticColor,
-  ["-"] = arithmeticColor,
-  ["/"] = arithmeticColor,
-  ["*"] = arithmeticColor,
-  [".."] = arithmeticColor,
-  -- relational operators
-  ["=="] = relationColor,
-  ["<"] = relationColor,
-  ["<="] = relationColor,
-  [">"] = relationColor,
-  [">="] = relationColor,
-  ["~="] = relationColor,
-  -- logical operators
-  ["and"] = logicColor,
-  ["or"] = logicColor,
-  ["not"] = logicColor,
-  -- misc
-  [0] = "|r",
+local editor_themes = {
+  ["Standard"] = {
+    ["Table"] = "|c00ff3333",
+    ["Arithmetic"] = "|c00ff3333",
+    ["Relational"] = "|c00ff3333",
+    ["Logical"] = "|c004444ff",
+    ["Special"] = "|c00ff3333",
+    ["Keyword"] =  "|c004444ff",
+    ["Comment"] = "|c0000aa00",
+    ["Number"] = "|c00ff9900",
+    ["String"] = "|c00999999"
+  },
+  ["Monokai"] = {
+    ["Table"] = "|c00ffffff",
+    ["Arithmetic"] = "|c00f92672",
+    ["Relational"] = "|c00ff3333",
+    ["Logical"] = "|c00f92672",
+    ["Special"] = "|c0066d9ef",
+    ["Keyword"] =  "|c00f92672",
+    ["Comment"] = "|c0075715e",
+    ["Number"] = "|c00ae81ff",
+    ["String"] = "|c00e6db74"
+  }
 }
+
+local function get_scheme(theme_name)
+  local color_scheme = {
+    [IndentationLib.tokens.TOKEN_SPECIAL] = editor_themes[theme_name]["Special"],
+    [IndentationLib.tokens.TOKEN_KEYWORD] = editor_themes[theme_name]["Keyword"],
+    [IndentationLib.tokens.TOKEN_COMMENT_SHORT] = editor_themes[theme_name]["Comment"],
+    [IndentationLib.tokens.TOKEN_COMMENT_LONG] = editor_themes[theme_name]["Comment"],
+    [IndentationLib.tokens.TOKEN_NUMBER] = editor_themes[theme_name]["Number"],
+
+    [IndentationLib.tokens.TOKEN_STRING] = editor_themes[theme_name]["String"],
+    [".."] = editor_themes[theme_name]["String"],
+
+    ["..."] = editor_themes[theme_name]["Table"],
+    ["{"] = editor_themes[theme_name]["Table"],
+    ["}"] = editor_themes[theme_name]["Table"],
+    ["["] = editor_themes[theme_name]["Table"],
+    ["]"] = editor_themes[theme_name]["Table"],
+
+    ["+"] = editor_themes[theme_name]["Arithmetic"],
+    ["-"] = editor_themes[theme_name]["Arithmetic"],
+    ["/"] = editor_themes[theme_name]["Arithmetic"],
+    ["*"] = editor_themes[theme_name]["Arithmetic"],
+
+    ["=="] = editor_themes[theme_name]["Relational"],
+    ["<"] = editor_themes[theme_name]["Relational"],
+    ["<="] = editor_themes[theme_name]["Relational"],
+    [">"] = editor_themes[theme_name]["Relational"],
+    [">="] = editor_themes[theme_name]["Relational"],
+    ["~="] = editor_themes[theme_name]["Relational"],
+
+    ["and"] = editor_themes[theme_name]["Logical"],
+    ["or"] = editor_themes[theme_name]["Logical"],
+    ["not"] = editor_themes[theme_name]["Logical"],
+    [0] = "|r",
+  }
+  return color_scheme
+end
 
 local function ConstructTextEditor(frame)
   local group = AceGUI:Create("InlineGroup");
@@ -77,7 +100,6 @@ local function ConstructTextEditor(frame)
   -- The indention lib overrides GetText, but for the line number
   -- display we ned the original, so save it here.
   local originalGetText = editor.editBox.GetText;
-  IndentationLib.enable(editor.editBox, colorScheme, 4);
 
   local cancel = CreateFrame("Button", nil, group.frame, "UIPanelButtonTemplate");
   cancel:SetScript("OnClick", function() group:CancelClose() end);
@@ -92,6 +114,38 @@ local function ConstructTextEditor(frame)
   close:SetHeight(20);
   close:SetWidth(100);
   close:SetText(L["Done"]);
+
+  local selected_theme = "Monokai"
+  IndentationLib.enable(editor.editBox, get_scheme(selected_theme), 4)
+  local theme_frame = CreateFrame("Button", "WAThemeButton", close, "UIPanelButtonTemplate")
+  theme_frame:SetPoint("RIGHT", close, "LEFT", -10, 0)
+  theme_frame:SetHeight(20)
+  theme_frame:SetWidth(100)
+  theme_frame:SetText("Theme")
+  theme_frame:EnableMouse(true)
+  theme_frame:RegisterForClicks("AnyDown")
+  theme_frame:SetScript("OnClick", function(self, button, down)
+    if button == "LeftButton" then
+      local menu = {}
+      for k, v in pairs(editor_themes) do
+        local item = {
+          text = k,
+          isNotRadio = false,
+          checked = k == selected_theme,
+          func = function()
+            selected_theme = k
+            IndentationLib.disable(editor.editBox)
+            IndentationLib.enable(editor.editBox, get_scheme(selected_theme), 4)
+          end
+        }
+        table.insert(menu, item)
+      end
+      local menu_frame = CreateFrame("Frame", "ThemeMenuFrame", theme_frame, "UIDropDownMenuTemplate")
+      menu_frame:SetPoint("CENTER", theme_frame, "Center")
+      menu_frame:Hide()
+      EasyMenu(menu, menu_frame, theme_frame, 0, 0, "MENU")
+    end
+  end)
 
   local editorError = group.frame:CreateFontString(nil, "OVERLAY");
   editorError:SetFont("Fonts\\FRIZQT__.TTF", 10)

--- a/WeakAurasOptions/OptionsFrames/TextEditor.lua
+++ b/WeakAurasOptions/OptionsFrames/TextEditor.lua
@@ -63,7 +63,7 @@ local function set_scheme()
   color_scheme["["] = theme["Table"]
   color_scheme["]"] = theme["Table"]
 
-  color_scheme[""] = theme["Arithmetic"]
+  color_scheme["+"] = theme["Arithmetic"]
   color_scheme["-"] = theme["Arithmetic"]
   color_scheme["/"] = theme["Arithmetic"]
   color_scheme["*"] = theme["Arithmetic"]

--- a/WeakAurasOptions/OptionsFrames/TextEditor.lua
+++ b/WeakAurasOptions/OptionsFrames/TextEditor.lua
@@ -17,10 +17,11 @@ local textEditor
 local valueFromPath = WeakAuras.ValueFromPath;
 local valueToPath = WeakAuras.ValueToPath;
 
-if not WeakAurasSaved["editor_themes"] then
-  WeakAurasSaved["editor_themes"] = {
-    ["selected"] = "Monokai",
-    ["themes"] = {
+if not WeakAurasSaved.editor_themes.selected then
+  WeakAurasSaved.editor_themes.selected = "Monokai"
+end
+
+local editor_themes = {
       ["Standard"] = {
         ["Table"] = "|c00ff3333",
         ["Arithmetic"] = "|c00ff3333",
@@ -43,46 +44,40 @@ if not WeakAurasSaved["editor_themes"] then
         ["Number"] = "|c00ae81ff",
         ["String"] = "|c00e6db74"
       }
-    }
-  }
-end
-
-if not WeakAurasSaved["bracket_matching"] then
-  WeakAurasSaved["bracket_matching"] = true
-end
+}
 
 local function get_scheme(theme_name)
   local color_scheme = {
-    [IndentationLib.tokens.TOKEN_SPECIAL] = WeakAurasSaved["editor_themes"]["themes"][theme_name]["Special"],
-    [IndentationLib.tokens.TOKEN_KEYWORD] = WeakAurasSaved["editor_themes"]["themes"][theme_name]["Keyword"],
-    [IndentationLib.tokens.TOKEN_COMMENT_SHORT] = WeakAurasSaved["editor_themes"]["themes"][theme_name]["Comment"],
-    [IndentationLib.tokens.TOKEN_COMMENT_LONG] = WeakAurasSaved["editor_themes"]["themes"][theme_name]["Comment"],
-    [IndentationLib.tokens.TOKEN_NUMBER] = WeakAurasSaved["editor_themes"]["themes"][theme_name]["Number"],
+    [IndentationLib.tokens.TOKEN_SPECIAL] = editor_themes[theme_name]["Special"],
+    [IndentationLib.tokens.TOKEN_KEYWORD] = editor_themes[theme_name]["Keyword"],
+    [IndentationLib.tokens.TOKEN_COMMENT_SHORT] = editor_themes[theme_name]["Comment"],
+    [IndentationLib.tokens.TOKEN_COMMENT_LONG] = editor_themes[theme_name]["Comment"],
+    [IndentationLib.tokens.TOKEN_NUMBER] = editor_themes[theme_name]["Number"],
 
-    [IndentationLib.tokens.TOKEN_STRING] = WeakAurasSaved["editor_themes"]["themes"][theme_name]["String"],
-    [".."] = WeakAurasSaved["editor_themes"]["themes"][theme_name]["String"],
+    [IndentationLib.tokens.TOKEN_STRING] = editor_themes[theme_name]["String"],
+    [".."] = editor_themes[theme_name]["String"],
 
-    ["..."] = WeakAurasSaved["editor_themes"]["themes"][theme_name]["Table"],
-    ["{"] = WeakAurasSaved["editor_themes"]["themes"][theme_name]["Table"],
-    ["}"] = WeakAurasSaved["editor_themes"]["themes"][theme_name]["Table"],
-    ["["] = WeakAurasSaved["editor_themes"]["themes"][theme_name]["Table"],
-    ["]"] = WeakAurasSaved["editor_themes"]["themes"][theme_name]["Table"],
+    ["..."] = editor_themes[theme_name]["Table"],
+    ["{"] = editor_themes[theme_name]["Table"],
+    ["}"] = editor_themes[theme_name]["Table"],
+    ["["] = editor_themes[theme_name]["Table"],
+    ["]"] = editor_themes[theme_name]["Table"],
 
-    ["+"] = WeakAurasSaved["editor_themes"]["themes"][theme_name]["Arithmetic"],
-    ["-"] = WeakAurasSaved["editor_themes"]["themes"][theme_name]["Arithmetic"],
-    ["/"] = WeakAurasSaved["editor_themes"]["themes"][theme_name]["Arithmetic"],
-    ["*"] = WeakAurasSaved["editor_themes"]["themes"][theme_name]["Arithmetic"],
+    ["+"] = editor_themes[theme_name]["Arithmetic"],
+    ["-"] = editor_themes[theme_name]["Arithmetic"],
+    ["/"] = editor_themes[theme_name]["Arithmetic"],
+    ["*"] = editor_themes[theme_name]["Arithmetic"],
 
-    ["=="] = WeakAurasSaved["editor_themes"]["themes"][theme_name]["Relational"],
-    ["<"] = WeakAurasSaved["editor_themes"]["themes"][theme_name]["Relational"],
-    ["<="] = WeakAurasSaved["editor_themes"]["themes"][theme_name]["Relational"],
-    [">"] = WeakAurasSaved["editor_themes"]["themes"][theme_name]["Relational"],
-    [">="] = WeakAurasSaved["editor_themes"]["themes"][theme_name]["Relational"],
-    ["~="] = WeakAurasSaved["editor_themes"]["themes"][theme_name]["Relational"],
+    ["=="] = editor_themes[theme_name]["Relational"],
+    ["<"] = editor_themes[theme_name]["Relational"],
+    ["<="] = editor_themes[theme_name]["Relational"],
+    [">"] = editor_themes[theme_name]["Relational"],
+    [">="] = editor_themes[theme_name]["Relational"],
+    ["~="] = editor_themes[theme_name]["Relational"],
 
-    ["and"] = WeakAurasSaved["editor_themes"]["themes"][theme_name]["Logical"],
-    ["or"] = WeakAurasSaved["editor_themes"]["themes"][theme_name]["Logical"],
-    ["not"] = WeakAurasSaved["editor_themes"]["themes"][theme_name]["Logical"],
+    ["and"] = editor_themes[theme_name]["Logical"],
+    ["or"] = editor_themes[theme_name]["Logical"],
+    ["not"] = editor_themes[theme_name]["Logical"],
     [0] = "|r",
   }
   return color_scheme
@@ -126,15 +121,13 @@ local function ConstructTextEditor(frame)
   close:SetWidth(100);
   close:SetText(L["Done"]);
 
-  IndentationLib.enable(editor.editBox, get_scheme(WeakAurasSaved["editor_themes"]["selected"]), 4)
-  local is_settings_open = false
+  IndentationLib.enable(editor.editBox, get_scheme(WeakAurasSaved.editor_themes.selected), 4)
   local settings_frame = CreateFrame("Button", "WASettingsButton", close, "UIPanelButtonTemplate")
   settings_frame:SetPoint("RIGHT", close, "LEFT", -10, 0)
   settings_frame:SetHeight(20)
   settings_frame:SetWidth(100)
   settings_frame:SetText("Settings")
   settings_frame:EnableMouse(true)
-  settings_frame:RegisterForClicks("AnyDown")
 
   local menu_frame = CreateFrame("Frame", "SettingsMenuFrame", settings_frame, "UIDropDownMenuTemplate")
   menu_frame:SetPoint("CENTER", settings_frame, "Center")
@@ -143,46 +136,41 @@ local function ConstructTextEditor(frame)
   local function settings_menu()
     local menu = {}
     -- themes options
-    for k, v in pairs(WeakAurasSaved["editor_themes"]["themes"]) do
+    for k, v in pairs(editor_themes) do
       local item = {
         text = k,
         isNotRadio = false,
-        checked = (WeakAurasSaved["editor_themes"]["selected"] == k and true) or false,
+        checked = WeakAurasSaved.editor_themes.selected == k,
         func = function()
-          is_settings_open = false
-          WeakAurasSaved["editor_themes"]["selected"] = k
+          WeakAurasSaved.editor_themes.selected = k
           IndentationLib.enable(editor.editBox, get_scheme(k), 4)
           editor.editBox:SetText(editor.editBox:GetText())
         end
-      }
-      table.insert(menu, item)
+    }
+    table.insert(menu, item)
     end
     -- bracket matching option
     table.insert(menu, {
       text = "Bracket Matching",
       isNotRadio = true,
-      checked = WeakAurasSaved["bracket_matching"],
+      checked = WeakAurasSaved.editor_bracket_mathcing,
       func = function()
-        is_settings_open = false
-        WeakAurasSaved["bracket_matching"] = not WeakAurasSaved["bracket_matching"]
+        WeakAurasSaved.editor_bracket_mathcing = not WeakAurasSaved.editor_bracket_mathcing
       end
     })
     return menu
   end
+  EasyMenu(settings_menu(), menu_frame, settings_frame, 0, 0, "MENU")
+  ToggleDropDownMenu(1, nil, menu_frame, settings_frame, 0, 0, settings_menu(), nil, 0)
+
 
   settings_frame:SetScript("OnClick", function(self, button, down)
     if button == "LeftButton" then
-      if is_settings_open then
-        ToggleDropDownMenu(1, nil, menu_frame, settings_frame, 0, 0, settings_menu(), nil, 0)
-        is_settings_open = false
-      else
-        EasyMenu(settings_menu(), menu_frame, settings_frame, 0, 0, "MENU")
-        is_settings_open = true
-      end
+        ToggleDropDownMenu(1, nil, menu_frame, settings_frame, 0, 0, settings_menu(), nil, 27)
     end
   end)
 
-  -- bracket matching, saving (ctrl + s) and closing (esc)
+  -- bracket mathcing, saving (ctrl + s) and closing (esc)
   editor.editBox:HookScript("OnKeyDown", function(_, key)
     if IsControlKeyDown() and key == "S" then
       close:Click("LeftButton", true)
@@ -195,7 +183,7 @@ local function ConstructTextEditor(frame)
   end)
 
   editor.editBox:HookScript("OnChar", function(_, char)
-    if not IsControlKeyDown() and WeakAurasSaved["bracket_matching"] then
+    if not IsControlKeyDown() and WeakAurasSaved.editor_bracket_mathcing then
       if char == "(" then
         editor.editBox:Insert(")")
         editor.editBox:SetCursorPosition(editor.editBox:GetCursorPosition() - 1)

--- a/WeakAurasOptions/OptionsFrames/TextEditor.lua
+++ b/WeakAurasOptions/OptionsFrames/TextEditor.lua
@@ -17,70 +17,64 @@ local textEditor
 local valueFromPath = WeakAuras.ValueFromPath;
 local valueToPath = WeakAuras.ValueToPath;
 
-if not WeakAurasSaved.editor_themes.selected then
-  WeakAurasSaved.editor_themes.selected = "Monokai"
-end
-
 local editor_themes = {
-      ["Standard"] = {
-        ["Table"] = "|c00ff3333",
-        ["Arithmetic"] = "|c00ff3333",
-        ["Relational"] = "|c00ff3333",
-        ["Logical"] = "|c004444ff",
-        ["Special"] = "|c00ff3333",
-        ["Keyword"] =  "|c004444ff",
-        ["Comment"] = "|c0000aa00",
-        ["Number"] = "|c00ff9900",
-        ["String"] = "|c00999999"
-      },
-      ["Monokai"] = {
-        ["Table"] = "|c00ffffff",
-        ["Arithmetic"] = "|c00f92672",
-        ["Relational"] = "|c00ff3333",
-        ["Logical"] = "|c00f92672",
-        ["Special"] = "|c0066d9ef",
-        ["Keyword"] =  "|c00f92672",
-        ["Comment"] = "|c0075715e",
-        ["Number"] = "|c00ae81ff",
-        ["String"] = "|c00e6db74"
-      }
+  ["Standard"] = {
+    ["Table"] = "|c00ff3333",
+    ["Arithmetic"] = "|c00ff3333",
+    ["Relational"] = "|c00ff3333",
+    ["Logical"] = "|c004444ff",
+    ["Special"] = "|c00ff3333",
+    ["Keyword"] =  "|c004444ff",
+    ["Comment"] = "|c0000aa00",
+    ["Number"] = "|c00ff9900",
+    ["String"] = "|c00999999"
+  },
+  ["Monokai"] = {
+    ["Table"] = "|c00ffffff",
+    ["Arithmetic"] = "|c00f92672",
+    ["Relational"] = "|c00ff3333",
+    ["Logical"] = "|c00f92672",
+    ["Special"] = "|c0066d9ef",
+    ["Keyword"] =  "|c00f92672",
+    ["Comment"] = "|c0075715e",
+    ["Number"] = "|c00ae81ff",
+    ["String"] = "|c00e6db74"
+  }
 }
 
-local function get_scheme(theme_name)
-  local color_scheme = {
-    [IndentationLib.tokens.TOKEN_SPECIAL] = editor_themes[theme_name]["Special"],
-    [IndentationLib.tokens.TOKEN_KEYWORD] = editor_themes[theme_name]["Keyword"],
-    [IndentationLib.tokens.TOKEN_COMMENT_SHORT] = editor_themes[theme_name]["Comment"],
-    [IndentationLib.tokens.TOKEN_COMMENT_LONG] = editor_themes[theme_name]["Comment"],
-    [IndentationLib.tokens.TOKEN_NUMBER] = editor_themes[theme_name]["Number"],
+local color_scheme = { [0] = "|r" }
+local function set_scheme(theme_name)
+  local theme = editor_themes[theme_name]
+  color_scheme[IndentationLib.tokens.TOKEN_SPECIAL] = theme["Special"]
+  color_scheme[IndentationLib.tokens.TOKEN_KEYWORD] = theme["Keyword"]
+  color_scheme[IndentationLib.tokens.TOKEN_COMMENT_SHORT] = theme["Comment"]
+  color_scheme[IndentationLib.tokens.TOKEN_COMMENT_LONG] = theme["Comment"]
+  color_scheme[IndentationLib.tokens.TOKEN_NUMBER] = theme["Number"]
+  color_scheme[IndentationLib.tokens.TOKEN_STRING] = theme["String"]
 
-    [IndentationLib.tokens.TOKEN_STRING] = editor_themes[theme_name]["String"],
-    [".."] = editor_themes[theme_name]["String"],
+  color_scheme[".."] = theme["String"]
 
-    ["..."] = editor_themes[theme_name]["Table"],
-    ["{"] = editor_themes[theme_name]["Table"],
-    ["}"] = editor_themes[theme_name]["Table"],
-    ["["] = editor_themes[theme_name]["Table"],
-    ["]"] = editor_themes[theme_name]["Table"],
+  color_scheme["..."] = theme["Table"]
+  color_scheme["{"] = theme["Table"]
+  color_scheme["}"] = theme["Table"]
+  color_scheme["["] = theme["Table"]
+  color_scheme["]"] = theme["Table"]
 
-    ["+"] = editor_themes[theme_name]["Arithmetic"],
-    ["-"] = editor_themes[theme_name]["Arithmetic"],
-    ["/"] = editor_themes[theme_name]["Arithmetic"],
-    ["*"] = editor_themes[theme_name]["Arithmetic"],
+  color_scheme[""] = theme["Arithmetic"]
+  color_scheme["-"] = theme["Arithmetic"]
+  color_scheme["/"] = theme["Arithmetic"]
+  color_scheme["*"] = theme["Arithmetic"]
 
-    ["=="] = editor_themes[theme_name]["Relational"],
-    ["<"] = editor_themes[theme_name]["Relational"],
-    ["<="] = editor_themes[theme_name]["Relational"],
-    [">"] = editor_themes[theme_name]["Relational"],
-    [">="] = editor_themes[theme_name]["Relational"],
-    ["~="] = editor_themes[theme_name]["Relational"],
+  color_scheme["=="] = theme["Relational"]
+  color_scheme["<"] = theme["Relational"]
+  color_scheme["<="] = theme["Relational"]
+  color_scheme[">"] = theme["Relational"]
+  color_scheme[">="] = theme["Relational"]
+  color_scheme["~="] = theme["Relational"]
 
-    ["and"] = editor_themes[theme_name]["Logical"],
-    ["or"] = editor_themes[theme_name]["Logical"],
-    ["not"] = editor_themes[theme_name]["Logical"],
-    [0] = "|r",
-  }
-  return color_scheme
+  color_scheme["and"] = theme["Logical"]
+  color_scheme["or"] = theme["Logical"]
+  color_scheme["not"] = theme["Logical"]
 end
 
 local menu = {}
@@ -90,14 +84,14 @@ for k, v in pairs(editor_themes) do
     text = k,
     isNotRadio = false,
     checked = function()
-      return WeakAurasSaved.editor_themes.selected == k
+      return WeakAurasSaved.editor_theme == k
     end,
     func = function()
-      WeakAurasSaved.editor_themes.selected = k
-      IndentationLib.enable(WeakAuras.editor.editBox, get_scheme(k), 4)
+      WeakAurasSaved.editor_theme = k
+      set_scheme(k)
       WeakAuras.editor.editBox:SetText(WeakAuras.editor.editBox:GetText())
     end
-}
+  }
   table.insert(menu, item)
 end
 -- bracket matching option
@@ -130,9 +124,15 @@ local function ConstructTextEditor(frame)
   group:AddChild(editor);
   editor.frame:SetClipsChildren(true);
 
+  if not WeakAurasSaved.editor_theme then
+    WeakAurasSaved.editor_theme = "Monokai"
+  end
+  set_scheme(WeakAurasSaved.editor_theme)
+
   -- The indention lib overrides GetText, but for the line number
   -- display we ned the original, so save it here.
   local originalGetText = editor.editBox.GetText;
+  IndentationLib.enable(editor.editBox, color_scheme, 4)
 
   local cancel = CreateFrame("Button", nil, group.frame, "UIPanelButtonTemplate");
   cancel:SetScript("OnClick", function() group:CancelClose() end);
@@ -150,7 +150,6 @@ local function ConstructTextEditor(frame)
   close:SetWidth(100);
   close:SetText(L["Done"]);
 
-  IndentationLib.enable(editor.editBox, get_scheme(WeakAurasSaved.editor_themes.selected), 4)
   local settings_frame = CreateFrame("Button", "WASettingsButton", close, "UIPanelButtonTemplate")
   settings_frame:SetPoint("RIGHT", close, "LEFT", -10, 0)
   settings_frame:SetHeight(20)
@@ -167,11 +166,11 @@ local function ConstructTextEditor(frame)
 
   settings_frame:SetScript("OnClick", function(self, button, down)
     if button == "LeftButton" then
-        ToggleDropDownMenu(1, nil, menu_frame, settings_frame, 0, 0, menu, nil, 27)
+      ToggleDropDownMenu(1, nil, menu_frame, settings_frame, 0, 0, menu, nil, 27)
     end
   end)
 
-  -- bracket matching, saving (ctrl + s) and closing (esc)
+  -- CTRL + S saves and closes, ESC cancels and closes
   editor.editBox:HookScript("OnKeyDown", function(_, key)
     if IsControlKeyDown() and key == "S" then
       close:Click("LeftButton", true)
@@ -183,6 +182,7 @@ local function ConstructTextEditor(frame)
     end
   end)
 
+  -- Bracket matching
   editor.editBox:HookScript("OnChar", function(_, char)
     if not IsControlKeyDown() and WeakAurasSaved.editor_bracket_matching then
       if char == "(" then

--- a/WeakAurasOptions/OptionsFrames/TextEditor.lua
+++ b/WeakAurasOptions/OptionsFrames/TextEditor.lua
@@ -46,6 +46,9 @@ WeakAurasSaved["editor_themes"] = {
     }
   }
 end
+if not WeakAurasSaved["bracket_matching"] then
+  WeakAurasSaved["bracket_matching"] = true
+end
 
 local function get_scheme(theme_name)
   local color_scheme = {
@@ -127,12 +130,13 @@ local function ConstructTextEditor(frame)
   theme_frame:SetPoint("RIGHT", close, "LEFT", -10, 0)
   theme_frame:SetHeight(20)
   theme_frame:SetWidth(100)
-  theme_frame:SetText("Theme")
+  theme_frame:SetText("Settings")
   theme_frame:EnableMouse(true)
   theme_frame:RegisterForClicks("AnyDown")
   theme_frame:SetScript("OnClick", function(self, button, down)
     if button == "LeftButton" then
       local menu = {}
+      -- themes options
       for k, v in pairs(WeakAurasSaved["editor_themes"]["themes"]) do
         local item = {
           text = k,
@@ -148,6 +152,15 @@ local function ConstructTextEditor(frame)
         }
         table.insert(menu, item)
       end
+      -- bracket matching option
+      table.insert(menu, {
+        text = "Bracket Matching",
+        isNotRadio = true,
+        checked = WeakAurasSaved["bracket_matching"],
+        func = function()
+          WeakAurasSaved["bracket_matching"] = not WeakAurasSaved["bracket_matching"]
+        end
+      })
       local menu_frame = CreateFrame("Frame", "ThemeMenuFrame", theme_frame, "UIDropDownMenuTemplate")
       menu_frame:SetPoint("CENTER", theme_frame, "Center")
       menu_frame:Hide()
@@ -168,7 +181,7 @@ local function ConstructTextEditor(frame)
   end)
 
   editor.editBox:HookScript("OnChar", function(_, char)
-    if not IsControlKeyDown() then
+    if not IsControlKeyDown() and WeakAurasSaved["bracket_matching"] then
       if char == "(" then
         editor.editBox:Insert(")")
         editor.editBox:SetCursorPosition(editor.editBox:GetCursorPosition() - 1)

--- a/WeakAurasOptions/OptionsFrames/TextEditor.lua
+++ b/WeakAurasOptions/OptionsFrames/TextEditor.lua
@@ -148,18 +148,28 @@ local function ConstructTextEditor(frame)
     end
   end)
 
-  -- bracket mathcing
+  -- bracket mathcing, saving (ctrl + s) and closing (esc)
   local ctrl_down = false
   editor.editBox:HookScript("OnKeyDown", function(_, key)
+    if ctrl_down and key == "S" then
+      close:Click("LeftButton", true)
+      close:Click("LeftButton", false)
+    end
+    if key == "ESCAPE" then
+      cancel:Click("LeftButton", true)
+      cancel:Click("LeftButton", false)
+    end
     if key == "LCTRL" or key == "RCTRL" then
       ctrl_down = true
     end
   end)
+
   editor.editBox:HookScript("OnKeyUp", function(_, key)
     if key == "LCTRL" or key == "RCTRL" then
       ctrl_down = false
     end
   end)
+
   editor.editBox:HookScript("OnChar", function(_, char)
     if not ctrl_down then
       if char == "(" then
@@ -174,7 +184,7 @@ local function ConstructTextEditor(frame)
       end
     end
   end)
-
+  
   local editorError = group.frame:CreateFontString(nil, "OVERLAY");
   editorError:SetFont("Fonts\\FRIZQT__.TTF", 10)
   editorError:SetJustifyH("LEFT");

--- a/WeakAurasOptions/OptionsFrames/TextEditor.lua
+++ b/WeakAurasOptions/OptionsFrames/TextEditor.lua
@@ -97,7 +97,7 @@ local function settings_dropdown_initialize(frame, level, menu)
     UIDropDownMenu_AddButton(item)
   end
   UIDropDownMenu_AddButton({
-    text = "Bracket Matching",
+    text = L["Bracket Matching"],
     isNotRadio = true,
     checked = function()
       return WeakAurasSaved.editor_bracket_matching
@@ -152,7 +152,7 @@ local function ConstructTextEditor(frame)
   settings_frame:SetPoint("RIGHT", close, "LEFT", -10, 0)
   settings_frame:SetHeight(20)
   settings_frame:SetWidth(100)
-  settings_frame:SetText("Settings")
+  settings_frame:SetText(L["Settings"])
   settings_frame:RegisterForClicks("LeftButtonUp")
 
   local dropdown = CreateFrame("Frame", "SettingsMenuFrame", settings_frame, "UIDropDownMenuTemplate")

--- a/WeakAurasOptions/OptionsFrames/TextEditor.lua
+++ b/WeakAurasOptions/OptionsFrames/TextEditor.lua
@@ -126,14 +126,20 @@ local function ConstructTextEditor(frame)
   close:SetText(L["Done"]);
 
   IndentationLib.enable(editor.editBox, get_scheme(WeakAurasSaved["editor_themes"]["selected"]), 4)
-  local theme_frame = CreateFrame("Button", "WAThemeButton", close, "UIPanelButtonTemplate")
-  theme_frame:SetPoint("RIGHT", close, "LEFT", -10, 0)
-  theme_frame:SetHeight(20)
-  theme_frame:SetWidth(100)
-  theme_frame:SetText("Settings")
-  theme_frame:EnableMouse(true)
-  theme_frame:RegisterForClicks("AnyDown")
-  theme_frame:SetScript("OnClick", function(self, button, down)
+
+  local settings_frame = CreateFrame("Button", "WASettingsButton", close, "UIPanelButtonTemplate")
+  settings_frame:SetPoint("RIGHT", close, "LEFT", -10, 0)
+  settings_frame:SetHeight(20)
+  settings_frame:SetWidth(100)
+  settings_frame:SetText("Settings")
+  settings_frame:EnableMouse(true)
+  settings_frame:RegisterForClicks("AnyDown")
+
+  local menu_frame = CreateFrame("Frame", "SettingsMenuFrame", settings_frame, "UIDropDownMenuTemplate")
+  menu_frame:SetPoint("CENTER", settings_frame, "Center")
+  menu_frame:Hide()
+
+  settings_frame:SetScript("OnClick", function(self, button, down)
     if button == "LeftButton" then
       local menu = {}
       -- themes options
@@ -161,10 +167,7 @@ local function ConstructTextEditor(frame)
           WeakAurasSaved["bracket_matching"] = not WeakAurasSaved["bracket_matching"]
         end
       })
-      local menu_frame = CreateFrame("Frame", "ThemeMenuFrame", theme_frame, "UIDropDownMenuTemplate")
-      menu_frame:SetPoint("CENTER", theme_frame, "Center")
-      menu_frame:Hide()
-      EasyMenu(menu, menu_frame, theme_frame, 0, 0, "MENU")
+      EasyMenu(menu, menu_frame, settings_frame, 0, 0, "MENU")
     end
   end)
 

--- a/WeakAurasOptions/OptionsFrames/TextEditor.lua
+++ b/WeakAurasOptions/OptionsFrames/TextEditor.lua
@@ -78,7 +78,7 @@ local function set_scheme(theme_name)
 end
 
 local menu = {}
--- themes options
+-- themes option
 for k, v in pairs(editor_themes) do
   local item = {
     text = k,
@@ -158,19 +158,17 @@ local function ConstructTextEditor(frame)
   settings_frame:RegisterForClicks("LeftButtonUp")
 
   local menu_frame = CreateFrame("Frame", "SettingsMenuFrame", settings_frame, "UIDropDownMenuTemplate")
-  menu_frame:SetPoint("CENTER", settings_frame, "Center")
-  menu_frame:Hide()
 
-  local function settings_dropdown_inittialize(frame, level, menuList)
-    for index = 1, #menuList do
-      local value = menuList[index]
+  local function settings_dropdown_initialize(frame, level, menu)
+    for index = 1, #menu do
+      local value = menu[index]
       if (value.text) then
         value.index = index
         UIDropDownMenu_AddButton(value, level)
       end
     end
   end
-  UIDropDownMenu_Initialize(menu_frame, settings_dropdown_inittialize, "MENU", nil, menu)
+  UIDropDownMenu_Initialize(menu_frame, settings_dropdown_initialize, "MENU", nil, menu)
 
   settings_frame:SetScript("OnClick", function(self, button, down)
     ToggleDropDownMenu(1, nil, menu_frame, settings_frame, 0, 0, menu, nil, 27)
@@ -186,7 +184,7 @@ local function ConstructTextEditor(frame)
     end
   end)
 
-  -- Bracket matching
+  -- bracket matching
   editor.editBox:HookScript("OnChar", function(_, char)
     if not IsControlKeyDown() and WeakAurasSaved.editor_bracket_matching then
       if char == "(" then

--- a/WeakAurasOptions/OptionsFrames/TextEditor.lua
+++ b/WeakAurasOptions/OptionsFrames/TextEditor.lua
@@ -175,6 +175,33 @@ local function ConstructTextEditor(frame)
     end
   end)
 
+  -- bracket mathcing
+  local ctrl_down = false
+  editor.editBox:HookScript("OnKeyDown", function(_, key)
+    if key == "LCTRL" or key == "RCTRL" then
+      ctrl_down = true
+    end
+  end)
+  editor.editBox:HookScript("OnKeyUp", function(_, key)
+    if key == "LCTRL" or key == "RCTRL" then
+      ctrl_down = false
+    end
+  end)
+  editor.editBox:HookScript("OnChar", function(_, char)
+    if not ctrl_down then
+      if char == "(" then
+        editor.editBox:Insert(")")
+        editor.editBox:SetCursorPosition(editor.editBox:GetCursorPosition() - 1)
+      elseif char == "{" then
+        editor.editBox:Insert("}")
+        editor.editBox:SetCursorPosition(editor.editBox:GetCursorPosition() - 1)
+      elseif char == "[" then
+        editor.editBox:Insert("]")
+        editor.editBox:SetCursorPosition(editor.editBox:GetCursorPosition() - 1)
+      end
+    end
+  end)
+
   local editorError = group.frame:CreateFontString(nil, "OVERLAY");
   editorError:SetFont("Fonts\\FRIZQT__.TTF", 10)
   editorError:SetJustifyH("LEFT");

--- a/WeakAurasOptions/OptionsFrames/TextEditor.lua
+++ b/WeakAurasOptions/OptionsFrames/TextEditor.lua
@@ -176,9 +176,8 @@ local function ConstructTextEditor(frame)
   end)
 
   -- bracket mathcing, saving (ctrl + s) and closing (esc)
-  local ctrl_down = false
   editor.editBox:HookScript("OnKeyDown", function(_, key)
-    if ctrl_down and key == "S" then
+    if IsControlKeyDown() and key == "S" then
       close:Click("LeftButton", true)
       close:Click("LeftButton", false)
     end
@@ -186,19 +185,10 @@ local function ConstructTextEditor(frame)
       cancel:Click("LeftButton", true)
       cancel:Click("LeftButton", false)
     end
-    if key == "LCTRL" or key == "RCTRL" then
-      ctrl_down = true
-    end
-  end)
-
-  editor.editBox:HookScript("OnKeyUp", function(_, key)
-    if key == "LCTRL" or key == "RCTRL" then
-      ctrl_down = false
-    end
   end)
 
   editor.editBox:HookScript("OnChar", function(_, char)
-    if not ctrl_down then
+    if not IsControlKeyDown() then
       if char == "(" then
         editor.editBox:Insert(")")
         editor.editBox:SetCursorPosition(editor.editBox:GetCursorPosition() - 1)
@@ -211,7 +201,7 @@ local function ConstructTextEditor(frame)
       end
     end
   end)
-  
+
   local editorError = group.frame:CreateFontString(nil, "OVERLAY");
   editorError:SetFont("Fonts\\FRIZQT__.TTF", 10)
   editorError:SetJustifyH("LEFT");

--- a/WeakAurasOptions/OptionsFrames/TextEditor.lua
+++ b/WeakAurasOptions/OptionsFrames/TextEditor.lua
@@ -149,9 +149,8 @@ local function ConstructTextEditor(frame)
   end)
 
   -- bracket mathcing, saving (ctrl + s) and closing (esc)
-  local ctrl_down = false
   editor.editBox:HookScript("OnKeyDown", function(_, key)
-    if ctrl_down and key == "S" then
+    if IsControlKeyDown() and key == "S" then
       close:Click("LeftButton", true)
       close:Click("LeftButton", false)
     end
@@ -159,19 +158,10 @@ local function ConstructTextEditor(frame)
       cancel:Click("LeftButton", true)
       cancel:Click("LeftButton", false)
     end
-    if key == "LCTRL" or key == "RCTRL" then
-      ctrl_down = true
-    end
-  end)
-
-  editor.editBox:HookScript("OnKeyUp", function(_, key)
-    if key == "LCTRL" or key == "RCTRL" then
-      ctrl_down = false
-    end
   end)
 
   editor.editBox:HookScript("OnChar", function(_, char)
-    if not ctrl_down then
+    if not IsControlKeyDown() then
       if char == "(" then
         editor.editBox:Insert(")")
         editor.editBox:SetCursorPosition(editor.editBox:GetCursorPosition() - 1)
@@ -184,7 +174,7 @@ local function ConstructTextEditor(frame)
       end
     end
   end)
-  
+
   local editorError = group.frame:CreateFontString(nil, "OVERLAY");
   editorError:SetFont("Fonts\\FRIZQT__.TTF", 10)
   editorError:SetJustifyH("LEFT");

--- a/WeakAurasOptions/OptionsFrames/TextEditor.lua
+++ b/WeakAurasOptions/OptionsFrames/TextEditor.lua
@@ -150,8 +150,6 @@ local function ConstructTextEditor(frame)
         func = function()
           is_settings_open = false
           WeakAurasSaved["editor_themes"]["selected"] = k
-          -- Caused mentioned overflow bug, the codeeditor text now has to be changed for the given theme to appear
-          --IndentationLib.disable(editor.editBox)
           IndentationLib.enable(editor.editBox, get_scheme(k), 4)
           editor.editBox:SetText(editor.editBox:GetText())
         end

--- a/WeakAurasOptions/OptionsFrames/TextEditor.lua
+++ b/WeakAurasOptions/OptionsFrames/TextEditor.lua
@@ -206,29 +206,6 @@ local function ConstructTextEditor(frame)
     editorLine:SetNumber(line);
   end);
 
-  -- autocomplete for brackets and strings
-  local autocomplete_scripted = false
-  editor.editBox:SetScript("OnChar", function(_, char)
-    if autocomplete_scripted then
-      autocomplete_scripted = false
-      return
-    end
-    if char == "(" then
-      editor.editBox:Insert(")")
-      editor.editBox:SetCursorPosition(editor.editBox:GetCursorPosition()-1)
-    elseif char == "{" then
-      editor.editBox:Insert("}")
-      editor.editBox:SetCursorPosition(editor.editBox:GetCursorPosition()-1)
-    elseif char == "[" then
-      editor.editBox:Insert("]")
-      editor.editBox:SetCursorPosition(editor.editBox:GetCursorPosition()-1)
-    elseif char == "\"" or char == "\'" then
-      autocomplete_scripted = true
-      editor.editBox:Insert(char)
-      editor.editBox:SetCursorPosition(editor.editBox:GetCursorPosition()-1)
-    end
-  end)
-
   editorLine:SetScript("OnEnterPressed", function()
     local newLine = editorLine:GetNumber();
     local newPosition = 0;

--- a/WeakAurasOptions/OptionsFrames/TextEditor.lua
+++ b/WeakAurasOptions/OptionsFrames/TextEditor.lua
@@ -164,6 +164,7 @@ local function ConstructTextEditor(frame)
       isNotRadio = true,
       checked = WeakAurasSaved["bracket_matching"],
       func = function()
+        is_settings_open = false
         WeakAurasSaved["bracket_matching"] = not WeakAurasSaved["bracket_matching"]
       end
     })

--- a/WeakAurasOptions/OptionsFrames/TextEditor.lua
+++ b/WeakAurasOptions/OptionsFrames/TextEditor.lua
@@ -18,7 +18,7 @@ local valueFromPath = WeakAuras.ValueFromPath;
 local valueToPath = WeakAuras.ValueToPath;
 
 if not WeakAurasSaved["editor_themes"] then
-WeakAurasSaved["editor_themes"] = {
+  WeakAurasSaved["editor_themes"] = {
     ["selected"] = "Monokai",
     ["themes"] = {
       ["Standard"] = {
@@ -46,6 +46,7 @@ WeakAurasSaved["editor_themes"] = {
     }
   }
 end
+
 if not WeakAurasSaved["bracket_matching"] then
   WeakAurasSaved["bracket_matching"] = true
 end
@@ -153,8 +154,8 @@ local function ConstructTextEditor(frame)
           IndentationLib.enable(editor.editBox, get_scheme(k), 4)
           editor.editBox:SetText(editor.editBox:GetText())
         end
-    }
-    table.insert(menu, item)
+      }
+      table.insert(menu, item)
     end
     -- bracket matching option
     table.insert(menu, {
@@ -169,20 +170,19 @@ local function ConstructTextEditor(frame)
     return menu
   end
 
-
   settings_frame:SetScript("OnClick", function(self, button, down)
     if button == "LeftButton" then
-        if is_settings_open then
-          ToggleDropDownMenu(1, nil, menu_frame, settings_frame, 0, 0, settings_menu(), nil, 0)
-          is_settings_open = false
-        else
-          EasyMenu(settings_menu(), menu_frame, settings_frame, 0, 0, "MENU")
-          is_settings_open = true
+      if is_settings_open then
+        ToggleDropDownMenu(1, nil, menu_frame, settings_frame, 0, 0, settings_menu(), nil, 0)
+        is_settings_open = false
+      else
+        EasyMenu(settings_menu(), menu_frame, settings_frame, 0, 0, "MENU")
+        is_settings_open = true
       end
     end
   end)
 
-  -- bracket mathcing, saving (ctrl + s) and closing (esc)
+  -- bracket matching, saving (ctrl + s) and closing (esc)
   editor.editBox:HookScript("OnKeyDown", function(_, key)
     if IsControlKeyDown() and key == "S" then
       close:Click("LeftButton", true)

--- a/WeakAurasOptions/OptionsFrames/TextEditor.lua
+++ b/WeakAurasOptions/OptionsFrames/TextEditor.lua
@@ -106,6 +106,16 @@ table.insert(menu, {
   end
 })
 
+local function settings_dropdown_initialize(frame, level, menu)
+  for index = 1, #menu do
+    local value = menu[index]
+    if (value.text) then
+      value.index = index
+      UIDropDownMenu_AddButton(value, level)
+    end
+  end
+end
+
 local function ConstructTextEditor(frame)
   local group = AceGUI:Create("InlineGroup");
   group.frame:SetParent(frame);
@@ -157,21 +167,11 @@ local function ConstructTextEditor(frame)
   settings_frame:SetText("Settings")
   settings_frame:RegisterForClicks("LeftButtonUp")
 
-  local menu_frame = CreateFrame("Frame", "SettingsMenuFrame", settings_frame, "UIDropDownMenuTemplate")
-
-  local function settings_dropdown_initialize(frame, level, menu)
-    for index = 1, #menu do
-      local value = menu[index]
-      if (value.text) then
-        value.index = index
-        UIDropDownMenu_AddButton(value, level)
-      end
-    end
-  end
-  UIDropDownMenu_Initialize(menu_frame, settings_dropdown_initialize, "MENU", nil, menu)
+  local dropdown = CreateFrame("Frame", "SettingsMenuFrame", settings_frame, "UIDropDownMenuTemplate")
+  UIDropDownMenu_Initialize(dropdown, settings_dropdown_initialize, "MENU", nil, menu)
 
   settings_frame:SetScript("OnClick", function(self, button, down)
-    ToggleDropDownMenu(1, nil, menu_frame, settings_frame, 0, 0, menu, nil, 27)
+    ToggleDropDownMenu(1, nil, dropdown, settings_frame, 0, 0, menu, nil, 27)
   end)
 
   -- CTRL + S saves and closes, ESC cancels and closes

--- a/WeakAurasOptions/OptionsFrames/TextEditor.lua
+++ b/WeakAurasOptions/OptionsFrames/TextEditor.lua
@@ -161,8 +161,16 @@ local function ConstructTextEditor(frame)
   menu_frame:SetPoint("CENTER", settings_frame, "Center")
   menu_frame:Hide()
 
-  EasyMenu(menu, menu_frame, settings_frame, 0, 0, "MENU")
-  ToggleDropDownMenu(1, nil, menu_frame, settings_frame, 0, 0, menu, nil, 0)
+  local function settings_dropdown_inittialize(frame, level, menuList)
+    for index = 1, #menuList do
+      local value = menuList[index]
+      if (value.text) then
+        value.index = index
+        UIDropDownMenu_AddButton(value, level)
+      end
+    end
+  end
+  UIDropDownMenu_Initialize(menu_frame, settings_dropdown_inittialize, "MENU", nil, menu)
 
   settings_frame:SetScript("OnClick", function(self, button, down)
     ToggleDropDownMenu(1, nil, menu_frame, settings_frame, 0, 0, menu, nil, 27)

--- a/WeakAurasOptions/OptionsFrames/TextEditor.lua
+++ b/WeakAurasOptions/OptionsFrames/TextEditor.lua
@@ -137,6 +137,8 @@ local function ConstructTextEditor(frame)
             -- Caused mentioned overflow bug, the codeeditor text now has to be changed for the given theme to appear
             --IndentationLib.disable(editor.editBox)
             IndentationLib.enable(editor.editBox, get_scheme(selected_theme), 4)
+            -- switches directly to the new color scheme
+            editor.editBox:SetText(editor.editBox:GetText())
           end
         }
         table.insert(menu, item)


### PR DESCRIPTION
I have decided to remove double and triple click word/line selection and do it in a future update

# Current additions
* ctrl + s closing and esc cancelclosing
* automatic bracket mathcing
* editor color themes

![ss](https://i.gyazo.com/d79f2a818855d15e11ff1a0b5746d800.gif)

# issues
* ~~the following bug appears when changing themes, [pastebin link](https://pastebin.com/n09TWUcf)~~
* ~~Some issues with bracket matching when pasting code~~
* ~~editor themes not being saved across sessions~~