### PR TITLE
Consider gemcutting UI as vehicle UI

### DIFF
--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -1290,6 +1290,12 @@ function WeakAuras.ScanForLoads(self, event, arg1)
   local inpetbattle = C_PetBattles.IsInBattle()
   local vehicle = UnitInVehicle('player');
   local vehicleUi = UnitHasVehicleUI('player');
+  -- Consider the gemcutting UI as a vehicle UI as well
+  for i=1,40 do
+    if select(11, UnitBuff("player", i)) == 235786 then
+      vehicleUi = true
+    end
+  end
 
   local _, instanceType, difficultyIndex, _, _, _, _, ZoneMapID = GetInstanceInfo()
   if (inInstance) then
@@ -1445,6 +1451,7 @@ loadFrame:RegisterEvent("UNIT_EXITED_VEHICLE");
 loadFrame:RegisterEvent("SPELLS_CHANGED");
 loadFrame:RegisterEvent("GROUP_JOINED");
 loadFrame:RegisterEvent("GROUP_LEFT");
+loadFrame:RegisterEvent("UNIT_AURA");
 
 function WeakAuras.RegisterLoadEvents()
   loadFrame:SetScript("OnEvent", WeakAuras.ScanForLoads);


### PR DESCRIPTION
Consider the gemcutting professions UI as a vehicle UI as well.
Otherwise user's weakauras might overlay and interfere with the delicate process of gemcutting

[old](https://i.gyazo.com/577d6765e1624d016bfa15415b6c8015.gif)
[new](https://i.gyazo.com/f0464f1a81d162667ee1e177fdda52cd.gif)