### PR TITLE
Consider the gemcutting UI as a vehicle and vehicle UI as well

### DIFF
--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -1288,8 +1288,8 @@ function WeakAuras.ScanForLoads(self, event, arg1)
   local size, difficulty
   local incombat = UnitAffectingCombat("player") -- or UnitAffectingCombat("pet");
   local inpetbattle = C_PetBattles.IsInBattle()
-  local vehicle = UnitInVehicle('player');
-  local vehicleUi = UnitHasVehicleUI('player');
+  local vehicle = UnitInVehicle('player') or UnitBuff("player", GetSpellInfo(235806));
+  local vehicleUi = UnitHasVehicleUI('player') or UnitBuff("player", GetSpellInfo(235806));
 
   local _, instanceType, difficultyIndex, _, _, _, _, ZoneMapID = GetInstanceInfo()
   if (inInstance) then
@@ -1445,6 +1445,7 @@ loadFrame:RegisterEvent("UNIT_EXITED_VEHICLE");
 loadFrame:RegisterEvent("SPELLS_CHANGED");
 loadFrame:RegisterEvent("GROUP_JOINED");
 loadFrame:RegisterEvent("GROUP_LEFT");
+loadFrame:RegisterEvent("UPDATE_OVERRIDE_ACTIONBAR")
 
 function WeakAuras.RegisterLoadEvents()
   loadFrame:SetScript("OnEvent", WeakAuras.ScanForLoads);

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -1288,8 +1288,8 @@ function WeakAuras.ScanForLoads(self, event, arg1)
   local size, difficulty
   local incombat = UnitAffectingCombat("player") -- or UnitAffectingCombat("pet");
   local inpetbattle = C_PetBattles.IsInBattle()
-  local vehicle = UnitInVehicle('player') or UnitBuff("player", GetSpellInfo(235806));
-  local vehicleUi = UnitHasVehicleUI('player') or UnitBuff("player", GetSpellInfo(235806));
+  local vehicle = UnitInVehicle('player') or HasOverrideActionBar();
+  local vehicleUi = UnitHasVehicleUI('player')
 
   local _, instanceType, difficultyIndex, _, _, _, _, ZoneMapID = GetInstanceInfo()
   if (inInstance) then
@@ -1445,7 +1445,7 @@ loadFrame:RegisterEvent("UNIT_EXITED_VEHICLE");
 loadFrame:RegisterEvent("SPELLS_CHANGED");
 loadFrame:RegisterEvent("GROUP_JOINED");
 loadFrame:RegisterEvent("GROUP_LEFT");
-loadFrame:RegisterEvent("ACTIONBAR_SLOT_CHANGED")
+loadFrame:RegisterEvent("UPDATE_OVERRIDE_ACTIONBAR")
 
 function WeakAuras.RegisterLoadEvents()
   loadFrame:SetScript("OnEvent", WeakAuras.ScanForLoads);

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -1288,8 +1288,8 @@ function WeakAuras.ScanForLoads(self, event, arg1)
   local size, difficulty
   local incombat = UnitAffectingCombat("player") -- or UnitAffectingCombat("pet");
   local inpetbattle = C_PetBattles.IsInBattle()
-  local vehicle = UnitInVehicle('player') or HasOverrideActionBar();
-  local vehicleUi = UnitHasVehicleUI('player')
+  local vehicle = UnitInVehicle('player')
+  local vehicleUi = UnitHasVehicleUI('player') or HasOverrideActionBar()
 
   local _, instanceType, difficultyIndex, _, _, _, _, ZoneMapID = GetInstanceInfo()
   if (inInstance) then

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -1445,7 +1445,7 @@ loadFrame:RegisterEvent("UNIT_EXITED_VEHICLE");
 loadFrame:RegisterEvent("SPELLS_CHANGED");
 loadFrame:RegisterEvent("GROUP_JOINED");
 loadFrame:RegisterEvent("GROUP_LEFT");
-loadFrame:RegisterEvent("UPDATE_OVERRIDE_ACTIONBAR")
+loadFrame:RegisterEvent("ACTIONBAR_SLOT_CHANGED")
 
 function WeakAuras.RegisterLoadEvents()
   loadFrame:SetScript("OnEvent", WeakAuras.ScanForLoads);


### PR DESCRIPTION
# About
Gemcutting is a very difficult to master and refined delicate art and weakaura HUDs (which are the best) should not interfere with this delicate and intricate process.

On a more serious note this makes it that WeakAuras considers the shown gemcutting UI as a vehicle and a vehicle UI (the small icon that remains shown is part of me testing some other weakauras and is not part of the overal HUD)
# Settings
![settings](https://i.imgur.com/Acr4p93.png)
# Old Result
![old-result](https://i.imgur.com/jWTEn1F.png)
# New Result
![new-result](https://i.imgur.com/RjKFRdL.png)