### PR TITLE
protect _G lookups

### DIFF
--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -2576,7 +2576,7 @@ function WeakAuras.PerformActions(data, type, region)
         glow_frame = regions[frame_name].region;
       end
     else
-      glow_frame = _G[actions.glow_frame];
+      glow_frame = exec_env[actions.glow_frame];
       original_glow_frame = glow_frame
     end
 
@@ -4350,8 +4350,8 @@ local function GetAnchorFrame(id, anchorFrameType, parent, anchorFrameFrame)
       end
       postponeAnchor(id);
     else
-      if (_G[anchorFrameFrame]) then
-        return _G[anchorFrameFrame];
+      if (exec_env[anchorFrameFrame]) then
+        return exec_env[anchorFrameFrame];
       end
       postponeAnchor(id);
       return  parent;

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -345,6 +345,8 @@ local blockedFunctions = {
   setfenv = true,
   loadstring = true,
   pcall = true,
+  _G = true,
+  getglobal = true,
   -- blocked WoW API
   SendMail = true,
   SetTradeMoney = true,
@@ -2539,6 +2541,10 @@ function WeakAuras.PerformActions(data, type, region)
     return;
   end
 
+  if blockedFunctions[actions.glow_frame] then
+    return forbidden() --returns nil, but warns user about potential abuse
+  end
+
   if(actions.do_message and actions.message_type and actions.message and not squelch_actions) then
     local customFunc = WeakAuras.customActionsFunctions[data.id][type .. "_message"];
     WeakAuras.HandleChatAction(actions.message_type, actions.message, actions.message_dest, actions.message_channel, actions.r, actions.g, actions.b, region, customFunc);
@@ -4315,6 +4321,10 @@ local function postponeAnchor(id)
 end
 
 local function GetAnchorFrame(id, anchorFrameType, parent, anchorFrameFrame)
+  if blockedFunctions[anchorFrameFrame] then
+    return forbidden() --returns nil, but warns user about potential abuse
+  end
+
   if (personalRessourceDisplayFrame) then
     personalRessourceDisplayFrame:anchorFrame(id, anchorFrameType);
   end

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -345,8 +345,6 @@ local blockedFunctions = {
   setfenv = true,
   loadstring = true,
   pcall = true,
-  _G = true,
-  getglobal = true,
   -- blocked WoW API
   SendMail = true,
   SetTradeMoney = true,
@@ -2541,10 +2539,6 @@ function WeakAuras.PerformActions(data, type, region)
     return;
   end
 
-  if blockedFunctions[actions.glow_frame] then
-    return forbidden() --returns nil, but warns user about potential abuse
-  end
-
   if(actions.do_message and actions.message_type and actions.message and not squelch_actions) then
     local customFunc = WeakAuras.customActionsFunctions[data.id][type .. "_message"];
     WeakAuras.HandleChatAction(actions.message_type, actions.message, actions.message_dest, actions.message_channel, actions.r, actions.g, actions.b, region, customFunc);
@@ -4321,10 +4315,6 @@ local function postponeAnchor(id)
 end
 
 local function GetAnchorFrame(id, anchorFrameType, parent, anchorFrameFrame)
-  if blockedFunctions[anchorFrameFrame] then
-    return forbidden() --returns nil, but warns user about potential abuse
-  end
-
   if (personalRessourceDisplayFrame) then
     personalRessourceDisplayFrame:anchorFrame(id, anchorFrameType);
   end


### PR DESCRIPTION
Dunno how else to post this. There are currently two different _G lookups that can be fed arbitrary keys from within custom display code to retrieve globals otherwise blocked through blockedFunctions. I can provide proof of concept code if needed (via Twitter pm @lqnrd), but will obviously not post that here.

Some comments about this pull:

- `_G` and `getglobal` being added to `blockedFunctions` is just a convenient way of having those two included in the check, and will not alter the rest of the code, as these two keys are checked and handled in `exec_env` before `blockedFunctions` is checked.

- The two functions `WeakAuras.PerformActions` and `GetAnchorFrame` will throw errors when called with malicious arguments, but should still function just as before with legitimate input. For now the user is warned about a lookup being blocked just like when calling a blocked function directly. Maybe there is a better way to cleanly exit them, but then again, calling a blocked function directly can also result in errors outside of the control of this addon.