### PR TITLE
Security Fix: Scrub inputs of ScanEvents

### DIFF
--- a/WeakAuras/GenericTrigger.lua
+++ b/WeakAuras/GenericTrigger.lua
@@ -479,11 +479,11 @@ function WeakAuras.ScanEvents(event, arg1, arg2, ...)
           local untriggerCheck = false;
           local allStates = WeakAuras.GetTriggerStateForTrigger(id, triggernum);
           if (data.statesParameter == "full") then
-            if (data.triggerFunc(allStates, event, scrub(argi, arg2, ...))) then
+            if (data.triggerFunc(allStates, event, scrub(arg1, arg2, ...))) then
               updateTriggerState = true;
             end
           elseif (data.statesParameter == "all") then
-            if(data.triggerFunc(allStates, event, scrub(argi, arg2, ...))) then
+            if(data.triggerFunc(allStates, event, scrub(arg1, arg2, ...))) then
               for id, state in pairs(allStates) do
                 if (state.changed) then
                   if (WeakAuras.ActivateEvent(id, triggernum, data, state)) then
@@ -497,7 +497,7 @@ function WeakAuras.ScanEvents(event, arg1, arg2, ...)
           elseif (data.statesParameter == "one") then
             allStates[""] = allStates[""] or {};
             local state = allStates[""];
-            if(data.triggerFunc(state, event, scrub(argi, arg2, ...))) then
+            if(data.triggerFunc(state, event, scrub(arg1, arg2, ...))) then
               if(WeakAuras.ActivateEvent(id, triggernum, data, state)) then
                 updateTriggerState = true;
               end
@@ -505,7 +505,7 @@ function WeakAuras.ScanEvents(event, arg1, arg2, ...)
               untriggerCheck = true;
             end
           else
-            if(data.triggerFunc(event, scrub(argi, arg2, ...))) then
+            if(data.triggerFunc(event, scrub(arg1, arg2, ...))) then
               allStates[""] = allStates[""] or {};
               local state = allStates[""];
               if(WeakAuras.ActivateEvent(id, triggernum, data, state)) then
@@ -517,7 +517,7 @@ function WeakAuras.ScanEvents(event, arg1, arg2, ...)
           end
           if (untriggerCheck) then
             if (data.statesParameter == "all") then
-              if(data.untriggerFunc and data.untriggerFunc(allStates, event, scrub(argi, arg2, ...))) then
+              if(data.untriggerFunc and data.untriggerFunc(allStates, event, scrub(arg1, arg2, ...))) then
                 for id, state in pairs(allStates) do
                   if (state.changed) then
                     if (WeakAuras.EndEvent(id, triggernum, nil, state)) then
@@ -529,13 +529,13 @@ function WeakAuras.ScanEvents(event, arg1, arg2, ...)
             elseif (data.statesParameter == "one") then
               allStates[""] = allStates[""] or {};
               local state = allStates[""];
-              if(data.untriggerFunc and data.untriggerFunc(state, event, scrub(argi, arg2, ...))) then
+              if(data.untriggerFunc and data.untriggerFunc(state, event, scrub(arg1, arg2, ...))) then
                 if (WeakAuras.EndEvent(id, triggernum, nil, state)) then
                   updateTriggerState = true;
                 end
               end
             else
-              if(data.untriggerFunc and data.untriggerFunc(event, scrub(argi, arg2, ...))) then
+              if(data.untriggerFunc and data.untriggerFunc(event, scrub(arg1, arg2, ...))) then
                 allStates[""] = allStates[""] or {};
                 local state = allStates[""];
                 if(WeakAuras.EndEvent(id, triggernum, nil, state)) then

--- a/WeakAuras/GenericTrigger.lua
+++ b/WeakAuras/GenericTrigger.lua
@@ -479,11 +479,11 @@ function WeakAuras.ScanEvents(event, arg1, arg2, ...)
           local untriggerCheck = false;
           local allStates = WeakAuras.GetTriggerStateForTrigger(id, triggernum);
           if (data.statesParameter == "full") then
-            if (data.triggerFunc(allStates, event, arg1, arg2, scrub(...))) then
+            if (data.triggerFunc(allStates, event, scrub(argi, arg2, ...))) then
               updateTriggerState = true;
             end
           elseif (data.statesParameter == "all") then
-            if(data.triggerFunc(allStates, event, arg1, arg2, scrub(...))) then
+            if(data.triggerFunc(allStates, event, scrub(argi, arg2, ...))) then
               for id, state in pairs(allStates) do
                 if (state.changed) then
                   if (WeakAuras.ActivateEvent(id, triggernum, data, state)) then
@@ -497,7 +497,7 @@ function WeakAuras.ScanEvents(event, arg1, arg2, ...)
           elseif (data.statesParameter == "one") then
             allStates[""] = allStates[""] or {};
             local state = allStates[""];
-            if(data.triggerFunc(state, event, arg1, arg2, scrub(...))) then
+            if(data.triggerFunc(state, event, scrub(argi, arg2, ...))) then
               if(WeakAuras.ActivateEvent(id, triggernum, data, state)) then
                 updateTriggerState = true;
               end
@@ -505,7 +505,7 @@ function WeakAuras.ScanEvents(event, arg1, arg2, ...)
               untriggerCheck = true;
             end
           else
-            if(data.triggerFunc(event, arg1, arg2, scrub(...))) then
+            if(data.triggerFunc(event, scrub(argi, arg2, ...))) then
               allStates[""] = allStates[""] or {};
               local state = allStates[""];
               if(WeakAuras.ActivateEvent(id, triggernum, data, state)) then
@@ -517,7 +517,7 @@ function WeakAuras.ScanEvents(event, arg1, arg2, ...)
           end
           if (untriggerCheck) then
             if (data.statesParameter == "all") then
-              if(data.untriggerFunc and data.untriggerFunc(allStates, event, arg1, arg2, scrub(...))) then
+              if(data.untriggerFunc and data.untriggerFunc(allStates, event, scrub(argi, arg2, ...))) then
                 for id, state in pairs(allStates) do
                   if (state.changed) then
                     if (WeakAuras.EndEvent(id, triggernum, nil, state)) then
@@ -529,13 +529,13 @@ function WeakAuras.ScanEvents(event, arg1, arg2, ...)
             elseif (data.statesParameter == "one") then
               allStates[""] = allStates[""] or {};
               local state = allStates[""];
-              if(data.untriggerFunc and data.untriggerFunc(state, event, arg1, arg2, scrub(...))) then
+              if(data.untriggerFunc and data.untriggerFunc(state, event, scrub(argi, arg2, ...))) then
                 if (WeakAuras.EndEvent(id, triggernum, nil, state)) then
                   updateTriggerState = true;
                 end
               end
             else
-              if(data.untriggerFunc and data.untriggerFunc(event, arg1, arg2, scrub(...))) then
+              if(data.untriggerFunc and data.untriggerFunc(event, scrub(argi, arg2, ...))) then
                 allStates[""] = allStates[""] or {};
                 local state = allStates[""];
                 if(WeakAuras.EndEvent(id, triggernum, nil, state)) then

--- a/WeakAuras/GenericTrigger.lua
+++ b/WeakAuras/GenericTrigger.lua
@@ -479,11 +479,11 @@ function WeakAuras.ScanEvents(event, arg1, arg2, ...)
           local untriggerCheck = false;
           local allStates = WeakAuras.GetTriggerStateForTrigger(id, triggernum);
           if (data.statesParameter == "full") then
-            if (data.triggerFunc(allStates, event, arg1, arg2, ...)) then
+            if (data.triggerFunc(allStates, event, arg1, arg2, scrub(...))) then
               updateTriggerState = true;
             end
           elseif (data.statesParameter == "all") then
-            if(data.triggerFunc(allStates, event, arg1, arg2, ...)) then
+            if(data.triggerFunc(allStates, event, arg1, arg2, scrub(...))) then
               for id, state in pairs(allStates) do
                 if (state.changed) then
                   if (WeakAuras.ActivateEvent(id, triggernum, data, state)) then
@@ -497,7 +497,7 @@ function WeakAuras.ScanEvents(event, arg1, arg2, ...)
           elseif (data.statesParameter == "one") then
             allStates[""] = allStates[""] or {};
             local state = allStates[""];
-            if(data.triggerFunc(state, event, arg1, arg2, ...)) then
+            if(data.triggerFunc(state, event, arg1, arg2, scrub(...))) then
               if(WeakAuras.ActivateEvent(id, triggernum, data, state)) then
                 updateTriggerState = true;
               end
@@ -505,7 +505,7 @@ function WeakAuras.ScanEvents(event, arg1, arg2, ...)
               untriggerCheck = true;
             end
           else
-            if(data.triggerFunc(event, arg1, arg2, ...)) then
+            if(data.triggerFunc(event, arg1, arg2, scrub(...))) then
               allStates[""] = allStates[""] or {};
               local state = allStates[""];
               if(WeakAuras.ActivateEvent(id, triggernum, data, state)) then
@@ -517,7 +517,7 @@ function WeakAuras.ScanEvents(event, arg1, arg2, ...)
           end
           if (untriggerCheck) then
             if (data.statesParameter == "all") then
-              if(data.untriggerFunc and data.untriggerFunc(allStates, event, arg1, arg2, ...)) then
+              if(data.untriggerFunc and data.untriggerFunc(allStates, event, arg1, arg2, scrub(...))) then
                 for id, state in pairs(allStates) do
                   if (state.changed) then
                     if (WeakAuras.EndEvent(id, triggernum, nil, state)) then
@@ -529,13 +529,13 @@ function WeakAuras.ScanEvents(event, arg1, arg2, ...)
             elseif (data.statesParameter == "one") then
               allStates[""] = allStates[""] or {};
               local state = allStates[""];
-              if(data.untriggerFunc and data.untriggerFunc(state, event, arg1, arg2, ...)) then
+              if(data.untriggerFunc and data.untriggerFunc(state, event, arg1, arg2, scrub(...))) then
                 if (WeakAuras.EndEvent(id, triggernum, nil, state)) then
                   updateTriggerState = true;
                 end
               end
             else
-              if(data.untriggerFunc and data.untriggerFunc(event, arg1, arg2, ...)) then
+              if(data.untriggerFunc and data.untriggerFunc(event, arg1, arg2, scrub(...))) then
                 allStates[""] = allStates[""] or {};
                 local state = allStates[""];
                 if(WeakAuras.EndEvent(id, triggernum, nil, state)) then


### PR DESCRIPTION
WeakAuras.ScanEvents can be manipulated to send any value, including `_G` into the sandbox. To prevent this, we can [scrub](http://wowprogramming.com/docs/api/scrub) the inputs to ensure that the only things passed in are innocuous.

This is a breaking change for any custom aura that relies on ScanEvents to pass complicated information between it and other auras.

Note: I discovered and reported this issue (via discord) on August 4; I simply couldn't think of a good fix until today.