### PR TITLE
Revert "Work around Editboxes buggyness with 7.3"

### DIFF
--- a/WeakAurasOptions/OptionsFrames/ImportExport.lua
+++ b/WeakAurasOptions/OptionsFrames/ImportExport.lua
@@ -23,8 +23,6 @@ local function ConstructImportExport(frame)
   input:SetWidth(400);
   input.button:Hide();
   input.frame:SetClipsChildren(true);
-  -- WORKAROUND around WoW 7.3 misplacing the cursor
-  input.editBox:SetIgnoreParentScale(true);
   group:AddChild(input);
 
   local close = CreateFrame("Button", nil, group.frame, "UIPanelButtonTemplate");

--- a/WeakAurasOptions/OptionsFrames/TextEditor.lua
+++ b/WeakAurasOptions/OptionsFrames/TextEditor.lua
@@ -131,11 +131,8 @@ local function ConstructTextEditor(frame)
   editor.button:Hide();
   local fontPath = SharedMedia:Fetch("font", "Fira Mono Medium");
   if(fontPath) then
-    -- Manually scale our font size
-    editor.editBox:SetFont(fontPath, 12 * editor.editBox:GetEffectiveScale());
+    editor.editBox:SetFont(fontPath, 12);
   end
-  -- WORKAROUND And ignore our parent scale, to work around a bug in WoW 7.3
-  editor.editBox:SetIgnoreParentScale(true);
   group:AddChild(editor);
   editor.frame:SetClipsChildren(true);
 


### PR DESCRIPTION
7.3.2 fixed the bug, so we can remove our workaround again.

This reverts commit 8305cd5733c6b4470a84a8df37bd725e104b9c1c.