### PR TITLE
Format percenthealth to limit to two decimal places

### DIFF
--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -1037,7 +1037,7 @@ WeakAuras.event_prototypes = {
         name = "percenthealth",
         display = L["Health (%)"],
         type = "number",
-        init = "(UnitHealth(concernedUnit) / math.max(1, UnitHealthMax(concernedUnit))) * 100",
+        init = "string.format(\"%.2f\",(UnitHealth(concernedUnit) / math.max(1, UnitHealthMax(concernedUnit))) * 100)",
         store = true,
         conditionType = "number"
       },


### PR DESCRIPTION
Without this fix, %percenthealth would display a high number of decimal places