### PR TITLE
RegionPrototype.lua: attempt to compare number with string

### DIFF
--- a/WeakAuras/RegionTypes/RegionPrototype.lua
+++ b/WeakAuras/RegionTypes/RegionPrototype.lua
@@ -307,7 +307,7 @@ function WeakAuras.regionPrototype.AddSetDurationInfo(region)
     region.SetValueFromCustomValueFunc = function()
       local value, total, _ = region.customValueFunc(region.state.trigger);
       value = type(value) == "number" and value or 0
-      total = type(value) == "number" and total or 0
+      total = type(total) == "number" and total or 0
       SetProgressValue(region, value, total);
     end
 
@@ -322,7 +322,7 @@ function WeakAuras.regionPrototype.AddSetDurationInfo(region)
         if type(customValue) == "function" then
           local value, total = customValue(region.state.trigger);
           value = type(value) == "number" and value or 0
-          total = type(value) == "number" and total or 0
+          total = type(total) == "number" and total or 0
           if total > 0 and value < total then
             self.customValueFunc = customValue;
             self:SetScript("OnUpdate", region.SetValueFromCustomValueFunc);


### PR DESCRIPTION
```
Message: ...ace\AddOns\WeakAuras\RegionTypes\RegionPrototype.lua:324: attempt to compare number with string
Time: 11/22/17 16:11:34
Count: 846
Stack: ...ace\AddOns\WeakAuras\RegionTypes\RegionPrototype.lua:324: attempt to compare number with string
Interface\SharedXML\SharedBasicControls.lua:208: in function `origErrorHandler'
...rface\AddOns\TradeSkillMaster\Debug\ErrorHandler.lua:317: in function <...rface\AddOns\TradeSkillMaster\Debug\ErrorHandler.lua:300>
[C]: ?
...ace\AddOns\WeakAuras\RegionTypes\RegionPrototype.lua:324: in function `SetDurationInfo'
Interface\AddOns\WeakAuras\WeakAuras.lua:3611: in function <Interface\AddOns\WeakAuras\WeakAuras.lua:3593>
Interface\AddOns\WeakAuras\WeakAuras.lua:3695: in function <Interface\AddOns\WeakAuras\WeakAuras.lua:3687>
Interface\AddOns\WeakAuras\WeakAuras.lua:3790: in function `UpdatedTriggerState'
Interface\AddOns\WeakAuras\GenericTrigger.lua:550: in function `ScanEvents'
Interface\AddOns\WeakAuras\GenericTrigger.lua:890: in function <Interface\AddOns\WeakAuras\GenericTrigger.lua:888>

Locals: errorMessage = "...ace\AddOns\WeakAuras\RegionTypes\RegionPrototype.lua:324: attempt to compare number with string"
DisplayMessageInternal = <function> defined @Interface\SharedXML\SharedBasicControls.lua:191
MESSAGE_TYPE_ERROR = 0
```