### PR TITLE
field 'spellCache' can be nil

### DIFF
--- a/WeakAuras/Transmission.lua
+++ b/WeakAuras/Transmission.lua
@@ -782,7 +782,7 @@ function WeakAuras.ShowDisplayTooltip(data, children, icon, icons, import, compr
               if (icons) then
                 tinsert(tooltip, {2, left, name..(icons[name] and (" |T"..icons[name]..":12:12:0:0:64:64:4:60:4:60|t") or ""), 1, 1, 1, 1, 1, 1});
               else
-                local icon = WeakAuras.spellCache.GetIcon(name) or "Interface\\Icons\\INV_Misc_QuestionMark";
+                local icon = WeakAuras.spellCache and WeakAuras.spellCache.GetIcon(name) or "Interface\\Icons\\INV_Misc_QuestionMark";
                 tinsert(tooltip, {2, left, name.." |T"..icon..":12:12:0:0:64:64:4:60:4:60|t", 1, 1, 1, 1, 1, 1});
               end
             end


### PR DESCRIPTION
`WeakAuras.spellCache` is nil until WeakAurasOptons has been loaded.

Steps to reproduce: Reload interface. Have another person link a display with an Aura trigger (and Aura Name, like spellId). Click on link.

I'm not sure if the same can happen in line 468 in function `WeakAuras.DisplayToString`.