### PR TITLE
adding region table into aura_env

### DIFF
--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -391,6 +391,7 @@ function WeakAuras.ActivateAuraEnvironment(id, cloneId, state)
       current_aura_env = aura_environments[id];
       current_aura_env.cloneId = cloneId;
       current_aura_env.state = state;
+      current_aura_env.region = WeakAuras.GetRegion(id, cloneId);
       -- Push the new environment onto the stack
       tinsert(aura_env_stack, current_aura_env);
     else
@@ -399,6 +400,7 @@ function WeakAuras.ActivateAuraEnvironment(id, cloneId, state)
       current_aura_env = aura_environments[id];
       current_aura_env.cloneId = cloneId;
       current_aura_env.state = state;
+      current_aura_env.region = WeakAuras.GetRegion(id, cloneId);
       -- Push the new environment onto the stack
       tinsert(aura_env_stack, current_aura_env);
       -- Run the init function if supplied


### PR DESCRIPTION
Hopefully using a current version this time :)
Pure quality of life change for people who use `WeakAuras.regions[aura_env.id].region` a lot. 