### PR TITLE
Fix Copy/Paste code for Groups

### DIFF
--- a/WeakAurasOptions/WeakAurasOptions.lua
+++ b/WeakAurasOptions/WeakAurasOptions.lua
@@ -3941,12 +3941,6 @@ function WeakAuras.EnsureDisplayButton(data)
   end
 end
 
-function WeakAuras.SetCopying(data)
-  for id, button in pairs(displayButtons) do
-    button:SetCopying(data);
-  end
-end
-
 function WeakAuras.SetGrouping(data)
   for id, button in pairs(displayButtons) do
     button:SetGrouping(data);


### PR DESCRIPTION
- Don't copy controlledChildren.
- In the context menu for groups offer only "Copy Group"
- Pasting a individual auras settings onto a group paste it to
  each child.