### PR TITLE
Setup fallback state so that it has no duration

### DIFF
--- a/WeakAuras/BuffTrigger.lua
+++ b/WeakAuras/BuffTrigger.lua
@@ -1749,6 +1749,9 @@ end
 function BuffTrigger.CreateFallbackState(data, triggernum, state)
   state.show = true;
   state.changed = true;
+  state.progressType = "timed";
+  state.duration = 0;
+  state.expirationTime = math.huge;
 end
 
 WeakAuras.RegisterTriggerSystem({"aura"}, BuffTrigger);

--- a/WeakAuras/GenericTrigger.lua
+++ b/WeakAuras/GenericTrigger.lua
@@ -2848,10 +2848,10 @@ function GenericTrigger.CreateFallbackState(data, triggernum, state)
       state.inverse = inverse;
     end
   else
-    state.progressType = "static";
-    state.duration = nil;
+    state.progressType = "timed";
+    state.duration = 0;
+    state.expirationTime = math.huge;
     state.resort = nil;
-    state.expirationTime = nil;
     state.value = nil;
     state.total = nil;
   end


### PR DESCRIPTION
Before b3e57359e128d4e23f9f7f3bf1b9c64f6300293b would overwrite
the duration information in the fallback state.

Github-Issue: 382