### PR TITLE
Change progressPrecision to use floor

### DIFF
--- a/WeakAuras/RegionTypes/RegionPrototype.lua
+++ b/WeakAuras/RegionTypes/RegionPrototype.lua
@@ -265,7 +265,7 @@ local function UpateRegionValues(region)
     elseif (region.progressPrecision == 4 or region.progressPrecision == 5) and remaining > 3 then
       remainingStr = remainingStr..floor(remaining);
     else
-      remainingStr = remainingStr..floor(remaining*(10^region.progressPrecision))/(10^region.progressPrecision);
+      remainingStr = remainingStr..floor(remaining*(10^(region.progressPrecision or 0)))/(10^(region.progressPrecision or 0));
     end
   else
     remainingStr     = " ";

--- a/WeakAuras/RegionTypes/RegionPrototype.lua
+++ b/WeakAuras/RegionTypes/RegionPrototype.lua
@@ -259,13 +259,13 @@ local function UpateRegionValues(region)
   elseif remaining > 0 then
     -- remainingStr = remainingStr..string.format("%."..(data.progressPrecision or 1).."f", remaining);
     if region.progressPrecision == 4 and remaining <= 3 then
-      remainingStr = remainingStr..string.format("%.1f", remaining);
+      remainingStr = remainingStr..floor(remaining*10)/10;
     elseif region.progressPrecision == 5 and remaining <= 3 then
-      remainingStr = remainingStr..string.format("%.2f", remaining);
+      remainingStr = remainingStr..floor(remaining*100)/100;
     elseif (region.progressPrecision == 4 or region.progressPrecision == 5) and remaining > 3 then
-      remainingStr = remainingStr..string.format("%d", remaining);
+      remainingStr = remainingStr..floor(remaining);
     else
-      remainingStr = remainingStr..string.format("%."..(region.progressPrecision or 1).."f", remaining);
+      remainingStr = remainingStr..floor(remaining*(10^region.progressPrecision))/(10^region.progressPrecision);
     end
   else
     remainingStr     = " ";


### PR DESCRIPTION
Having rounded numbers for a timer instead of floored feels odd, especially when showing no decimals, zero shows for half a second. Leaving the totalPrecision using Round seems fine though so I haven't altered that stuff.