### PR TITLE
ticket #456

### DIFF
--- a/WeakAuras/RegionTypes/RegionPrototype.lua
+++ b/WeakAuras/RegionTypes/RegionPrototype.lua
@@ -269,7 +269,9 @@ function WeakAuras.regionPrototype.modify(parent, region, data)
 
   region:SetOffset(data.xOffset or 0, data.yOffset or 0);
   region:SetOffsetAnim(0, 0);
-  WeakAuras.AnchorFrame(data, region, parent);
+  if not parent or parent.regionType ~= "dynamicgroup" then
+    WeakAuras.AnchorFrame(data, region, parent);
+  end
 end
 
 local function SetProgressValue(region, value, total)


### PR DESCRIPTION
If a child of a dynamic group has anchorFrameType of SELECT and anchorFrameFrame refers to a frame which doesn't exist, then WeakAuras will get stuck in a loop trying to anchor, which eventually causes the group to fail to control its children. We can prevent this by forcing GetAnchorFrame to detect a dynamicgroup parent.