### PR TITLE
Add functions commonly used by custom WA authors

### DIFF
--- a/WeakAuras/HelperFunctions.lua
+++ b/WeakAuras/HelperFunctions.lua
@@ -1,0 +1,50 @@
+local UnitAura = UnitAura
+-- Unit Aura functions that return info about the first Aura matching the spellName or spellID given on the unit.
+local WA_GetUnitAura = function(unit, spell, filter)
+    for i = 1, 40 do
+        local name, _, _, _, _, _, _, _, _, spellId = UnitAura(unit, i, filter)
+        if not name then return end
+        if spell == spellId or spell == name then
+            return UnitAura(unit, i, filter)
+        end
+    end
+end
+local WA_GetUnitBuff = function(unit, spell, filter)
+    return WA_GetUnitAura(unit, spell, filter)
+end
+local WA_GetUnitDebuff = function(unit, spell, filter)
+    filter = filter and filter.."|HARMFUL" or "HARMFUL"
+    return WA_GetUnitAura(unit, spell, filter)
+end
+
+-- Function to assist iterating group members whether in a party or raid.
+local WA_IterateGroupMembers = function(reversed, forceParty)
+   local unit  = (not forceParty and IsInRaid()) and 'raid' or 'party'
+   local numGroupMembers = (forceParty and GetNumSubgroupMembers()  or GetNumGroupMembers()) - (unit == "party" and 1 or 0)
+   local i = reversed and numGroupMembers or (unit == 'party' and 0 or 1)
+   return function()
+      local ret
+      if i == 0 and unit == 'party' then
+         ret = 'player'
+      elseif i <= numGroupMembers and i > 0 then
+         ret = unit .. i
+      end
+      i = i + (reversed and -1 or 1)
+      return ret
+   end
+end
+
+-- Wrapping a unit's name in its class colour is very common in custom Auras
+local WA_ClassColorName = function(unit)
+    local _, class = UnitClass(unit)
+    if not class then return end
+    return RAID_CLASS_COLORS[class]:WrapTextInColorCode(UnitName(unit))
+end
+
+WeakAuras.helperFunctions = {
+  WA_GetUnitAura = WA_GetUnitAura,
+  WA_GetUnitBuff = WA_GetUnitBuff,
+  WA_GetUnitDebuff = WA_GetUnitDebuff,
+  WA_IterateGroupMembers = WA_IterateGroupMembers,
+  WA_ClassColorName = WA_ClassColorName,
+}

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -458,6 +458,8 @@ local exec_env = setmetatable({}, { __index =
       return forbidden
     elseif overrideFunctions[k] then
       return overrideFunctions[k]
+    elseif WeakAuras.helperFunctions[k] then
+      return WeakAuras.helperFunctions[k]
     else
       return _G[k]
     end

--- a/WeakAuras/WeakAuras.toc
+++ b/WeakAuras/WeakAuras.toc
@@ -27,6 +27,7 @@ WeakAuras.lua
 Transmission.lua
 BuffTrigger.lua
 GenericTrigger.lua
+HelperFunctions.lua
 
 RegionTypes\RegionPrototype.lua
 RegionTypes\ProgressTexture.lua


### PR DESCRIPTION
WeakAuras.UnitAura, WeakAuras.UnitBuff, WeakAuras.UnitDebuff - mimicking functionality from pre-8.0
WeakAuras.GroupMembers - Very popular in Legion.

This would be a bit of a step off the normal path so I totally understand if providing stuff for custom WA authors isn't something you want to get into, or if the functions I added simply aren't strong enough that you want them to be carried by your addon. 
However, I thought that if I throw a PR up then it at least sparks the discussion and you can always reject the PR if you're not keen.