### PR TITLE
Add "Adjust Timer" option to DBM and BigWigs timers

### DIFF
--- a/WeakAuras/GenericTrigger.lua
+++ b/WeakAuras/GenericTrigger.lua
@@ -2123,7 +2123,9 @@ do
     return bar;
   end
 
-  function WeakAuras.CopyBarToState(bar, states, id)
+  function WeakAuras.CopyBarToState(bar, states, id, extendTimer)
+    extendTimer = extendTimer or 0;
+    if extendTimer + bar.duration < 0 then return end
     states[id] = states[id] or {};
     local state = states[id];
     state.show = true;
@@ -2131,13 +2133,17 @@ do
     state.icon = bar.icon;
     state.message = bar.message;
     state.name = bar.message;
-    state.expirationTime = bar.expirationTime;
+    state.expirationTime = bar.expirationTime + extendTimer;
     state.progressType = 'timed';
     state.resort = true;
-    state.duration = bar.duration;
+    state.duration = bar.duration + extendTimer;
     state.timerType = bar.timerType;
     state.spellId = bar.spellId;
     state.colorId = bar.colorId;
+    state.extend = extendTimer;
+    if extendTimer ~= 0 then
+        state.autoHide = true
+    end
   end
 
   function WeakAuras.RegisterDBMCallback(event)
@@ -2257,7 +2263,9 @@ do
     WeakAuras.RegisterBigWigsCallback("BigWigs_OnBossDisable");
   end
 
-  function WeakAuras.CopyBigWigsTimerToState(bar, states, id)
+  function WeakAuras.CopyBigWigsTimerToState(bar, states, id, extendTimer)
+    extendTimer = extendTimer or 0;
+    if extendTimer + bar.duration < 0 then return end
     states[id] = states[id] or {};
     local state = states[id];
     state.show = true;
@@ -2266,11 +2274,15 @@ do
     state.spellId = bar.spellId;
     state.text = bar.text;
     state.name = bar.text;
-    state.duration = bar.duration;
-    state.expirationTime = bar.expirationTime;
+    state.duration = bar.duration + extendTimer;
+    state.expirationTime = bar.expirationTime + extendTimer;
     state.resort = true;
     state.progressType = "timed";
     state.icon = bar.icon;
+    state.extend = extendTimer;
+    if extendTimer ~= 0 then
+      state.autoHide = true
+    end
   end
 
   function WeakAuras.BigWigsTimerMatches(id, addon, spellId, textOperator, text)

--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -2575,6 +2575,12 @@ WeakAuras.event_prototypes = {
           local triggerSpellId = nil;
         ]];
       end
+
+      local ret2 = [[
+        local extendTimer = %s;
+      ]]
+      ret = ret .. ret2:format(trigger.use_extend and tonumber(trigger.extend or 0) or 0)
+      
       local copyOrSchedule;
       if (trigger.use_remaining) then
         local ret2 = [[
@@ -2582,21 +2588,21 @@ WeakAuras.event_prototypes = {
         ]];
         ret = ret .. ret2:format(trigger.remaining or 0);
         copyOrSchedule = [[
-          local remainingTime = bar.expirationTime - GetTime()
+          local remainingTime = bar.expirationTime - GetTime() + extendTimer;
           if (remainingTime %s %s) then
-            WeakAuras.CopyBarToState(bar, states, id);
+            WeakAuras.CopyBarToState(bar, states, id, extendTimer);
           elseif (states[id] and states[id].show) then
               states[id].show = false;
               states[id].changed = true;
           end
           if (remainingTime >= remainingCheck) then
-            WeakAuras.ScheduleDbmCheck(bar.expirationTime - remainingCheck);
+            WeakAuras.ScheduleDbmCheck(bar.expirationTime - remainingCheck + extendTimer);
           end
         ]]
         copyOrSchedule = copyOrSchedule:format(trigger.remaining_operator or "<", trigger.remaining or 0);
       else
         copyOrSchedule = [[
-          WeakAuras.CopyBarToState(bar, states, id);
+          WeakAuras.CopyBarToState(bar, states, id, extendTimer);
           ]];
       end
       if (trigger.use_cloneId) then
@@ -2618,7 +2624,7 @@ WeakAuras.event_prototypes = {
             end
 
           elseif (event == "DBM_TimerStop") then
-            if (states[id]) then
+            if (states[id] and states[id].extend == 0) then
               states[id].show = false;
               states[id].changed = true;
             end
@@ -2651,7 +2657,7 @@ WeakAuras.event_prototypes = {
       ret = ret .. copyOrSchedule;
       ret = ret .. [[
           else
-            if (states[""] and states[""].show) then
+            if (states[""] and states[""].show and states[""].extend == 0) then
               states[""].show = false;
               states[""].changed = true;
             end
@@ -2687,6 +2693,11 @@ WeakAuras.event_prototypes = {
         name = "remaining",
         display = L["Remaining Time"],
         type = "number",
+      },
+      {
+        name = "extend",
+        display = L["Adjust Timer"],
+        type = "string",
       },
       {
         name = "cloneId",
@@ -2782,6 +2793,11 @@ WeakAuras.event_prototypes = {
         trigger.use_text and ('[[' .. (trigger.text or '') .. ']]') or "nil",
         trigger.use_text and trigger.text_operator or ""
       );
+     
+      local ret2 = [[
+        local extendTimer = %s;
+      ]]
+      ret = ret .. ret2:format(trigger.use_extend and tonumber(trigger.extend or 0) or 0)
 
       local copyOrSchedule;
       if (trigger.use_remaining) then
@@ -2790,21 +2806,21 @@ WeakAuras.event_prototypes = {
         ]];
         ret = ret .. ret2:format(trigger.remaining or 0);
         copyOrSchedule = [[
-          local remainingTime = bar.expirationTime - GetTime()
+          local remainingTime = bar.expirationTime - GetTime() + extendTimer;
           if (remainingTime %s %s) then
-            WeakAuras.CopyBigWigsTimerToState(bar, states, id);
+            WeakAuras.CopyBigWigsTimerToState(bar, states, id, extendTimer);
           elseif (states[id] and states[id].show) then
               states[id].show = false;
               states[id].changed = true;
           end
           if (remainingTime >= remainingCheck) then
-            WeakAuras.ScheduleBigWigsCheck(bar.expirationTime - remainingCheck);
+            WeakAuras.ScheduleBigWigsCheck(bar.expirationTime - remainingCheck + extendTimer);
           end
           ]]
         copyOrSchedule = copyOrSchedule:format(trigger.remaining_operator or "", trigger.remaining or 0);
       else
         copyOrSchedule = [[
-          WeakAuras.CopyBigWigsTimerToState(bar, states, id);
+          WeakAuras.CopyBigWigsTimerToState(bar, states, id, extendTimer);
           ]];
       end
 
@@ -2818,9 +2834,9 @@ WeakAuras.event_prototypes = {
         ret = ret .. [[
             end
           elseif (event == "BigWigs_StopBar") then
-            if (states[id]) then
-              states[id].show = false;
-              states[id].changed = true;
+            if (states[id] and states[id].extend == 0) then
+                states[id].show = false;
+                states[id].changed = true;
             end
           elseif (event == "BigWigs_Timer_Update") then
             for id, bar in pairs(WeakAuras.GetAllBigWigsTimers()) do
@@ -2853,7 +2869,7 @@ WeakAuras.event_prototypes = {
         ret = ret .. copyOrSchedule;
         ret = ret .. [[
           else
-            if (states[""] and states[""].show) then
+            if (states[""] and states[""].show and states[""].extend == 0) then 
               states[""].show = false;
               states[""].changed = true;
             end
@@ -2887,6 +2903,11 @@ WeakAuras.event_prototypes = {
         name = "remaining",
         display = L["Remaining Time"],
         type = "number",
+      },
+      {
+        name = "extend",
+        display = L["Adjust Timer"],
+        type = "string",
       },
       {
         name = "cloneId",


### PR DESCRIPTION
This option let you change the duration & expirationTime for bigwigs and dbm timers

I did this because bossmods tend to give timers that end when a boss start casting instead of when they finish their cast.

Tests done for both bigwigs and dbm 
- with and without remaining time set
- with and without clone per event set
- with positive and negative value
- with negative value > - duration (it skip bar creation)

screenshot of gui:
https://i.imgur.com/XBP7JO4.png

The timer adjustment is done in WeakAuras.CopyBarToState() and  WeakAuras.CopyBigWigsTimerToState()

To avoid that the bar stop prematurely from DBM_TimerStop or BigWigs_StopBar events i made it skip them if extendTimer is set, and use state.autoHide = true instead