### PR TITLE
ensure that the childID exists before using it

### DIFF
--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -2343,7 +2343,9 @@ function WeakAuras.Modernize(data)
         local newSortTable = {}
         for index, isHybrid in pairs(data.sortHybridTable) do
           local childID = data.controlledChildren[index]
-          newSortTable[childID] = isHybrid
+          if childID then
+            newSortTable[childID] = isHybrid
+          end
         end
         data.sortHybridTable = newSortTable
       end


### PR DESCRIPTION
This shouldn't have been a problem, but sortHybridTable isn't properly maintained and can collect clutter if an index becomes no longer valid. Fix this by double checking before migrating that index.