### PR TITLE
Add links to explain force pushing for rebase

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,7 @@ If you want to help, here's what you need to do:
   > git push --force
   ```
 * Note: Force-pushing is a destructive operation, so make sure you don't lose something in the progress.
-* Read [here](https://www.atlassian.com/git/tutorials/merging-vs-rebasing#the-golden-rule-of-rebasing) and [here](https://www.reddit.com/r/git/comments/6jzogp/why_am_i_force_pushing_after_a_rebase/) to explain why we force push after a rebase.
+* If you want to know more about force-pushing and why we do it, there are a two good posts about it: one by [Atlassian](https://www.atlassian.com/git/tutorials/merging-vs-rebasing#the-golden-rule-of-rebasing) and one on [Reddit](https://www.reddit.com/r/git/comments/6jzogp/why_am_i_force_pushing_after_a_rebase/).
 * Your pull request should now have no conflicts and be ready for review and merging.
 
 ## Reporting Issues and Requesting Features

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,7 @@ If you want to help, here's what you need to do:
   > git push --force
   ```
 * Note: Force-pushing is a destructive operation, so make sure you don't lose something in the progress.
+* Read [here](https://www.atlassian.com/git/tutorials/merging-vs-rebasing#the-golden-rule-of-rebasing) and [here](https://www.reddit.com/r/git/comments/6jzogp/why_am_i_force_pushing_after_a_rebase/) to explain why we force push after a rebase.
 * Your pull request should now have no conflicts and be ready for review and merging.
 
 ## Reporting Issues and Requesting Features


### PR DESCRIPTION
Added 2 links for people to follow if they want more information to explain why they need to force push after a rebase.  

Since rebasing can be a complicated subject on its own for newer programmers, some people may find it unsettling to have to force push if such an operation is so 'destructive', the way it is described in the CONTRIBUTING.md.  These links can help contributors understand why it must be done as well as the benefits of rebasing their branches.