### PR TITLE
default to ratio of 1 if the aspect ratio is undefined

### DIFF
--- a/WeakAuras/RegionTypes/Icon.lua
+++ b/WeakAuras/RegionTypes/Icon.lua
@@ -473,7 +473,12 @@ local function modify(parent, region, data)
     icon:SetAllPoints();
 
     local texWidth = 1 - 0.5 * data.zoom;
-    local aspectRatio = region.keepAspectRatio and width / height or 1;
+    local aspectRatio
+    if not region.keepAspectRatio or (width == 0 and height == 0) then
+      aspectRatio = 1
+    else
+      aspectRatio = width / height;
+    end
 
     local ulx, uly, llx, lly, urx, ury, lrx, lry = GetTexCoord(region, texWidth, aspectRatio)
 


### PR DESCRIPTION
Animation scale funcs can return 0, 0. This would set the width and height to 0.
But then the aspect ratio of that is NaN. So guard against that since SetTexCoord
doesn't like getting NaN.
Github issue #533