### PR TITLE
Add group unit options

### DIFF
--- a/WeakAuras/BuffTrigger.lua
+++ b/WeakAuras/BuffTrigger.lua
@@ -652,7 +652,7 @@ function WeakAuras.ScanAuras(unit)
                 end
               end
             end
-            
+
             local satisfies_role = true
             if data.group_role then
               satisfies_role = data.group_role == "ANY" or UnitGroupRolesAssigned(unit) == data.group_role
@@ -696,6 +696,9 @@ function WeakAuras.ScanAuras(unit)
               if(data.group_count) then
                 -- Query count from aura cache
                 local aura_count, max = aura_object:GetNumber(id, triggernum, data), aura_object:GetMaxNumber();
+                if (data.ignoreSelf) then
+                  max = max - 1;
+                end
                 local satisfies_count = data.group_count(aura_count, max);
 
                 if(data.hideAlone and not IsInGroup()) then

--- a/WeakAuras/BuffTrigger.lua
+++ b/WeakAuras/BuffTrigger.lua
@@ -697,7 +697,7 @@ function WeakAuras.ScanAuras(unit)
                 -- Query count from aura cache
                 local aura_count, max = aura_object:GetNumber(id, triggernum, data), aura_object:GetMaxNumber();
                 local satisfies_count = data.group_count(aura_count, max);
-                
+
                 if(data.hideAlone and not IsInGroup()) then
                   satisfies_count = false;
                 end

--- a/WeakAuras/BuffTrigger.lua
+++ b/WeakAuras/BuffTrigger.lua
@@ -652,6 +652,15 @@ function WeakAuras.ScanAuras(unit)
                 end
               end
             end
+            
+            local satisfies_role = true
+            if data.group_role then
+              satisfies_role = data.group_role == "ANY" or UnitGroupRolesAssigned(unit) == data.group_role
+            end
+            local satisfies_ignoreSelf = not data.ignoreSelf or not UnitIsUnit(unit, "player")
+            if not satisfies_role or not satisfies_ignoreSelf then
+              active = false
+            end
 
             -- Update aura cache (and clones)
             if (active) then
@@ -689,18 +698,12 @@ function WeakAuras.ScanAuras(unit)
                 local aura_count, max = aura_object:GetNumber(id, triggernum, data), aura_object:GetMaxNumber();
                 local satisfies_count = data.group_count(aura_count, max);
                 
-                local satisfies_role = true 
-                if data.group_role then 
-                  satisfies_role = data.group_role == "ANY" or UnitGroupRolesAssigned(unit) == data.group_role
-                end
-                local satisfies_ignoreSelf = not data.ignoreSelf or not UnitIsUnit(unit, "player")
-
                 if(data.hideAlone and not IsInGroup()) then
                   satisfies_count = false;
                 end
 
-                -- Satisfying count condition and role condition and ignoreSelf
-                if(satisfies_count and satisfies_role and satisfies_ignoreSelf) then
+                -- Satisfying count condition
+                if(satisfies_count) then
                   -- Update clones (show)
                   if(data.groupclone) then
                     for guid, playerName in pairs(groupcloneToUpdate) do

--- a/WeakAuras/BuffTrigger.lua
+++ b/WeakAuras/BuffTrigger.lua
@@ -1537,7 +1537,9 @@ function BuffTrigger.Add(data)
           numAdditionalTriggers = data.additional_triggers and #data.additional_triggers or 0,
           hideAlone = trigger.hideAlone,
           stack_info = trigger.stack_info,
-          name_info = trigger.name_info
+          name_info = trigger.name_info,
+          group_role = trigger.group_role,
+          ignoreSelf = trigger.ignoreSelf
         };
       end
     end

--- a/WeakAuras/BuffTrigger.lua
+++ b/WeakAuras/BuffTrigger.lua
@@ -1544,7 +1544,7 @@ function BuffTrigger.Add(data)
           hideAlone = trigger.hideAlone,
           stack_info = trigger.stack_info,
           name_info = trigger.name_info,
-          group_role = trigger.group_role,
+          group_role =  trigger.useGroupRole and trigger.group_role,
           ignoreSelf = trigger.ignoreSelf
         };
       end

--- a/WeakAuras/BuffTrigger.lua
+++ b/WeakAuras/BuffTrigger.lua
@@ -688,13 +688,19 @@ function WeakAuras.ScanAuras(unit)
                 -- Query count from aura cache
                 local aura_count, max = aura_object:GetNumber(id, triggernum, data), aura_object:GetMaxNumber();
                 local satisfies_count = data.group_count(aura_count, max);
+                
+                local satisfies_role = true 
+                if data.group_role then 
+                  satisfies_role = data.group_role == "ANY" or UnitGroupRolesAssigned(unit) == data.group_role
+                end
+                local satisfies_ignoreSelf = not data.ignoreSelf or not UnitIsUnit(unit, "player")
 
                 if(data.hideAlone and not IsInGroup()) then
                   satisfies_count = false;
                 end
 
-                -- Satisfying count condition
-                if(satisfies_count) then
+                -- Satisfying count condition and role condition and ignoreSelf
+                if(satisfies_count and satisfies_role and satisfies_ignoreSelf) then
                   -- Update clones (show)
                   if(data.groupclone) then
                     for guid, playerName in pairs(groupcloneToUpdate) do

--- a/WeakAuras/Types.lua
+++ b/WeakAuras/Types.lua
@@ -1306,7 +1306,7 @@ WeakAuras.group_roles = {
   ANY = "Any", 
   TANK = "TANK", 
   HEALER = "HEALER", 
-  DAMAGER = "DAMAGER" 
+  DAMAGER = "DPS" 
 } 
   
 WeakAuras.cast_types = {

--- a/WeakAuras/Types.lua
+++ b/WeakAuras/Types.lua
@@ -1302,13 +1302,13 @@ WeakAuras.group_aura_stack_info_types = {
   stack = L["Aura Stack"]
 }
 
-WeakAuras.group_roles = { 
-  ANY = L["Any"], 
-  TANK = L["Tanks"], 
-  HEALER = L["Healers"], 
-  DAMAGER = L["DPS"] 
-} 
-  
+WeakAuras.group_roles = {
+  ANY = L["Any"],
+  TANK = L["Tanks"],
+  HEALER = L["Healers"],
+  DAMAGER = L["DPS"]
+}
+
 WeakAuras.cast_types = {
   cast = L["Cast"],
   channel = L["Channel (Spell)"]

--- a/WeakAuras/Types.lua
+++ b/WeakAuras/Types.lua
@@ -1303,10 +1303,10 @@ WeakAuras.group_aura_stack_info_types = {
 }
 
 WeakAuras.group_roles = { 
-  ANY = "Any", 
-  TANK = "TANK", 
-  HEALER = "HEALER", 
-  DAMAGER = "DPS" 
+  ANY = L["Any"], 
+  TANK = L["Tanks"], 
+  HEALER = L["Healers"], 
+  DAMAGER = L["DPS"] 
 } 
   
 WeakAuras.cast_types = {

--- a/WeakAuras/Types.lua
+++ b/WeakAuras/Types.lua
@@ -1302,13 +1302,6 @@ WeakAuras.group_aura_stack_info_types = {
   stack = L["Aura Stack"]
 }
 
-WeakAuras.group_roles = {
-  ANY = L["Any"],
-  TANK = L["Tanks"],
-  HEALER = L["Healers"],
-  DAMAGER = L["DPS"]
-}
-
 WeakAuras.cast_types = {
   cast = L["Cast"],
   channel = L["Channel (Spell)"]

--- a/WeakAuras/Types.lua
+++ b/WeakAuras/Types.lua
@@ -1302,6 +1302,13 @@ WeakAuras.group_aura_stack_info_types = {
   stack = L["Aura Stack"]
 }
 
+WeakAuras.group_roles = { 
+  ANY = "Any", 
+  TANK = "TANK", 
+  HEALER = "HEALER", 
+  DAMAGER = "DAMAGER" 
+} 
+  
 WeakAuras.cast_types = {
   cast = L["Cast"],
   channel = L["Channel (Spell)"]

--- a/WeakAurasOptions/BuffTrigger.lua
+++ b/WeakAurasOptions/BuffTrigger.lua
@@ -756,6 +756,20 @@ function WeakAuras.GetBuffTriggerOptions(data, trigger)
       end,
       values = group_aura_stack_info_types
     },
+    ignoreSelf = { 
+      type = "toggle", 
+      name = "Ignore player", 
+      order = 47.7, 
+      hidden = function() return not (trigger.type == "aura" and trigger.unit == "group"); end, 
+    }, 
+    group_role = { 
+      type = "select", 
+      name = "Group Member Role", 
+      values = WeakAuras.group_roles, 
+      hidden = function() return not (trigger.type == "aura" and trigger.unit == "group"); end, 
+      get = function() return trigger.group_role; end, 
+      order = 47.8 
+    }, 
     hideAlone = {
       type = "toggle",
       name = L["Hide When Not In Group"],

--- a/WeakAurasOptions/BuffTrigger.lua
+++ b/WeakAurasOptions/BuffTrigger.lua
@@ -767,16 +767,15 @@ function WeakAuras.GetBuffTriggerOptions(data, trigger)
       type = "toggle",
       name = L["Filter by Group Role"],
       order = 47.9,
-      disabled = true,
       hidden = function() return not (trigger.type == "aura" and trigger.unit == "group"); end,
-      get = function() return true end
     },
     group_role = {
       type = "select",
       name = L["Group Role"],
-      values = WeakAuras.group_roles,
+      values = WeakAuras.role_types,
       hidden = function() return not (trigger.type == "aura" and trigger.unit == "group"); end,
-      get = function() return trigger.group_role or "ANY"; end,
+      disabled = function() return not trigger.useGroupRole; end,
+      get = function() return trigger.group_role; end,
       order = 48
     },
     ignoreSelf = {

--- a/WeakAurasOptions/BuffTrigger.lua
+++ b/WeakAurasOptions/BuffTrigger.lua
@@ -756,24 +756,33 @@ function WeakAuras.GetBuffTriggerOptions(data, trigger)
       end,
       values = group_aura_stack_info_types
     },
-    ignoreSelf = { 
-      type = "toggle", 
-      name = L["Ignore self"],
-      order = 47.7, 
-      hidden = function() return not (trigger.type == "aura" and trigger.unit == "group"); end, 
-    }, 
-    group_role = { 
-      type = "select", 
-      name = L["Group Role"], 
-      values = WeakAuras.group_roles, 
-      hidden = function() return not (trigger.type == "aura" and trigger.unit == "group"); end, 
-      get = function() return trigger.group_role; end, 
-      order = 47.8 
-    }, 
     hideAlone = {
       type = "toggle",
       name = L["Hide When Not In Group"],
-      order = 48,
+      order = 47.7,
+      width = "double",
+      hidden = function() return not (trigger.type == "aura" and trigger.unit == "group"); end,
+    },
+    useGroupRole = {
+      type = "toggle",
+      name = L["Filter by Group Role"],
+      order = 47.9,
+      disabled = true,
+      hidden = function() return not (trigger.type == "aura" and trigger.unit == "group"); end,
+      get = function() return true end
+    },
+    group_role = {
+      type = "select",
+      name = L["Group Role"],
+      values = WeakAuras.group_roles,
+      hidden = function() return not (trigger.type == "aura" and trigger.unit == "group"); end,
+      get = function() return trigger.group_role or "ANY"; end,
+      order = 48
+    },
+    ignoreSelf = {
+      type = "toggle",
+      name = L["Ignore self"],
+      order = 48.1,
       width = "double",
       hidden = function() return not (trigger.type == "aura" and trigger.unit == "group"); end,
     },

--- a/WeakAurasOptions/BuffTrigger.lua
+++ b/WeakAurasOptions/BuffTrigger.lua
@@ -758,13 +758,13 @@ function WeakAuras.GetBuffTriggerOptions(data, trigger)
     },
     ignoreSelf = { 
       type = "toggle", 
-      name = "Ignore player", 
+      name = L["Ignore self"],
       order = 47.7, 
       hidden = function() return not (trigger.type == "aura" and trigger.unit == "group"); end, 
     }, 
     group_role = { 
       type = "select", 
-      name = "Group Member Role", 
+      name = L["Group Role"], 
       values = WeakAuras.group_roles, 
       hidden = function() return not (trigger.type == "aura" and trigger.unit == "group"); end, 
       get = function() return trigger.group_role; end, 


### PR DESCRIPTION
The goal is to provide options in the group=unit settings for users to specify raiding roles to watch and also exclude themselves from results.
 
The use case I had in mind for this was be to track "tank swap" debuffs on other tanks. These settings would let users only see debuffs on other tanks which is a very common thing to want to see without a very satisfactory method currently. 
Currently while raiding as tank I would *always* focus my cotank and use the focus unit for tank monitoring Auras. This gets messy when there are 3 tanks and removes any other uses I might have for my focus. Other people have made complex TSU auras to track the other tank. 

Of course I expect that the setting could be useful for other stuff too. 