### PR TITLE
Rewrite SetFrameLevel code to be more robust for clones

### DIFF
--- a/WeakAuras/RegionTypes/DynamicGroup.lua
+++ b/WeakAuras/RegionTypes/DynamicGroup.lua
@@ -49,6 +49,7 @@ function WeakAuras.GetPolarCoordinates(x, y, originX, originY)
 end
 
 local function modify(parent, region, data)
+  WeakAuras.FixGroupChildrenOrderForGroup(data);
   -- Scale
   region:SetScale(data.scale and data.scale > 0 and data.scale or 1)
 
@@ -657,16 +658,6 @@ local function modify(parent, region, data)
   end
 
   region:PositionChildren();
-
-  -- Adjust frame-level sorting
-  local frameLevel = 1;
-  for i=1,#region.controlledRegions do
-    local childRegion = region.controlledRegions[i].region
-    if(childRegion) then
-      frameLevel = frameLevel + 4
-      childRegion:SetFrameLevel(frameLevel)
-    end
-  end
 
   function region:Scale(scalex, scaley)
     region:SetWidth((region.currentWidth or 16) * scalex);

--- a/WeakAuras/RegionTypes/Group.lua
+++ b/WeakAuras/RegionTypes/Group.lua
@@ -102,14 +102,7 @@ local function modify(parent, region, data)
   region.try = highest;
 
   -- Adjust frame-level sorting
-  local frameLevel = 1
-  for i=1,#data.controlledChildren do
-    local childRegion = WeakAuras.regions[data.controlledChildren[i]] and WeakAuras.regions[data.controlledChildren[i]].region
-    if(childRegion) then
-      frameLevel = frameLevel + 4
-      childRegion:SetFrameLevel(frameLevel)
-    end
-  end
+  WeakAuras.FixGroupChildrenOrderForGroup(data);
 
   -- Control children (does not happen with "group")
   function region:UpdateBorder(childRegion)

--- a/WeakAuras/RegionTypes/Icon.lua
+++ b/WeakAuras/RegionTypes/Icon.lua
@@ -211,6 +211,7 @@ local function create(parent, data)
     SetFrameLevel(region, level);
     cooldown:SetFrameLevel(level);
     stacksFrame:SetFrameLevel(level + 1);
+    text2Frame:SetFrameLevel(level + 1);
     if (self.__WAGlowFrame) then
       self.__WAGlowFrame:SetFrameLevel(level + 1);
     end

--- a/WeakAuras/RegionTypes/RegionPrototype.lua
+++ b/WeakAuras/RegionTypes/RegionPrototype.lua
@@ -500,6 +500,7 @@ function WeakAuras.regionPrototype.AddExpandFunction(data, region, id, cloneId, 
 
       parent:EnsureTrays();
       region.justCreated = nil;
+      region:SetFrameLevel(WeakAuras.GetFrameLevelFor(id));
       WeakAuras.PerformActions(data, "start", region);
       if not(WeakAuras.Animate("display", data, "start", data.animation.start, region, true, startMainAnimation, nil, cloneId)) then
         startMainAnimation();
@@ -540,6 +541,7 @@ function WeakAuras.regionPrototype.AddExpandFunction(data, region, id, cloneId, 
       if(region.PreShow) then
         region:PreShow();
       end
+      region:SetFrameLevel(WeakAuras.GetFrameLevelFor(id));
       region:Show();
       WeakAuras.PerformActions(data, "start", region);
       if not(WeakAuras.Animate("display", data, "start", data.animation.start, region, true, startMainAnimation, nil, cloneId)) then

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -3248,7 +3248,15 @@ function WeakAuras.Animate(namespace, data, type, anim, region, inverse, onFinis
         anim.alphaType = anim.alphaType or "straight";
         anim.alphaFunc = anim_function_strings[anim.alphaType]
       end
-      alphaFunc = WeakAuras.LoadFunction("return " .. anim.alphaFunc, id);
+      if (anim.alphaFunc) then
+        alphaFunc = WeakAuras.LoadFunction("return " .. anim.alphaFunc, id);
+      else
+        if (region.SetAnimAlpha) then
+          region:SetAnimAlpha(nil);
+        else
+          region:SetAlpha(startAlpha);
+        end
+      end
     else
       if (region.SetAnimAlpha) then
         region:SetAnimAlpha(nil);
@@ -3261,7 +3269,11 @@ function WeakAuras.Animate(namespace, data, type, anim, region, inverse, onFinis
         anim.scaleType = anim.scaleType or "straightScale";
         anim.scaleFunc = anim_function_strings[anim.scaleType]
       end
-      scaleFunc = WeakAuras.LoadFunction("return " .. anim.scaleFunc, id);
+      if (anim.scaleFunc) then
+        scaleFunc = WeakAuras.LoadFunction("return " .. anim.scaleFunc, id);
+      else
+        region:Scale(1, 1);
+      end
     elseif(region.Scale) then
       region:Scale(1, 1);
     end
@@ -3270,7 +3282,11 @@ function WeakAuras.Animate(namespace, data, type, anim, region, inverse, onFinis
         anim.rotateType = anim.rotateType or "straight";
         anim.rotateFunc = anim_function_strings[anim.rotateType]
       end
-      rotateFunc = WeakAuras.LoadFunction("return " .. anim.rotateFunc, id);
+      if (anim.rotateFunc) then
+        rotateFunc = WeakAuras.LoadFunction("return " .. anim.rotateFunc, id);
+      else
+        region:Rotate(startRotation);
+      end
     elseif(region.Rotate) then
       region:Rotate(startRotation);
     end
@@ -3279,7 +3295,11 @@ function WeakAuras.Animate(namespace, data, type, anim, region, inverse, onFinis
         anim.colorType = anim.colorType or "straightColor";
         anim.colorFunc = anim_function_strings[anim.colorType]
       end
-      colorFunc = WeakAuras.LoadFunction("return " .. anim.colorFunc, id);
+      if (anim.colorFunc) then
+        colorFunc = WeakAuras.LoadFunction("return " .. anim.colorFunc, id);
+      else
+        region:ColorAnim(nil);
+      end
     elseif(region.ColorAnim) then
       region:ColorAnim(nil);
     end


### PR DESCRIPTION
The group/dynamic group now simply record the desired frame levels
in their modify function. And get the desired frame level in the
expand function.

Github-Issue: 613