### PR TITLE
Aura updating UI tweaks

### DIFF
--- a/WeakAuras/Transmission.lua
+++ b/WeakAuras/Transmission.lua
@@ -797,7 +797,9 @@ function WeakAuras.RefreshTooltipButtons()
           importButton:SetText(L["Import as Copy"])
         end
       else
-        if #pendingData.newData > 0 then
+        if pendingData.mode == 1 then
+          importButton:SetText(L["Import as Copy"])
+        elseif #pendingData.newData > 0 then
           importButton:SetText(L["Import Group"])
         else
           importButton:SetText(L["Import"])
@@ -1441,6 +1443,7 @@ function WeakAuras.ShowDisplayTooltip(data, children, icon, icons, import, compr
       tinsert(tooltip, {1, " "})
       if type(match) ~= "table" then
         -- there is no difference whatsoever
+        pendingData.mode = 1
         tinsert(tooltip, {1, L["You already have this group/aura, importing will create a duplicate."], 1, 0.82, 0,})
       else
         -- load pendingData

--- a/WeakAuras/Types.lua
+++ b/WeakAuras/Types.lua
@@ -1529,14 +1529,6 @@ WeakAuras.update_categories = {
     label = L["Aura Names"],
   },
   {
-    name = "metadata",
-    fields = {
-      "url",
-      "desc",
-    },
-    label = L["Meta Data"],
-  },
-  {
     name = "display",
     fields = {},
     label = L["Display"],
@@ -1599,6 +1591,14 @@ WeakAuras.update_categories = {
     name = "newchildren",
     fields = {},
     label = L["Add Missing Auras"],
+  },
+  {
+    name = "metadata",
+    fields = {
+      "url",
+      "desc",
+    },
+    label = L["Meta Data"],
   },
 }
 


### PR DESCRIPTION
Implements two requests in #579 - placing update category `metadata` at the bottom of the list, and using the `Import as Copy` phrase for when an identical import is received, and the only possible mode is to import as a copy.

All changes are entirely cosmetic and do not affect the functionality of importing.