### PR TITLE
revert a bad change to an earlier modernization

### DIFF
--- a/WeakAuras/BuffTrigger.lua
+++ b/WeakAuras/BuffTrigger.lua
@@ -1620,7 +1620,7 @@ function BuffTrigger.Modernize(data)
     if (data.internalVersion < 2) then
       if (trigger and trigger.type == "aura") then
         if (trigger.showOn == nil or trigger.showOn == "showOnCooldown" or trigger.showOn == "showOnReady" or trigger.showOn == "showAlways") then
-          trigger.buffShowOn = trigger.inverse and "showOnMissing" or "showOnActive";
+          trigger.showOn = trigger.inverse and "showOnMissing" or "showOnActive";
           trigger.inverse = nil;
         end
       end


### PR DESCRIPTION
An early modernization (v1 -> v2) was unintentionally changed, which unfortunately breaks the v5 -> v6 modernization.
So revert that.

Reported on Discord.