### PR TITLE
Ensure that Options Frame exists before commiting to an import job

### DIFF
--- a/WeakAuras/Transmission.lua
+++ b/WeakAuras/Transmission.lua
@@ -381,12 +381,16 @@ local function importPendingData()
   local indexMap = pendingData.indexMap
 
   -- cleanup the mess
-  WeakAuras.CloseImportExport()
   HideUIPanel(ItemRefTooltip) -- this also wipes pendingData as a side effect
   buttonAnchor:Hide()
   thumbnailAnchor.currentThumbnail:Hide()
   thumbnailAnchor.currentThumbnail = nil
-  if not imports then return end
+  if imports and WeakAuras.LoadOptions() then
+    WeakAuras.ShowOptions()
+  else
+    return
+  end
+  WeakAuras.CloseImportExport()
   WeakAuras.SetImporting(true)
 
   -- import parent/single aura
@@ -550,9 +554,6 @@ local function importPendingData()
     WeakAuras.UpdateDisplayButton(parentData)
     WeakAuras.ReloadGroupRegionOptions(parentData)
     WeakAuras.SortDisplayButtons()
-  end
-  if not WeakAuras.IsOptionsOpen() then
-    WeakAuras.ShowOptions()
   end
   WeakAuras.SetImporting(false)
   WeakAuras.PickDisplay(installedData[0].id)


### PR DESCRIPTION
If a user clicks on a link in chat, then the import tooltip will appear and allow them to import an aura. This is fine, but importPendingData calls WeakAuras.CloseImportExport, which assumes that the options frame has been created. So, Load WeakAurasOptions and Show the options Frame, and if that fails then back out of the import job.

All of this would be solved if we weren't abusing the tooltip like we are.
Issue reported on Discord.