### PR TITLE
Fix crop for Circular Progress Textures

### DIFF
--- a/WeakAuras/RegionTypes/ProgressTexture.lua
+++ b/WeakAuras/RegionTypes/ProgressTexture.lua
@@ -37,7 +37,6 @@ local default = {
   user_y = 0,
   crop_x = 0.41,
   crop_y = 0.41,
-  crop = 0.41,
   rotation = 0,
   selfPoint = "CENTER",
   anchorPoint = "CENTER",
@@ -1040,7 +1039,6 @@ local function modify(parent, region, data)
   region.mirror_h = data.mirror;
   region.scale_x = 1 + (data.crop_x or 0.41);
   region.scale_y = 1 + (data.crop_y or 0.41);
-  region.scale = 1 + (data.crop or 0.41);
   region.rotation = data.rotation or 0;
   region.user_x = -1 * (data.user_x or 0);
   region.user_y = data.user_y or 0;

--- a/WeakAurasOptions/RegionOptions/ProgressTexture.lua
+++ b/WeakAurasOptions/RegionOptions/ProgressTexture.lua
@@ -160,7 +160,6 @@ local function createOptions(id, data)
         end
         WeakAuras.ResetMoverSizer();
       end,
-      hidden = function() return data.orientation == "CLOCKWISE" or data.orientation == "ANTICLOCKWISE"; end
     },
     crop_y = {
       type = "range",
@@ -185,33 +184,6 @@ local function createOptions(id, data)
         end
         WeakAuras.ResetMoverSizer();
       end,
-      hidden = function() return data.orientation == "CLOCKWISE" or data.orientation == "ANTICLOCKWISE"; end
-    },
-    crop = {
-      type = "range",
-      name = L["Crop"],
-      order = 47,
-      min = 0,
-      softMax = 2,
-      bigStep = 0.01,
-      isPercent = true,
-      set = function(info, v)
-        data.height = data.height * ((1 + data.crop or 0) / (1 + v));
-        data.width = data.width * ((1 + data.crop or 0) / (1 + v));
-        data.crop = v;
-        WeakAuras.Add(data);
-        WeakAuras.SetThumbnail(data);
-        WeakAuras.SetIconNames(data);
-        if(data.parent) then
-          local parentData = WeakAuras.GetData(data.parent);
-          if(parentData) then
-            WeakAuras.Add(parentData);
-            WeakAuras.SetThumbnail(parentData);
-          end
-        end
-        WeakAuras.ResetMoverSizer();
-      end,
-      hidden = function() return data.orientation ~= "CLOCKWISE" and data.orientation ~= "ANTICLOCKWISE"; end
     },
     rotation = {
       type = "range",


### PR DESCRIPTION
A rare case where fixing a bug involves only removing code.

Apparently at some point circular progress textures were meant to use
a different crop setting that applied to both x and y. While the option
was visible the actual aura used the crop_x/crop_y settings shared by
normal progress textures.

Thus simply removing the superflous option and making the normal crop
settings fixes the bug.

Github-Issue: 674