### PR TITLE
replace GetHeight with GetStringHeight

### DIFF
--- a/WeakAuras/RegionTypes/Text.lua
+++ b/WeakAuras/RegionTypes/Text.lua
@@ -84,7 +84,7 @@ local function modify(parent, region, data)
   text:SetPoint("CENTER", UIParent, "CENTER");
 
   region.width = text:GetWidth();
-  region.height = text:GetHeight();
+  region.height = text:GetStringHeight();
   region:SetWidth(region.width);
   region:SetHeight(region.height);
 
@@ -111,10 +111,10 @@ local function modify(parent, region, data)
         text:SetText(textStr);
       end
 
-      local height = text:GetHeight();
+      local height = text:GetStringHeight();
 
       if(region.height ~= height) then
-        region.height = text:GetHeight();
+        region.height = text:GetStringHeight();
         region:SetHeight(region.height);
         if(data.parent and WeakAuras.regions[data.parent].region.ControlChildren) then
           WeakAuras.regions[data.parent].region:ControlChildren();
@@ -132,7 +132,7 @@ local function modify(parent, region, data)
         end
       end
       local width = text:GetWidth();
-      local height = text:GetHeight();
+      local height = text:GetStringHeight();
       if(width ~= region.width or height ~= region.height ) then
         region.width = width;
         region.height = height;
@@ -282,7 +282,7 @@ local function fallbackmodify(parent, region, data)
   text:SetPoint("CENTER", region, "CENTER");
 
   region:SetWidth(text:GetWidth());
-  region:SetHeight(text:GetHeight());
+  region:SetHeight(text:GetStringHeight());
 end
 
 WeakAuras.RegisterRegionType("fallback", create, fallbackmodify, default);


### PR DESCRIPTION
Blizzard's anchoring code changed with BfA and it is suggested to use GetStringHeight for FontStrings.

From IRC:
```
[23:49:10] nevcairiel: Stanzilla: basically dont use GetHeight on FontStrings, use GetStringHeight instead
[23:50:00] nevcairiel: the big performance issue was fixed in beta already after i reported it
[23:52:15] nevcairiel: its only an issue if the fontstring is not fully anchored  yet
[23:52:33] nevcairiel: because it then tries to resolve anchors that are not valid yet and does a lot of extra work
```