### PR TITLE
Don't schedule a CooldownScan if the remaingtime can't decrease anymore

### DIFF
--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -2035,7 +2035,7 @@ WeakAuras.event_prototypes = {
         local ret2 = [[
           local remaining = expirationTime > 0 and (expirationTime - GetTime()) or 0;
           local remainingCheck = %s;
-          if(remaining >= remainingCheck) then
+          if(remaining >= remainingCheck and remaining > 0) then
             WeakAuras.ScheduleCooldownScan(expirationTime - remainingCheck);
           end
         ]];
@@ -2386,7 +2386,7 @@ WeakAuras.event_prototypes = {
           local expirationTime = startTime + duration
           local remaining = expirationTime > 0 and (expirationTime - GetTime()) or 0;
           local remainingCheck = %s;
-          if(remaining >= remainingCheck) then
+          if(remaining >= remainingCheck and remaining > 0) then
             WeakAuras.ScheduleCooldownScan(expirationTime - remainingCheck);
           end
         ]];
@@ -2504,7 +2504,7 @@ WeakAuras.event_prototypes = {
           local expirationTime = startTime + duration
           local remaining = expirationTime > 0 and (expirationTime - GetTime()) or 0;
           local remainingCheck = %s;
-          if(remaining >= remainingCheck) then
+          if(remaining >= remainingCheck and remaining > 0) then
             WeakAuras.ScheduleCooldownScan(expirationTime - remainingCheck);
           end
         ]];
@@ -3899,7 +3899,7 @@ WeakAuras.event_prototypes = {
         local expirationTime = startTime + duration
         local remaining = expirationTime - GetTime();
         local remainingCheck = %s;
-        if(remaining >= remainingCheck) then
+        if(remaining >= remainingCheck and remaining > 0) then
           WeakAuras.ScheduleCooldownScan(expirationTime - remainingCheck);
         end
       ]];
@@ -4284,7 +4284,7 @@ WeakAuras.event_prototypes = {
           local expirationTime = endTime and endTime > 0 and (endTime / 1000) or 0;
           local remaining = expirationTime - GetTime();
           local remainingCheck = %s;
-          if(remaining >= remainingCheck) then
+          if(remaining >= remainingCheck and remaining > 0) then
             WeakAuras.ScheduleCastCheck(expirationTime - remainingCheck);
           end
         ]];


### PR DESCRIPTION
The aura in the ticket has the remaining time option checked, without
a time. Since thus the remainingTime would be 0 and the remainingCheck
would be 0, this would lead to excessive ScheduleCooldownScan calls.

If the remaingtime is already 0 (or negative), it won't decrease
anymore, so scheduling any checks is pointless.

Github-Issue: 710