### PR TITLE
Create an Aura Environment for group regions as well.

### DIFF
--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -2583,6 +2583,7 @@ local function pAdd(data)
     error("Improper arguments to WeakAuras.Add - id not defined");
   elseif (data.controlledChildren) then
     db.displays[id] = data;
+    WeakAuras.CreateAuraEnvironment(id)
     WeakAuras.SetRegion(data);
   else
     if (not data.triggers.activeTriggerMode or data.triggers.activeTriggerMode > #data.triggers) then


### PR DESCRIPTION
This is necessary because the Animated Expand & Collapse feature animates the dynamic group region itself.
This eventually calls ActivateAuraEnvironment, which tries to get the aura environment for the dynamic group.
Before the aura_env support was split off, this would fallback to an empty table, which is rather wasteful since a new extra table would be
created every frame for every dynamic group which is animating an expand or collapse.