### PR TITLE
revert back to lazy aura environment creation

### DIFF
--- a/WeakAuras/AuraEnvironment.lua
+++ b/WeakAuras/AuraEnvironment.lua
@@ -105,7 +105,7 @@ function WeakAuras.IsEnvironmentInitialized(id)
   return environment_initialized[id]
 end
 
-function WeakAuras.CreateAuraEnvironment(id)
+function WeakAuras.ResetAuraEnvironment(id)
   aura_environments[id] = {}
   environment_initialized[id] = false
 end
@@ -132,6 +132,7 @@ function WeakAuras.ActivateAuraEnvironment(id, cloneId, state)
   else
     if environment_initialized[id] then
       -- Point the current environment to the correct table
+      aura_environments[id] = aura_environments[id] or {}
       current_aura_env = aura_environments[id]
       current_aura_env.cloneId = cloneId
       current_aura_env.state = state
@@ -141,7 +142,7 @@ function WeakAuras.ActivateAuraEnvironment(id, cloneId, state)
     else
       -- Reset the environment if we haven't completed init, i.e. if we add/update/replace a WeakAura
       environment_initialized[id] = true
-      wipe(aura_environments[id])
+      aura_environments[id] = {}
       current_aura_env = aura_environments[id]
       current_aura_env.cloneId = cloneId
       current_aura_env.state = state

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -2583,12 +2583,14 @@ local function pAdd(data)
     error("Improper arguments to WeakAuras.Add - id not defined");
   elseif (data.controlledChildren) then
     db.displays[id] = data;
-    WeakAuras.CreateAuraEnvironment(id)
+    WeakAuras.ResetAuraEnvironment(id)
     WeakAuras.SetRegion(data);
   else
+
     if (not data.triggers.activeTriggerMode or data.triggers.activeTriggerMode > #data.triggers) then
       data.triggers.activeTriggerMode = WeakAuras.trigger_modes.first_active;
     end
+    WeakAuras.ResetAuraEnvironment(id)
 
     for _, triggerSystem in pairs(triggerSystems) do
       triggerSystem.Add(data);
@@ -2636,8 +2638,6 @@ local function pAdd(data)
       triggerCount = 0,
       activatedConditions = {},
     };
-
-    WeakAuras.CreateAuraEnvironment(id)
 
     db.displays[id] = data;
 


### PR DESCRIPTION
Unfortunately, pAdd does still need to flag the aura as not initialized (since every change to aura data which would require a re-initialization goes through Add), so we do still need a method to do that, so right now it kind of does both.