### PR TITLE
ensure that the trigger reference actually refers to a trigger

### DIFF
--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -2446,7 +2446,7 @@ function WeakAuras.Modernize(data)
   if data.internalVersion < 9 then
     local function repairCheck(check)
       if check and check.variable == "buffed" then
-        local trigger = check.trigger and data.triggers[check.trigger].trigger;
+        local trigger = check.trigger and data.triggers[check.trigger] and data.triggers[check.trigger].trigger;
         if (trigger) then
           if(trigger.buffShowOn == "showOnActive") then
             check.variable = "show";


### PR DESCRIPTION
It seems that somehow some people have gotten auras with conditions that refer to nonexistent triggers. No idea how that happened, but we can guard against that in this modernization easily enough.
WoWAce Ticket 1227