### PR TITLE
fix WA_IterateGroupMembers again

### DIFF
--- a/WeakAuras/AuraEnvironment.lua
+++ b/WeakAuras/AuraEnvironment.lua
@@ -25,7 +25,7 @@ end
 
 -- Function to assist iterating group members whether in a party or raid.
 local WA_IterateGroupMembers = function(reversed, forceParty)
-  local unit  = (not forceParty and IsInRaid()) and 'raid' or 'party'
+  local unit = (not forceParty and IsInRaid()) and 'raid' or 'party'
   local numGroupMembers = unit == 'party' and GetNumSubgroupMembers() or GetNumGroupMembers()
   local i = reversed and numGroupMembers or (unit == 'party' and 0 or 1)
   return function()

--- a/WeakAuras/AuraEnvironment.lua
+++ b/WeakAuras/AuraEnvironment.lua
@@ -26,7 +26,7 @@ end
 -- Function to assist iterating group members whether in a party or raid.
 local WA_IterateGroupMembers = function(reversed, forceParty)
   local unit  = (not forceParty and IsInRaid()) and 'raid' or 'party'
-  local numGroupMembers = (forceParty and GetNumSubgroupMembers()  or GetNumGroupMembers())
+  local numGroupMembers = unit == 'party' and GetNumSubgroupMembers() or GetNumGroupMembers()
   local i = reversed and numGroupMembers or (unit == 'party' and 0 or 1)
   return function()
     local ret


### PR DESCRIPTION
the previous fix caused iterations in a party to have an extra unexpected unit, like party5. For whatever reason, GetNumGroupMembers() is inconsistent with GetNumSubgroupMembers(), and GetNumSubGroupMembers() never seems to count the player itself. Since this iterator already squeezes in the player as party0, we can just use GetNumSubgroupMembers() for all party iterations