### PR TITLE
Change Zoom property by Condition

### DIFF
--- a/WeakAuras/RegionTypes/Icon.lua
+++ b/WeakAuras/RegionTypes/Icon.lua
@@ -121,7 +121,8 @@ local properties = {
     min = 0,
     max = 1,
     step = 0.01,
-    default = 0
+    default = 0,
+    isPercent = true
   },
 };
 

--- a/WeakAuras/RegionTypes/Icon.lua
+++ b/WeakAuras/RegionTypes/Icon.lua
@@ -475,20 +475,10 @@ local function modify(parent, region, data)
   end
 
   function region:UpdateSize()
-    local mirror_h, mirror_v, width, height;
-    local scalex = region.scalex;
-    local scaley = region.scaley;
-    if(scalex < 0) then
-      mirror_h = true;
-      scalex = scalex * -1;
-    end
-    width = region.width * scalex;
+    local width = region.width * math.abs(region.scalex);
+    local height = region.height * math.abs(region.scaley);
+
     region:SetWidth(width);
-    if(scaley < 0) then
-      mirror_v = true;
-      scaley = scaley * -1;
-    end
-    height = region.height * scaley;
     region:SetHeight(height);
     if MSQ then
       button:SetWidth(width);
@@ -497,12 +487,26 @@ local function modify(parent, region, data)
     end
     icon:SetAllPoints();
 
+    region:UpdateTexCoords();
+  end
+  
+  function region:UpdateTexCoords()
+    local mirror_h = region.scalex < 0; 
+    local mirror_v = region.scaley < 0;
+
     local texWidth = 1 - 0.5 * region.zoom;
     local aspectRatio
-    if (not region.keepAspectRatio or width == 0 or height == 0) then
-      aspectRatio = 1
+    if not region.keepAspectRatio then
+      aspectRatio = 1;
     else
-      aspectRatio = width / height;
+      local width = region.width * math.abs(region.scalex);
+      local height = region.height * math.abs(region.scaley);
+
+      if width == 0 or height == 0 then
+        aspectRatio = 1;
+      else
+        aspectRatio = width / height;
+      end
     end
 
     local ulx, uly, llx, lly, urx, ury, lrx, lry = GetTexCoord(region, texWidth, aspectRatio)
@@ -571,7 +575,7 @@ local function modify(parent, region, data)
   
   function region:SetZoom(zoom)
     region.zoom = zoom;
-    region:UpdateSize();
+    region:UpdateTexCoords();
   end
 
   function region:SetGlow(showGlow)

--- a/WeakAuras/RegionTypes/Icon.lua
+++ b/WeakAuras/RegionTypes/Icon.lua
@@ -114,6 +114,15 @@ local properties = {
     setter = "SetInverse",
     type = "bool"
   },
+  zoom = {
+    display = L["Zoom"],
+    setter = "SetZoom",
+    type = "number",
+    min = 0,
+    max = 1,
+    step = 0.01,
+    default = 0
+  },
 };
 
 WeakAuras.regionPrototype.AddProperties(properties, default);
@@ -556,6 +565,11 @@ local function modify(parent, region, data)
 
   function region:SetInverse(inverse)
     cooldown:SetReverse(not inverse);
+  end
+  
+  function region:SetZoom(zoom)
+    data.zoom = zoom;
+    region:UpdateSize();
   end
 
   function region:SetGlow(showGlow)

--- a/WeakAuras/RegionTypes/Icon.lua
+++ b/WeakAuras/RegionTypes/Icon.lua
@@ -319,12 +319,13 @@ local function modify(parent, region, data)
   region.scalex = 1;
   region.scaley = 1;
   region.keepAspectRatio = data.keepAspectRatio;
+  region.zoom = data.zoom;
   icon:SetAllPoints();
 
   configureText(stacks, icon, data.text1Enabled, data.text1Point, data.width, data.height, data.text1Containment, data.text1Font, data.text1FontSize, data.text1FontFlags, data.text1Color);
   configureText(text2, icon, data.text2Enabled, data.text2Point, data.width, data.height, data.text2Containment, data.text2Font, data.text2FontSize, data.text2FontFlags, data.text2Color);
 
-  local texWidth = 1 - data.zoom * 0.5;
+  local texWidth = 1 - region.zoom * 0.5;
   local aspectRatio = region.keepAspectRatio and region.width / region.height or 1;
 
   icon:SetTexCoord(GetTexCoord(region, texWidth, aspectRatio))
@@ -496,7 +497,7 @@ local function modify(parent, region, data)
     end
     icon:SetAllPoints();
 
-    local texWidth = 1 - 0.5 * data.zoom;
+    local texWidth = 1 - 0.5 * region.zoom;
     local aspectRatio
     if (not region.keepAspectRatio or width == 0 or height == 0) then
       aspectRatio = 1
@@ -569,7 +570,7 @@ local function modify(parent, region, data)
   end
   
   function region:SetZoom(zoom)
-    data.zoom = zoom;
+    region.zoom = zoom;
     region:UpdateSize();
   end
 

--- a/WeakAurasOptions/ConditionOptions.lua
+++ b/WeakAurasOptions/ConditionOptions.lua
@@ -398,6 +398,7 @@ local function addControlsForChange(args, order, data, conditionVariable, condit
         args["condition" .. i .. "value" .. j].softMax = properties.softMax;
         args["condition" .. i .. "value" .. j].step = properties.step;
         args["condition" .. i .. "value" .. j].bigStep = properties.bigStep;
+        args["condition" .. i .. "value" .. j].isPercent = properties.isPercent;
       else
         args["condition" .. i .. "value" .. j].type = "input";
         args["condition" .. i .. "value" .. j].validate = WeakAuras.ValidateNumeric;


### PR DESCRIPTION
I like to have the zoom property set to 30% for non glowing icons but if they glow it looks better with 0% zoom, so I added an option to also set the zoom property of an icon via the condition tab.

I used the 'UpdateSize' function to apply the change, it seems a bit heavy but my goal was to keep the change as small as possible. I'm sure there is a better (less CPU heavy) way of doing this.