### PR TITLE
Tweak dynFrame timings

### DIFF
--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -4010,14 +4010,9 @@ do
   dynFrame.frame:Hide();
   local start = debugprofilestop()
   dynFrame.frame:SetScript("OnUpdate", function(self, elapsed)
-    -- Start timing
-    local hasData = true;
-
+    local hasData = false
     -- Resume as often as possible (Limit to 16ms per frame -> 60 FPS)
-    while (debugprofilestop() - start < 16 and hasData) do
-      -- Stop loop without data
-      hasData = false;
-
+    repeat
       -- Resume all coroutines
       for name, func in pairs(dynFrame.update) do
         -- Loop has data
@@ -4033,7 +4028,8 @@ do
           dynFrame:RemoveAction(name);
         end
       end
-    end
+    until not hasData or debugprofilestop() - start >= 16
+    -- update measure point
     start = debugprofilestop()
   end);
 end

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -4008,9 +4008,9 @@ do
 
   -- Setup frame
   dynFrame.frame:Hide();
+  local start = debugprofilestop()
   dynFrame.frame:SetScript("OnUpdate", function(self, elapsed)
     -- Start timing
-    local start = debugprofilestop();
     local hasData = true;
 
     -- Resume as often as possible (Limit to 16ms per frame -> 60 FPS)
@@ -4034,6 +4034,7 @@ do
         end
       end
     end
+    start = debugprofilestop()
   end);
 end
 


### PR DESCRIPTION
the current usage will let the frame be redrawn after it has been working for 16 milliseconds. But this doesn't imply 60 fps, since it will go frame update -> 16ms of work from weakauras -> next frame update.
So, instead, measure the time difference between last frame, and now. This will ensure that weakauras by itself will not consume too much cpu time per frame, though fps might still drop below 60 if another addon has work to do after weakauras finishes its threads.