### PR TITLE
Dynamic group rewrite

### DIFF
--- a/WeakAuras/RegionTypes/DynamicGroup.lua
+++ b/WeakAuras/RegionTypes/DynamicGroup.lua
@@ -48,56 +48,74 @@ function WeakAuras.GetPolarCoordinates(x, y, originX, originY)
   return r, theta;
 end
 
+local selfPoints = {
+  default = "CENTER",
+  RIGHT = function(data)
+    if data.align  == "LEFT" then
+      return "TOPLEFT"
+    elseif data.align == "RIGHT" then
+      return "BOTTOMLEFT"
+    else
+      return "LEFT"
+    end
+  end,
+  LEFT = function(data)
+    if data.align  == "LEFT" then
+      return "TOPRIGHT"
+    elseif data.align == "RIGHT" then
+      return "BOTTOMRIGHT"
+    else
+      return "RIGHT"
+    end
+  end,
+  UP = function(data)
+    if data.align == "LEFT" then
+      return "BOTTOMLEFT"
+    elseif data.align == "RIGHT" then
+      return "BOTTOMRIGHT"
+    else
+      return "BOTTOM"
+    end
+  end,
+  DOWN = function(data)
+    if data.align == "LEFT" then
+      return "TOPLEFT"
+    elseif data.align == "RIGHT" then
+      return "TOPRIGHT"
+    else
+      return "TOP"
+    end
+  end,
+  HORIZONTAL = function(data)
+    if data.align == "LEFT" then
+      return "TOP"
+    elseif data.align == "RIGHT" then
+      return "BOTTOM"
+    else
+      return "CENTER"
+    end
+  end,
+  VERTICAL = function(data)
+    if data.align == "LEFT" then
+      return "LEFT"
+    elseif data.align == "RIGHT" then
+      return "RIGHT"
+    else
+      return "CENTER"
+    end
+  end,
+  CIRCLE = "CENTER",
+  COUNTERCIRCLE = "CENTER",
+}
+
 local function modify(parent, region, data)
   WeakAuras.FixGroupChildrenOrderForGroup(data);
   -- Scale
   region:SetScale(data.scale and data.scale > 0 and data.scale or 1)
 
-  local selfPoint;
-  if(data.grow == "RIGHT") then
-    selfPoint = "LEFT";
-    if(data.align == "LEFT") then
-      selfPoint = "TOP"..selfPoint;
-    elseif(data.align == "RIGHT") then
-      selfPoint = "BOTTOM"..selfPoint;
-    end
-  elseif(data.grow == "LEFT") then
-    selfPoint = "RIGHT";
-    if(data.align == "LEFT") then
-      selfPoint = "TOP"..selfPoint;
-    elseif(data.align == "RIGHT") then
-      selfPoint = "BOTTOM"..selfPoint;
-    end
-  elseif(data.grow == "UP") then
-    selfPoint = "BOTTOM";
-    if(data.align == "LEFT") then
-      selfPoint = selfPoint.."LEFT";
-    elseif(data.align == "RIGHT") then
-      selfPoint = selfPoint.."RIGHT";
-    end
-  elseif(data.grow == "DOWN" ) then
-    selfPoint = "TOP";
-    if(data.align == "LEFT") then
-      selfPoint = selfPoint.."LEFT";
-    elseif(data.align == "RIGHT") then
-      selfPoint = selfPoint.."RIGHT";
-    end
-  elseif(data.grow == "HORIZONTAL") then
-    selfPoint = "CENTER";
-    if(data.align == "LEFT") then
-      selfPoint = "TOP";
-    elseif(data.align == "RIGHT") then
-      selfPoint = "BOTTOM";
-    end
-  elseif(data.grow == "VERTICAL") then
-    selfPoint = "CENTER";
-    if(data.align == "LEFT") then
-      selfPoint = "LEFT";
-    elseif(data.align == "RIGHT") then
-      selfPoint = "RIGHT";
-    end
-  elseif(data.grow == "CIRCLE" or data.grow == "COUNTERCIRCLE") then
-    selfPoint = "CENTER";
+  local selfPoint = selfPoints[data.grow] or selfPoints.default
+  if type(selfPoint) == "function" then
+    selfPoint = selfPoint(data)
   end
   data.selfPoint = selfPoint;
 

--- a/WeakAuras/RegionTypes/DynamicGroup.lua
+++ b/WeakAuras/RegionTypes/DynamicGroup.lua
@@ -33,6 +33,7 @@ local function create(parent)
   region.background = background;
 
   region.trays = {};
+  region.suspended = 0
 
   WeakAuras.regionPrototype.create(region);
 
@@ -545,7 +546,7 @@ local function modify(parent, region, data)
   end
 
   function region:Suspend()
-    self.suspended = (self.suspended or 0) + 1;
+    self.suspended = self.suspended + 1;
   end
 
   function region:Resume()
@@ -560,7 +561,7 @@ local function modify(parent, region, data)
   end
 
   function region:ControlChildren()
-    if(self.suspended and self.suspended > 0) then
+    if self.suspended > 0 then
       self.needToControlChildren = true;
       return;
     end

--- a/WeakAuras/RegionTypes/DynamicGroup.lua
+++ b/WeakAuras/RegionTypes/DynamicGroup.lua
@@ -314,8 +314,6 @@ local function modify(parent, region, data)
     end
   end
 
-  region:EnsureTrays();
-
   function region:DoResize()
     local numVisible = 0;
     local minX, maxX, minY, maxY;

--- a/WeakAuras/RegionTypes/DynamicGroup.lua
+++ b/WeakAuras/RegionTypes/DynamicGroup.lua
@@ -634,34 +634,24 @@ local function modify(parent, region, data)
   region.growFunc = grower(data)
 
   function region:PositionActiveRegions()
-    region:EnsureTrays();
-    local childData, childRegion;
-    local activeRegions = {}
-    for index, regionData in pairs(region.controlledRegions) do
-      childData = regionData.data;
-      childRegion = regionData.region;
-      if(childData and childRegion) then
-        if(childRegion.toShow or  WeakAuras.IsAnimating(childRegion) == "finish") then
-          activeRegions[#activeRegions] = regionData
-        end
-      end
-    end
     local newPositions = {}
-    region.growFunc(newPositions, activeRegions)
-    region.numVisible = 0
-    for index, activeRegion in ipairs(activeRegions) do
+    local positionsByKey = {}
+    self.growFunc(newPositions, self.activeRegions)
+    self.numVisible = 0
+    for index, regionData in ipairs(self.activeRegions) do
       local pos = newPositions[index] or {0, 0, true}
       pos[1] = type(pos[1]) == "number" and pos[1] or 0
       pos[2] = type(pos[2]) == "number" and pos[2] or 0
-      local tray = region.trays[activeRegion.key]
-      tray:ClearAllPoints()
-      tray:SetPoint(selfPoint, region, selfPoint, pos[1], pos[2])
+      local tray = regionData.tray
+      tray:SetPoint(selfPoint, pos[1], pos[2])
       tray:SetShown(not pos[3])
-      activeRegion.hidden = pos[3]
+      tray:SetWidth(regionData.data.width or regionData.region.width)
+      tray:SetHeight(regionData.data.height or regionData.region.height)
+      regionData.hidden = pos[3]
       self.numVisible = self.numVisible + (pos[3] and 0 or 1)
+      positionsByKey[regionData.key] = pos
     end
-
-    region:DoResize();
+    self.activePositions = positionsByKey
   end
 
   function region:DoResize()

--- a/WeakAuras/RegionTypes/DynamicGroup.lua
+++ b/WeakAuras/RegionTypes/DynamicGroup.lua
@@ -665,26 +665,25 @@ local function modify(parent, region, data)
   end
 
   function region:DoResize()
-    local numVisible = 0;
-    local minX, maxX, minY, maxY;
-    for index, regionData in pairs(region.controlledRegions) do
-      local childId = regionData.id;
-      local childData = regionData.data;
-      local childRegion = regionData.region;
-      if(childData and childRegion) then
-        if(childRegion.toShow or  WeakAuras.IsAnimating(childRegion) == "finish") then
-          numVisible = numVisible + 1;
-          local regionLeft, regionRight, regionTop, regionBottom = childRegion:GetLeft(), childRegion:GetRight(), childRegion:GetTop(), childRegion:GetBottom();
-          if(regionLeft and regionRight and regionTop and regionBottom) then
-            minX = minX and min(regionLeft, minX) or regionLeft;
-            maxX = maxX and max(regionRight, maxX) or regionRight;
-            minY = minY and min(regionBottom, minY) or regionBottom;
-            maxY = maxY and max(regionTop, maxY) or regionTop;
+    local numVisible = self.numVisible
+    if(numVisible > 0) then
+      local minX, maxX, minY, maxY;
+      for index, regionData in pairs(region.activeRegions) do
+        local childId = regionData.id;
+        local childData = regionData.data;
+        local childRegion = regionData.region;
+        if(childData and childRegion) then
+          if(not regionData.hidden or  WeakAuras.IsAnimating(childRegion) == "finish") then
+            local regionLeft, regionRight, regionTop, regionBottom = childRegion:GetLeft(), childRegion:GetRight(), childRegion:GetTop(), childRegion:GetBottom();
+            if(regionLeft and regionRight and regionTop and regionBottom) then
+              minX = minX and min(regionLeft, minX) or regionLeft;
+              maxX = maxX and max(regionRight, maxX) or regionRight;
+              minY = minY and min(regionBottom, minY) or regionBottom;
+              maxY = maxY and max(regionTop, maxY) or regionTop;
+            end
           end
         end
       end
-    end
-    if(numVisible > 0) then
       minX, maxX, minY, maxY = minX or 0, maxX or 0, minY or 0, maxY or 0;
       if(data.grow == "CIRCLE" or data.grow == "COUNTERCIRCLE") then
         local originX, originY = region:GetCenter();
@@ -741,7 +740,6 @@ local function modify(parent, region, data)
       region.previousWidth = 1;
       region.previousHeight = 1;
     end
-
     if(WeakAuras.IsOptionsOpen()) then
       WeakAuras.OptionsFrame().moversizer:ReAnchor();
     end

--- a/WeakAuras/RegionTypes/DynamicGroup.lua
+++ b/WeakAuras/RegionTypes/DynamicGroup.lua
@@ -771,89 +771,88 @@ local function modify(parent, region, data)
     local previous = self.activePositions or {}
     self:PositionActiveRegions()
     self:DoResize()
-    if data.animate then
-      local previousPreviousX, previousPreviousY;
-      for index, regionData in pairs(region.activeRegions) do
-        local childId = regionData.id;
-        local childData = regionData.data;
-        local childRegion = regionData.region;
-        if(childData and childRegion) then
-          if (childRegion.toShow or WeakAuras.IsAnimating(childRegion) == "finish") then
-            childRegion:Show();
-          end
-          local xOffset, yOffset = regionData.tray:GetCenter();
-          xOffset = xOffset or 0;
-          yOffset = yOffset or 0;
-          local previousX, previousY = previous[regionData.key] and previous[regionData.key].x or previousPreviousX or 0, previous[regionData.key] and previous[regionData.key].y or previousPreviousY or 0;
-          local xDelta, yDelta = previousX - xOffset, previousY - yOffset;
-          previousPreviousX, previousPreviousY = previousX, previousY;
-          if((not regionData.hidden and WeakAuras.IsAnimating(childRegion) == "finish") and not(abs(xDelta) < 0.1 and abs(yDelta) == 0.1)) then
-            local anim;
-            if(data.grow == "CIRCLE" or data.grow == "COUNTERCIRCLE") then
-              local originX, originY = region:GetCenter();
-              local radius1, previousAngle = WeakAuras.GetPolarCoordinates(previousX, previousY, originX, originY);
-              local radius2, newAngle = WeakAuras.GetPolarCoordinates(xOffset, yOffset, originX, originY);
-              local dAngle = newAngle - previousAngle;
-              dAngle = (
-                (dAngle > 180 and dAngle - 360)
-                or (dAngle < -180 and dAngle + 360)
-                or dAngle
-                );
-              if(math.abs(radius1 - radius2) > 0.1) then
-                local translateFunc = [[
-                                  function(progress, _, _, previousAngle, dAngle)
-                                      local previousRadius, dRadius = %f, %f;
-                                      local radius = previousRadius + (1 - progress) * dRadius;
-                                      local angle = previousAngle + (1 - progress) * dAngle;
-                                      return cos(angle) * radius, sin(angle) * radius;
-                                  end
-                              ]]
-                anim = {
-                  type = "custom",
-                  duration = 0.2,
-                  use_translate = true,
-                  translateType = "custom",
-                  translateFunc = translateFunc:format(radius1, radius2 - radius1),
-                  x = previousAngle,
-                  y = dAngle
-                };
-              else
-                local translateFunc = [[
-                                  function(progress, _, _, previousAngle, dAngle)
-                                      local radius = %f;
-                                      local angle = previousAngle + (1 - progress) * dAngle;
-                                      return cos(angle) * radius, sin(angle) * radius;
-                                  end
-                              ]]
-                anim = {
-                  type = "custom",
-                  duration = 0.2,
-                  use_translate = true,
-                  translateType = "custom",
-                  translateFunc = translateFunc:format(radius1),
-                  x = previousAngle,
-                  y = dAngle
-                };
-              end
-            end
-            if not(anim) then
+
+    local previousPreviousX, previousPreviousY;
+    for index, regionData in pairs(region.activeRegions) do
+      local childId = regionData.id;
+      local childData = regionData.data;
+      local childRegion = regionData.region;
+      if(childData and childRegion) then
+        if (childRegion.toShow or WeakAuras.IsAnimating(childRegion) == "finish") then
+          childRegion:Show();
+        end
+        local xOffset, yOffset = regionData.tray:GetCenter();
+        xOffset = xOffset or 0;
+        yOffset = yOffset or 0;
+        local previousX, previousY = previous[regionData.key] and previous[regionData.key].x or previousPreviousX or 0, previous[regionData.key] and previous[regionData.key].y or previousPreviousY or 0;
+        local xDelta, yDelta = previousX - xOffset, previousY - yOffset;
+        previousPreviousX, previousPreviousY = previousX, previousY;
+        if data.animate and (not regionData.hidden and WeakAuras.IsAnimating(childRegion) == "finish") and not(abs(xDelta) < 0.1 and abs(yDelta) == 0.1) then
+          local anim;
+          if(data.grow == "CIRCLE" or data.grow == "COUNTERCIRCLE") then
+            local originX, originY = region:GetCenter();
+            local radius1, previousAngle = WeakAuras.GetPolarCoordinates(previousX, previousY, originX, originY);
+            local radius2, newAngle = WeakAuras.GetPolarCoordinates(xOffset, yOffset, originX, originY);
+            local dAngle = newAngle - previousAngle;
+            dAngle = (
+              (dAngle > 180 and dAngle - 360)
+              or (dAngle < -180 and dAngle + 360)
+              or dAngle
+              );
+            if(math.abs(radius1 - radius2) > 0.1) then
+              local translateFunc = [[
+                                function(progress, _, _, previousAngle, dAngle)
+                                    local previousRadius, dRadius = %f, %f;
+                                    local radius = previousRadius + (1 - progress) * dRadius;
+                                    local angle = previousAngle + (1 - progress) * dAngle;
+                                    return cos(angle) * radius, sin(angle) * radius;
+                                end
+                            ]]
               anim = {
                 type = "custom",
                 duration = 0.2,
                 use_translate = true,
-                x = xDelta,
-                y = yDelta
+                translateType = "custom",
+                translateFunc = translateFunc:format(radius1, radius2 - radius1),
+                x = previousAngle,
+                y = dAngle
+              };
+            else
+              local translateFunc = [[
+                                function(progress, _, _, previousAngle, dAngle)
+                                    local radius = %f;
+                                    local angle = previousAngle + (1 - progress) * dAngle;
+                                    return cos(angle) * radius, sin(angle) * radius;
+                                end
+                            ]]
+              anim = {
+                type = "custom",
+                duration = 0.2,
+                use_translate = true,
+                translateType = "custom",
+                translateFunc = translateFunc:format(radius1),
+                x = previousAngle,
+                y = dAngle
               };
             end
+          end
+          if not(anim) then
+            anim = {
+              type = "custom",
+              duration = 0.2,
+              use_translate = true,
+              x = xDelta,
+              y = yDelta
+            };
+          end
 
-            WeakAuras.CancelAnimation(regionData.tray, nil, nil, nil, nil, nil, true);
-            WeakAuras.Animate("tray"..regionData.key, data, "tray", anim, regionData.tray, true, function() end);
-          elseif (not childRegion.toShow) then
-            if(WeakAuras.IsAnimating(childRegion) == "finish") then
-            -- childRegion will be hidden by its own animation, so it does not need to be hidden immediately
-            else
-              childRegion:Hide();
-            end
+          WeakAuras.CancelAnimation(regionData.tray, nil, nil, nil, nil, nil, true);
+          WeakAuras.Animate("tray"..regionData.key, data, "tray", anim, regionData.tray, true, function() end);
+        elseif (not childRegion.toShow) then
+          if(WeakAuras.IsAnimating(childRegion) == "finish") then
+          -- childRegion will be hidden by its own animation, so it does not need to be hidden immediately
+          else
+            childRegion:Hide();
           end
         end
       end

--- a/WeakAuras/RegionTypes/DynamicGroup.lua
+++ b/WeakAuras/RegionTypes/DynamicGroup.lua
@@ -230,8 +230,8 @@ local growers = {
         local pos = {x, y}
         local regionData = activeRegions[i]
         newPositions[i] = pos
-        x = x + (regionData.data.width or regionData.region.width) + space
-        y = y + stagger
+        x = x - (regionData.data.width or regionData.region.width) + space
+        y = y - stagger
         i = i + 1
       end
     end
@@ -249,7 +249,7 @@ local growers = {
         local pos = {x, y}
         local regionData = activeRegions[i]
         newPositions[i] = pos
-        x = x - (regionData.data.width or regionData.region.width) - space
+        x = x + (regionData.data.width or regionData.region.width) + space
         y = y + data.stagger
         i = i + 1
       end

--- a/WeakAuras/RegionTypes/DynamicGroup.lua
+++ b/WeakAuras/RegionTypes/DynamicGroup.lua
@@ -141,8 +141,6 @@ local function modify(parent, region, data)
   background:SetPoint("bottomleft", region, "bottomleft", -1 * data.borderOffset, -1 * data.borderOffset);
   background:SetPoint("topright", region, "topright", data.borderOffset, data.borderOffset);
 
-
-
   region.controlledRegions = {};
 
   function region:EnsureControlledRegions()

--- a/WeakAuras/RegionTypes/DynamicGroup.lua
+++ b/WeakAuras/RegionTypes/DynamicGroup.lua
@@ -476,179 +476,6 @@ local function modify(parent, region, data)
   background:SetPoint("bottomleft", region, "bottomleft", -1 * data.borderOffset, -1 * data.borderOffset);
   background:SetPoint("topright", region, "topright", data.borderOffset, data.borderOffset);
 
-  region.controlledRegions = {};
---[[
-  function region:EnsureControlledRegions()
-    local anyIndexInfo = false;
-    local dataIndex = 1;
-    local regionIndex = 1;
-    while(dataIndex <= #data.controlledChildren) do
-      local childId = data.controlledChildren[dataIndex];
-      local childData = WeakAuras.GetData(childId);
-      local childRegion = WeakAuras.regions[childId] and WeakAuras.regions[childId].region;
-      if(childRegion) then
-        if not(region.controlledRegions[regionIndex]) then
-          region.controlledRegions[regionIndex] = {};
-        end
-        region.controlledRegions[regionIndex].id = childId;
-        region.controlledRegions[regionIndex].data = childData;
-        region.controlledRegions[regionIndex].region = childRegion;
-        region.controlledRegions[regionIndex].key = tostring(region.controlledRegions[regionIndex].region);
-        anyIndexInfo = anyIndexInfo or childRegion.state and childRegion.state.index;
-        region.controlledRegions[regionIndex].dataIndex = dataIndex;
-        dataIndex = dataIndex + 1;
-        regionIndex = regionIndex + 1;
-        if(childData and WeakAuras.clones[childId]) then
-          for cloneId, cloneRegion in pairs(WeakAuras.clones[childId]) do
-            if not(region.controlledRegions[regionIndex]) then
-              region.controlledRegions[regionIndex] = {};
-            end
-            region.controlledRegions[regionIndex].id = childId;
-            region.controlledRegions[regionIndex].data = childData;
-            region.controlledRegions[regionIndex].cloneId = cloneId;
-            region.controlledRegions[regionIndex].region = cloneRegion;
-            region.controlledRegions[regionIndex].key = tostring(region.controlledRegions[regionIndex].region);
-            anyIndexInfo = anyIndexInfo or cloneRegion.state and cloneRegion.state.index;
-            region.controlledRegions[regionIndex].dataIndex = dataIndex;
-            regionIndex = regionIndex + 1;
-          end
-        end
-      else
-        dataIndex = dataIndex + 1;
-      end
-    end
-    while(region.controlledRegions[regionIndex]) do
-      region.controlledRegions[regionIndex] = nil;
-      regionIndex = regionIndex + 1;
-    end
-
-    local function expirationTime(region)
-      if (region.region and region.region.state) then
-        local expires = region.region.state.expirationTime;
-        if (expires and expires > 0 and expires > GetTime()) then
-          return expires;
-        end
-      end
-      return nil;
-    end
-
-    local function compareExpirationTimes(regionA, regionB)
-      local aExpires = expirationTime(regionA);
-      local bExpires = expirationTime(regionB);
-
-
-      if (aExpires and bExpires) then
-        if (aExpires == bExpires) then
-          return nil;
-        end
-        return aExpires < bExpires;
-      end
-
-      if (aExpires) then
-        return false;
-      end
-
-      if (bExpires) then
-        return true;
-      end
-
-      return nil;
-    end
-
-    if(data.sort == "ascending") then
-      table.sort(region.controlledRegions, function(a, b)
-        local result = compareExpirationTimes(a, b);
-        if (result == nil) then
-          return a.dataIndex < b.dataIndex;
-        end
-        return result;
-      end);
-    elseif(data.sort == "descending") then
-      table.sort(region.controlledRegions, function(a, b)
-        local result = compareExpirationTimes(a, b);
-        if (result == nil) then
-          return a.dataIndex < b.dataIndex;
-        end
-        return not result;
-      end);
-    elseif(data.sort == "hybrid") then
-      table.sort(region.controlledRegions, function(a, b)
-        if (not b) then return true; end
-        if (not a) then return false; end;
-        local aIndex;
-        local bIndex;
-        if (data.sortHybridTable and data.sortHybridTable[a.id]) then
-          aIndex = a.dataIndex;
-        end
-
-        if (data.sortHybridTable and data.sortHybridTable[b.id]) then
-          bIndex = b.dataIndex;
-        end
-
-        if (aIndex == bIndex) then
-          local result = compareExpirationTimes(a, b);
-          if (result == nil) then
-            return a.dataIndex < b.dataIndex;
-          end
-          if (data.hybridSortMode == "descending") then
-            result = not result;
-          end
-          return result;
-        end
-
-        if (aIndex and bIndex) then
-          return aIndex < bIndex;
-        end
-
-        if (aIndex) then
-          return data.hybridPosition == "hybridFirst";
-        end
-
-        if (bIndex) then
-          return data.hybridPosition ~= "hybridFirst";
-        end
-
-        -- Can't happen
-      end);
-    elseif(anyIndexInfo) then
-      table.sort(region.controlledRegions, function(a, b)
-        if (a.dataIndex ~= b.dataIndex) then
-          return (a.dataIndex or 0) < (b.dataIndex or 0)
-        end
-
-        local aIndex = a.region.state and a.region.state.index;
-        local bIndex = b.region.state and b.region.state.index;
-        if (aIndex == nil) then
-          return false;
-        end
-        if (bIndex == nil) then
-          return true;
-        end
-
-        return aIndex < bIndex;
-      end)
-    end
-  end
-
-  function region:EnsureTrays()
-    region:EnsureControlledRegions();
-    for index, regionData in ipairs(region.controlledRegions) do
-      if not(region.trays[regionData.key]) then
-        region.trays[regionData.key] = CreateFrame("Frame", nil, region);
-        regionData.region:SetParent(region.trays[regionData.key])
-      else
-        regionData.region:SetParent(region.trays[regionData.key]) -- removing and adding aura back doesnt delete tray, so need to reparent it
-      end
-      if(regionData.data and regionData.region) then
-        local tray = region.trays[regionData.key];
-        tray:SetWidth(regionData.data.width or regionData.region.width);
-        tray:SetHeight(regionData.data.height or regionData.region.height);
-
-        regionData.region:SetAnchor(selfPoint, tray, selfPoint);
-      end
-    end
-  end
- ]]
   function region:ReloadControlledRegions()
     WeakAuras.StartProfileSystem("dynamicgroup")
     WeakAuras.StartProfileAura(data.id)
@@ -785,6 +612,58 @@ local function modify(parent, region, data)
     regionData.sortIndex = nil
   end
 
+  function region:SortUpdatedRegions()
+    if self.suspended == 0 then
+      for regionKey, isActivating in pairs(self.updatedRegions) do
+        local regionData = self.controlledRegions[regionKey]
+        self.updatedRegions[regionKey] = nil
+        if regionData then
+          if isActivating then
+            insertRegion(regionData)
+          else
+            removeRegion(regionData)
+          end
+        end
+      end
+    elseif next(self.updatedRegions) ~= nil then
+      self.needToControlChildren = true
+    end
+  end
+
+  local grower = growers[data.grow] or growers.default
+  region.growFunc = grower(data)
+
+  function region:PositionActiveRegions()
+    region:EnsureTrays();
+    local childData, childRegion;
+    local activeRegions = {}
+    for index, regionData in pairs(region.controlledRegions) do
+      childData = regionData.data;
+      childRegion = regionData.region;
+      if(childData and childRegion) then
+        if(childRegion.toShow or  WeakAuras.IsAnimating(childRegion) == "finish") then
+          activeRegions[#activeRegions] = regionData
+        end
+      end
+    end
+    local newPositions = {}
+    region.growFunc(newPositions, activeRegions)
+    region.numVisible = 0
+    for index, activeRegion in ipairs(activeRegions) do
+      local pos = newPositions[index] or {0, 0, true}
+      pos[1] = type(pos[1]) == "number" and pos[1] or 0
+      pos[2] = type(pos[2]) == "number" and pos[2] or 0
+      local tray = region.trays[activeRegion.key]
+      tray:ClearAllPoints()
+      tray:SetPoint(selfPoint, region, selfPoint, pos[1], pos[2])
+      tray:SetShown(not pos[3])
+      activeRegion.hidden = pos[3]
+      self.numVisible = self.numVisible + (pos[3] and 0 or 1)
+    end
+
+    region:DoResize();
+  end
+
   function region:DoResize()
     local numVisible = 0;
     local minX, maxX, minY, maxY;
@@ -866,58 +745,6 @@ local function modify(parent, region, data)
     if(WeakAuras.IsOptionsOpen()) then
       WeakAuras.OptionsFrame().moversizer:ReAnchor();
     end
-  end
-
-  function region:SortUpdatedRegions()
-    if self.suspended == 0 then
-      for regionKey, isActivating in pairs(self.updatedRegions) do
-        local regionData = self.controlledRegions[regionKey]
-        self.updatedRegions[regionKey] = nil
-        if regionData then
-          if isActivating then
-            insertRegion(regionData)
-          else
-            removeRegion(regionData)
-          end
-        end
-      end
-    elseif next(self.updatedRegions) ~= nil then
-      self.needToControlChildren = true
-    end
-  end
-
-  local grower = growers[data.grow] or growers.default
-  region.growFunc = grower(data)
-
-  function region:PositionActiveRegions()
-    region:EnsureTrays();
-    local childData, childRegion;
-    local activeRegions = {}
-    for index, regionData in pairs(region.controlledRegions) do
-      childData = regionData.data;
-      childRegion = regionData.region;
-      if(childData and childRegion) then
-        if(childRegion.toShow or  WeakAuras.IsAnimating(childRegion) == "finish") then
-          activeRegions[#activeRegions] = regionData
-        end
-      end
-    end
-    local newPositions = {}
-    region.growFunc(newPositions, activeRegions)
-    region.numVisible = 0
-    for index, activeRegion in ipairs(activeRegions) do
-      local pos = newPositions[index] or {0, 0, true}
-      pos[1] = type(pos[1]) == "number" and pos[1] or 0
-      pos[2] = type(pos[2]) == "number" and pos[2] or 0
-      local tray = region.trays[activeRegion.key]
-      tray:ClearAllPoints()
-      tray:SetPoint(selfPoint, region, selfPoint, pos[1], pos[2])
-      tray:SetShown(not pos[3])
-      activeRegion.hidden = pos[3]
-      self.numVisible = self.numVisible + (pos[3] and 0 or 1)
-    end
-
-    region:DoResize();
   end
 
   function region:Suspend()

--- a/WeakAuras/RegionTypes/RegionPrototype.lua
+++ b/WeakAuras/RegionTypes/RegionPrototype.lua
@@ -486,9 +486,6 @@ function WeakAuras.regionPrototype.AddExpandFunction(data, region, id, cloneId, 
   end
 
   if(indynamicgroup) then
-    if not(cloneId) then
-      parent:PositionChildren();
-    end
     function region:Collapse()
       if (not region.toShow) then
         return;

--- a/WeakAuras/RegionTypes/RegionPrototype.lua
+++ b/WeakAuras/RegionTypes/RegionPrototype.lua
@@ -474,7 +474,7 @@ function WeakAuras.regionPrototype.AddExpandFunction(data, region, id, cloneId, 
       if (cloneId) then
         WeakAuras.ReleaseClone(id, cloneId, data.regionType);
       end
-      parent:ControlChildren();
+      parent:DeactivateRegion(id, cloneId);
     end
   else
     hideRegion = function()
@@ -499,7 +499,6 @@ function WeakAuras.regionPrototype.AddExpandFunction(data, region, id, cloneId, 
       if (not WeakAuras.Animate("display", data, "finish", data.animation.finish, region, false, hideRegion, nil, cloneId)) then
         hideRegion();
       end
-      parent:ControlChildren();
 
       if (region.SoundRepeatStop) then
         region:SoundRepeatStop();
@@ -514,14 +513,13 @@ function WeakAuras.regionPrototype.AddExpandFunction(data, region, id, cloneId, 
         region:PreShow();
       end
 
-      parent:EnsureTrays();
+      parent:ActivateRegion(id, cloneId)
       region.justCreated = nil;
       region:SetFrameLevel(WeakAuras.GetFrameLevelFor(id));
       WeakAuras.PerformActions(data, "start", region);
       if not(WeakAuras.Animate("display", data, "start", data.animation.start, region, true, startMainAnimation, nil, cloneId)) then
         startMainAnimation();
       end
-      parent:ControlChildren();
     end
   elseif not(data.controlledChildren) then
     function region:Collapse()

--- a/WeakAuras/Types.lua
+++ b/WeakAuras/Types.lua
@@ -1126,7 +1126,8 @@ WeakAuras.grow_types = {
   ["HORIZONTAL"] = L["Centered Horizontal"],
   ["VERTICAL"] = L["Centered Vertical"],
   ["CIRCLE"] = L["Counter Clockwise"],
-  ["COUNTERCIRCLE"] =L["Clockwise"]
+  ["COUNTERCIRCLE"] =L["Clockwise"],
+  ["CUSTOM"] = L["Custom"],
 }
 
 WeakAuras.text_rotate_types = {

--- a/WeakAuras/Types.lua
+++ b/WeakAuras/Types.lua
@@ -1128,6 +1128,18 @@ WeakAuras.grow_types = {
   ["CIRCLE"] = L["Counter Clockwise"],
   ["COUNTERCIRCLE"] =L["Clockwise"],
   ["CUSTOM"] = L["Custom"],
+  ["GRID"] = L["Grid"],
+}
+
+WeakAuras.grid_grow_types = {
+  ["RIGHTUP"] = L["Right, then Up"],
+  ["RIGHTDOWN"] = L["Right, then Down"],
+  ["LEFTUP"] = L["Left, then Up"],
+  ["LEFTDOWN"] = L["Left, then Down"],
+  ["UPRIGHT"] = L["Up, then Right"],
+  ["UPLEFT"] = L["Up, then Left"],
+  ["DOWNRIGHT"] = L["Down, then Right"],
+  ["DOWNLEFT"] = L["Down, then Left"],
 }
 
 WeakAuras.text_rotate_types = {

--- a/WeakAurasOptions/RegionOptions/DynamicGroup.lua
+++ b/WeakAurasOptions/RegionOptions/DynamicGroup.lua
@@ -13,7 +13,7 @@ local function createOptions(id, data)
       name = L["Align"],
       order = 10,
       values = WeakAuras.align_types,
-      hidden = function() return (data.grow == "LEFT" or data.grow == "RIGHT" or data.grow == "HORIZONTAL" or data.grow == "CIRCLE" or data.grow == "COUNTERCIRCLE") end,
+      hidden = function() return (data.grow == "CUSTOM" or data.grow == "LEFT" or data.grow == "RIGHT" or data.grow == "HORIZONTAL" or data.grow == "CIRCLE" or data.grow == "COUNTERCIRCLE") end,
       disabled = function() return data.grow == "CIRCLE" or data.grow == "COUNTERCIRCLE" end
     },
     rotated_align = {
@@ -21,7 +21,7 @@ local function createOptions(id, data)
       name = L["Align"],
       order = 10,
       values = WeakAuras.rotated_align_types,
-      hidden = function() return (data.grow == "UP" or data.grow == "DOWN" or data.grow == "VERTICAL" or data.grow == "CIRCLE" or data.grow == "COUNTERCIRCLE") end,
+      hidden = function() return (data.grow == "CUSTOM" or data.grow == "UP" or data.grow == "DOWN" or data.grow == "VERTICAL" or data.grow == "CIRCLE" or data.grow == "COUNTERCIRCLE") end,
       get = function() return data.align; end,
       set = function(info, v) data.align = v; WeakAuras.Add(data); end
     },
@@ -39,7 +39,7 @@ local function createOptions(id, data)
       softMin = 0,
       softMax = 300,
       bigStep = 1,
-      hidden = function() return (data.grow == "CIRCLE" or data.grow == "COUNTERCIRCLE") and data.constantFactor == "RADIUS" end
+      hidden = function() return data.grow == "CUSTOM" or ((data.grow == "CIRCLE" or data.grow == "COUNTERCIRCLE") and data.constantFactor == "RADIUS") end
     },
     rotation = {
       type = "range",
@@ -58,7 +58,7 @@ local function createOptions(id, data)
       max = 50,
       step = 0.1,
       bigStep = 1,
-      hidden = function() return data.grow == "CIRCLE" or data.grow == "COUNTERCIRCLE" end
+      hidden = function() return data.grow == "CUSTOM" or data.grow == "CIRCLE" or data.grow == "COUNTERCIRCLE" end
     },
     radius = {
       type = "range",
@@ -67,7 +67,7 @@ local function createOptions(id, data)
       softMin = 0,
       softMax = 500,
       bigStep = 1,
-      hidden = function() return not((data.grow == "CIRCLE" or data.grow == "COUNTERCIRCLE") and data.constantFactor == "RADIUS") end
+      hidden = function() return data.grow == "CUSTOM" or not((data.grow == "CIRCLE" or data.grow == "COUNTERCIRCLE") and data.constantFactor == "RADIUS") end
     },
     animate = {
       type = "toggle",

--- a/WeakAurasOptions/RegionOptions/DynamicGroup.lua
+++ b/WeakAurasOptions/RegionOptions/DynamicGroup.lua
@@ -35,7 +35,7 @@ local function createOptions(id, data)
       name = L["Max Visible"],
       order = 9,
       min = 0,
-      softmax = 30,
+      softMax = 30,
       step = 1,
       hidden = function() return data.grow == "CUSTOM" end,
       disabled = function() return not data.useLimit end,

--- a/WeakAurasOptions/RegionOptions/DynamicGroup.lua
+++ b/WeakAurasOptions/RegionOptions/DynamicGroup.lua
@@ -8,6 +8,38 @@ local function createOptions(id, data)
       order = 5,
       values = WeakAuras.grow_types
     },
+    gridType = {
+      type = "select",
+      name = L["Grid Orientation"],
+      order = 6,
+      values = WeakAuras.grid_grow_types,
+      hidden = function() return data.grow ~= "GRID" end,
+    },
+    columnLimit = {
+      type = "range",
+      name = L["Column Size"],
+      order = 7,
+      min = 1,
+      softMax = 10,
+      step = 1,
+      hidden = function() return data.grow ~= "GRID" end,
+    },
+    useLimit = {
+      type = "toggle",
+      name = L["Max Visible"],
+      order = 8,
+      hidden = function() return data.grow == "CUSTOM" end,
+    },
+    limit = {
+      type = "range",
+      name = L["Max Visible"],
+      order = 9,
+      min = 0,
+      softmax = 30,
+      step = 1,
+      hidden = function() return data.grow == "CUSTOM" end,
+      disabled = function() return not data.useLimit end,
+    },
     align = {
       type = "select",
       name = L["Align"],

--- a/WeakAurasOptions/WeakAurasOptions.lua
+++ b/WeakAurasOptions/WeakAurasOptions.lua
@@ -1452,6 +1452,14 @@ StaticPopupDialogs["WEAKAURAS_CONFIRM_DELETE"] = {
     end
   end,
   OnCancel = function(self)
+    if self.data.parents then
+      for id in pairs(self.data.parents) do
+        local parentRegion = WeakAuras.GetRegion(id)
+        if parentRegion.ControlChildren then
+          parentRegion:Resume()
+        end
+      end
+    end
     self.data = nil
   end,
   showAlert = true,


### PR DESCRIPTION
This is not yet ready to merge.

### Things to add

- [x] Fix a bug where canceling a Delete confirmation on a dynamic group could leave it permanently suspended.
- [x] Fix a bug where children with state indices of disparate types would cause the sorting to error out.
- [x] Implement [WoWAce 705](https://www.wowace.com/projects/weakauras-2/issues/705)
- [x] Implement [WoWAce 857](https://www.wowace.com/projects/weakauras-2/issues/857)
- [x] Rewrite how children of dynamic groups are sorted, to use an incremental insertion sort that's maintained only on active (visible) children. This could also allow custom sort scripts very easily (though the precise details on that I haven't thought through yet).
- [x] Rewrite how children of dynamic groups are positioned. Positioning code is untangled so that the exact grow type doesn't have to be checked dozens of time, and future additions are quite simple.
- [ ] Implement #687, by adding a start & end angle option to circle & countercircle grow types.
- [ ] Add new feature indicators where necessary
- [ ] Test literally everything
### Regressions to fix:
- [ ] DoResize is positioning the MoverResizer in the wrong position.
- [ ] Editing the grow type can cause positioning to break
- [ ] Grid and custom grow types can cause modifyThumbnail to error out. Likely, that function needs to be untangled as well.