### PR TITLE
Fix deactivation of conditions on collapsing clones

### DIFF
--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -4326,8 +4326,8 @@ function WeakAuras.UpdatedTriggerState(id)
   if (show and not oldShow) then -- Hide => Show
     ApplyStatesToRegions(id, newActiveTrigger, activeTriggerState);
   elseif (not show and oldShow) then -- Show => Hide
-    for cloneId, state in pairs(activeTriggerState) do
-      if (checkConditions[id]) then
+    if (checkConditions[id]) then
+      for cloneId, clone in pairs(clones[id]) do
         local region = WeakAuras.GetRegion(id, cloneId);
         checkConditions[id](region, true);
       end


### PR DESCRIPTION
This needs to iterate over all existing clones and hide the ones that
are not longer visible, instead of iterating over the list of new
states.

Github-Issue: 874