### PR TITLE
tweak glow options

### DIFF
--- a/WeakAuras/RegionTypes/Icon.lua
+++ b/WeakAuras/RegionTypes/Icon.lua
@@ -42,6 +42,7 @@ local default = {
   customTextUpdate = "update",
   glow = false,
   useglowColor = false,
+  glowColor = {1, 1, 1, 1},
   glowType = "buttonOverlay",
   cooldownTextEnabled = true,
 };

--- a/WeakAurasOptions/RegionOptions/Icon.lua
+++ b/WeakAurasOptions/RegionOptions/Icon.lua
@@ -84,28 +84,26 @@ local function createOptions(id, data)
       type = "toggle",
       name = L["Glow"],
       order = 20,
-      width = "double",
     },
     glowType = {
       type = "select",
       name = L["Glow Type"],
       order = 21,
       values = WeakAuras.glow_types,
-    },
-    glowToggleSpacer = {
-      type = "description",
-      name = "",
-      order = 22,
+      hidden = function() return not data.glow end,
     },
     useGlowColor = {
       type = "toggle",
       name = L["Glow Color"],
+      desc = L["If unchecked, then a default color will be used (usually yellow)"],
       order = 23,
+      hidden = function() return not data.glow end,
     },
     glowColor = {
       type = "color",
       name = L["Glow Color"],
       order = 24,
+      hidden = function() return not data.glow end,
       disabled = function() return not data.useGlowColor end,
     },
     textHeader1 = {


### PR DESCRIPTION
Added a description to useGlowColor to explain what exactly it does.
Set glow sub options to hide themselves if the main glow option is disabled.
Added a default glow color of white (1,1,1,1) to the icon region.
GitHub issue #880