### PR TITLE
fix cross-server transmission after login #934

### DIFF
--- a/WeakAuras/Transmission.lua
+++ b/WeakAuras/Transmission.lua
@@ -1720,13 +1720,12 @@ function TransmitDisplay(id, characterName)
   end
 end
 
-local myName, myServer = UnitFullName("player")
-
 Comm:RegisterComm("WeakAurasProg", function(prefix, message, distribution, sender)
   if distribution == "PARTY" or distribution == "RAID" then
     local dest, msg = string.match(message, "^§§(.+):(.+)$")
     if dest then
       local dName, dServer = string.match(dest, "^(.*)-(.*)$")
+      local myName, myServer = UnitFullName("player")
       if myName == dName and myServer == dServer then
         message = msg
       else
@@ -1756,6 +1755,7 @@ Comm:RegisterComm("WeakAuras", function(prefix, message, distribution, sender)
     local dest, msg = string.match(message, "^§§([^:]+):(.+)$")
     if dest then
       local dName, dServer = string.match(dest, "^(.*)-(.*)$")
+      local myName, myServer = UnitFullName("player")
       if myName == dName and myServer == dServer then
         message = msg
       else

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -1192,17 +1192,17 @@ local function tooltip_draw()
   tooltip:ClearLines();
   tooltip:AddDoubleLine("WeakAuras", versionString);
   tooltip:AddLine(" ");
-  tooltip:AddLine(L["|cffeda55fLeft-Click|r to toggle showing the main window."], 0.2, 1, 0.2, 1);
+  tooltip:AddLine(L["|cffeda55fLeft-Click|r to toggle showing the main window."], 0.2, 1, 0.2);
   if not WeakAuras.IsOptionsOpen() then
     if paused then
-      tooltip:AddLine("|cFFFF0000"..L["Paused"].." - "..L["Shift-Click to resume addon execution."], 0.2, 1, 0.2, 1);
+      tooltip:AddLine("|cFFFF0000"..L["Paused"].." - "..L["Shift-Click to resume addon execution."], 0.2, 1, 0.2);
     else
-      tooltip:AddLine(L["|cffeda55fShift-Click|r to pause addon execution."], 0.2, 1, 0.2, 1);
+      tooltip:AddLine(L["|cffeda55fShift-Click|r to pause addon execution."], 0.2, 1, 0.2);
     end
   end
-  tooltip:AddLine(L["|cffeda55fRight-Click|r to toggle performance profiling on or off."], 0.2, 1, 0.2, 1);
-  tooltip:AddLine(L["|cffeda55fShift-Right-Click|r to show profiling results."], 0.2, 1, 0.2, 1);
-  tooltip:AddLine(L["|cffeda55fMiddle-Click|r to toggle the minimap icon on or off."], 0.2, 1, 0.2, 1);
+  tooltip:AddLine(L["|cffeda55fRight-Click|r to toggle performance profiling on or off."], 0.2, 1, 0.2);
+  tooltip:AddLine(L["|cffeda55fShift-Right-Click|r to show profiling results."], 0.2, 1, 0.2);
+  tooltip:AddLine(L["|cffeda55fMiddle-Click|r to toggle the minimap icon on or off."], 0.2, 1, 0.2);
   tooltip:Show();
 end
 


### PR DESCRIPTION
UnitFullName("player") return nil for server when loading weakauras at login
moved the call when the information is needed