### PR TITLE
make glow type option visible when glow is disabled

### DIFF
--- a/WeakAurasOptions/RegionOptions/Icon.lua
+++ b/WeakAurasOptions/RegionOptions/Icon.lua
@@ -90,20 +90,17 @@ local function createOptions(id, data)
       name = L["Glow Type"],
       order = 21,
       values = WeakAuras.glow_types,
-      hidden = function() return not data.glow end,
     },
     useGlowColor = {
       type = "toggle",
       name = L["Glow Color"],
       desc = L["If unchecked, then a default color will be used (usually yellow)"],
       order = 23,
-      hidden = function() return not data.glow end,
     },
     glowColor = {
       type = "color",
       name = L["Glow Color"],
       order = 24,
-      hidden = function() return not data.glow end,
       disabled = function() return not data.useGlowColor end,
     },
     textHeader1 = {


### PR DESCRIPTION
This is a bandaid fix to directly address the concerns in the issue.
There is a more fundamental issue present, which requires more time to resolve.
Specifically, there are several options which show/hide a 'subregion'
and also show/hide several sub options for that 'subregion'. So, it is
impossible to edit a subregion's sub options without showing it. Before now, this
was not an issue, since there was no subregion which you could hide or show in
a condition, and also which had sub options. But now the glow subregion does, and
I expect that future development will cause this same problem to appear with other
subregions.

GitHub Issue #915