### PR TITLE
Fix SetInverse for hidden cooldowns

### DIFF
--- a/WeakAuras/RegionTypes/Icon.lua
+++ b/WeakAuras/RegionTypes/Icon.lua
@@ -592,7 +592,7 @@ local function modify(parent, region, data)
 
   function region:SetInverse(inverse)
     cooldown:SetReverse(not inverse);
-    if (cooldown.expirationTime and cooldown.duration) then
+    if (cooldown.expirationTime and cooldown.duration and cooldown:IsShown()) then
       -- WORKAROUND SetReverse not applying until next frame
       cooldown:SetCooldown(0, 0);
       cooldown:SetCooldown(cooldown.expirationTime - cooldown.duration, cooldown.duration);


### PR DESCRIPTION
In 30fa1f72d8ce6d8f54093020746167e68a32c874 I applied a workaround to
SetInverse of clearing and reseting the cooldown time, because otherwise
SetInverse would not show up until the next frame.

Setting a Cooldown does make the cooldown visible though, so apply the
workaround only if the cooldown is visible.

Github-Issue: fix #936