### PR TITLE
rename original glow property

### DIFF
--- a/WeakAuras/RegionTypes/Icon.lua
+++ b/WeakAuras/RegionTypes/Icon.lua
@@ -76,7 +76,7 @@ local properties = {
     default = 32
   },
   glow = {
-    display = L["Glow"],
+    display = WeakAuras.newFeatureString .. L["Set Glow Visibility"],
     setter = "SetGlow",
     type = "bool"
   },

--- a/WeakAurasOptions/RegionOptions/Icon.lua
+++ b/WeakAurasOptions/RegionOptions/Icon.lua
@@ -82,7 +82,7 @@ local function createOptions(id, data)
     },
     glow = {
       type = "toggle",
-      name = L["Glow"],
+      name = L["Show Glow Effect"],
       order = 20,
     },
     glowType = {


### PR DESCRIPTION
This seems to have been a point of confusion amongst users. Hopefully this will improve the UI somewhat.