### PR TITLE
Class Color toggles

### DIFF
--- a/WeakAuras/RegionTypes/AuraBar.lua
+++ b/WeakAuras/RegionTypes/AuraBar.lua
@@ -1218,9 +1218,9 @@ local function modify(parent, region, data)
     if data.timerClassColor then
       local col = RAID_CLASS_COLORS[select(2, UnitClass("player"))]
       timer:SetTextColor(col.r, col.g, col.b, col.a);
-      else
-        timer:SetTextColor(data.timerColor[1], data.timerColor[2], data.timerColor[3], data.timerColor[4]);
-      end
+    else
+      timer:SetTextColor(data.timerColor[1], data.timerColor[2], data.timerColor[3], data.timerColor[4]);
+    end
     animRotate(timer, textDegrees);
     timer:Show();
     timer.visible = true;
@@ -1526,7 +1526,7 @@ local function modify(parent, region, data)
 
   function region:SetTextClassColor(b)
     self.text:SetTextColor(RAID_CLASS_COLORS[select(2, UnitClass("player"))])   
-end
+  end
   function region:SetTextSize(size)
     self.text:SetFont(SharedMedia:Fetch("font", data.textFont), size, data.textFlags and data.textFlags ~= "None" and data.textFlags);
     self.text:SetTextHeight(size);

--- a/WeakAuras/RegionTypes/AuraBar.lua
+++ b/WeakAuras/RegionTypes/AuraBar.lua
@@ -15,6 +15,9 @@ local default = {
   textColor = {1.0, 1.0, 1.0, 1.0},
   timerColor = {1.0, 1.0, 1.0, 1.0},
   stacksColor = {1.0, 1.0, 1.0, 1.0},
+  textClassColor = false,
+  timerClassColor = false,
+  stacksClassColor = false,
   textFont = "Friz Quadrata TT",
   timerFont = "Friz Quadrata TT",
   stacksFont = "Friz Quadrata TT",
@@ -137,6 +140,22 @@ local properties = {
     setter = "SetStacksColor",
     type = "color"
   },
+  textClassColor = {
+    display = L["First Text Class Color"],
+    setter = "SetTextClassColor",
+    type = "bool"
+  },
+  timerClassColor = {
+    display = L["Second Text Class Color"],
+    setter = "SetTimerClassColor",
+    type = "bool"
+  },
+  stacksClassColor = {
+    display = L["Stacks Text Class Color"],
+    setter = "SetStacksClassColor",
+    type = "bool"
+  },
+
   textSize = {
     display = L["First Text Size"],
     setter = "SetTextSize",
@@ -1176,7 +1195,12 @@ local function modify(parent, region, data)
     -- Update text font
     text:SetFont(SharedMedia:Fetch("font", data.textFont), data.textSize, data.textFlags and data.textFlags ~= "None" and data.textFlags);
     text:SetTextHeight(data.textSize);
+    if data.textClassColor then
+      local col = RAID_CLASS_COLORS[select(2, UnitClass("player"))]
+      text:SetTextColor(col.r, col.g, col.b, col.a);
+    else
     text:SetTextColor(data.textColor[1], data.textColor[2], data.textColor[3], data.textColor[4]);
+    end
     text:SetWordWrap(false);
     animRotate(text, textDegrees);
     text:Show();
@@ -1191,7 +1215,12 @@ local function modify(parent, region, data)
     -- Update timer font
     timer:SetFont(SharedMedia:Fetch("font", data.timerFont), data.timerSize, data.timerFlags and data.timerFlags ~= "None" and data.timerFlags);
     timer:SetTextHeight(data.timerSize);
-    timer:SetTextColor(data.timerColor[1], data.timerColor[2], data.timerColor[3], data.timerColor[4]);
+    if data.timerClassColor then
+      local col = RAID_CLASS_COLORS[select(2, UnitClass("player"))]
+      timer:SetTextColor(col.r, col.g, col.b, col.a);
+      else
+        timer:SetTextColor(data.timerColor[1], data.timerColor[2], data.timerColor[3], data.timerColor[4]);
+      end
     animRotate(timer, textDegrees);
     timer:Show();
     timer.visible = true;
@@ -1236,7 +1265,13 @@ local function modify(parent, region, data)
       -- Update stack font
       stacks:SetFont(SharedMedia:Fetch("font", data.stacksFont), data.stacksSize, data.stacksFlags and data.stacksFlags ~= "None" and data.stacksFlags);
       stacks:SetTextHeight(data.stacksSize);
+      stacks:SetTextHeight(data.stacksSize);
+    if data.stacksClassColor then
+      local col = RAID_CLASS_COLORS[select(2, UnitClass("player"))]
+      stacks:SetTextColor(col.r, col.g, col.b, col.a);
+    else
       stacks:SetTextColor(data.stacksColor[1], data.stacksColor[2], data.stacksColor[3], data.stacksColor[4]);
+    end
       animRotate(stacks, textDegrees);
 
       -- Align text after rotation
@@ -1489,6 +1524,9 @@ local function modify(parent, region, data)
     self.stacks:SetTextColor(r, g, b, a);
   end
 
+  function region:SetTextClassColor(b)
+    self.text:SetTextColor(RAID_CLASS_COLORS[select(2, UnitClass("player"))])   
+end
   function region:SetTextSize(size)
     self.text:SetFont(SharedMedia:Fetch("font", data.textFont), size, data.textFlags and data.textFlags ~= "None" and data.textFlags);
     self.text:SetTextHeight(size);

--- a/WeakAuras/RegionTypes/Icon.lua
+++ b/WeakAuras/RegionTypes/Icon.lua
@@ -16,11 +16,13 @@ local default = {
   color = {1, 1, 1, 1},
   text1Enabled = true,
   text1Color = {1, 1, 1, 1},
+  text1ClassColor = false,
   text1 = "%s",
   text1Point = "BOTTOMRIGHT",
   text1Containment = "INSIDE",
   text2Enabled = false,
   text2Color = {1, 1, 1, 1},
+  text2ClassColor = false,
   text2 = "%p",
   text2Point = "CENTER",
   text2Containment = "INSIDE",
@@ -103,6 +105,11 @@ local properties = {
     setter = "SetText1Color",
     type = "color"
   },
+  text1ClassColor = {
+    display = L["1. Text Class Color"],
+    setter = "SetTextClassColor",
+    type = "bool"
+  },
   text1FontSize = {
     display = L["1. Text Size"],
     setter = "SetText1Height",
@@ -116,6 +123,11 @@ local properties = {
     display = L["2. Text Color"],
     setter = "SetText2Color",
     type = "color"
+  },
+  text2ClassColor = {
+    display = L["1. Text Class Color"],
+    setter = "SetTextClassColor",
+    type = "bool"
   },
   text2FontSize = {
     display = L["2. Text Size"],
@@ -271,7 +283,7 @@ local function create(parent, data)
   return region;
 end
 
-local function configureText(fontString, icon, enabled, point, width, height, containment, font, fontSize, fontFlags, textColor)
+local function configureText(fontString, icon, enabled, point, width, height, containment, font, fontSize, fontFlags, textColor, textClassColor)
   if (enabled) then
     fontString:Show();
   else
@@ -310,7 +322,15 @@ local function configureText(fontString, icon, enabled, point, width, height, co
   fontString:SetText(t);
 
   fontString:SetTextHeight(fontSize);
-  fontString:SetTextColor(textColor[1], textColor[2], textColor[3], textColor[4]);
+  -- This can be done better.
+  if not textClassColor then
+    fontString:SetTextColor(textColor[1], textColor[2], textColor[3], textColor[4]);
+    end
+    
+    if textClassColor then
+      local color = RAID_CLASS_COLORS[select(2, UnitClass("player"))]
+      fontString:SetTextColor(color.r, color.g, color.b, color.a); 
+    end
 
   fontString:SetJustifyH(h);
   fontString:SetJustifyV(v);
@@ -354,8 +374,8 @@ local function modify(parent, region, data)
   region.zoom = data.zoom;
   icon:SetAllPoints();
 
-  configureText(stacks, icon, data.text1Enabled, data.text1Point, data.width, data.height, data.text1Containment, data.text1Font, data.text1FontSize, data.text1FontFlags, data.text1Color);
-  configureText(text2, icon, data.text2Enabled, data.text2Point, data.width, data.height, data.text2Containment, data.text2Font, data.text2FontSize, data.text2FontFlags, data.text2Color);
+  configureText(stacks, icon, data.text1Enabled, data.text1Point, data.width, data.height, data.text1Containment, data.text1Font, data.text1FontSize, data.text1FontFlags, data.text1Color, data.text1ClassColor);
+  configureText(text2, icon, data.text2Enabled, data.text2Point, data.width, data.height, data.text2Containment, data.text2Font, data.text2FontSize, data.text2FontFlags, data.text2Color, data.text2ClassColor);
 
   local texWidth = 1 - region.zoom * 0.5;
   local aspectRatio = region.keepAspectRatio and region.width / region.height or 1;
@@ -583,6 +603,10 @@ local function modify(parent, region, data)
 
   function region:SetText1Color(r, g, b, a)
     region.stacks:SetTextColor(r, g, b, a);
+  end
+
+  function region:SetTextClassColor(b)
+    region.stacks:SetTextColor(RAID_CLASS_COLORS[select(2, UnitClass("player"))])   
   end
 
   function region:SetText2Color(r, g, b, a)

--- a/WeakAuras/RegionTypes/Text.lua
+++ b/WeakAuras/RegionTypes/Text.lua
@@ -5,6 +5,7 @@ local default = {
   displayText = "%p",
   outline = "OUTLINE",
   color = {1, 1, 1, 1},
+  classColor = false,
   justify = "LEFT",
   selfPoint = "BOTTOM",
   anchorPoint = "CENTER",
@@ -25,6 +26,11 @@ local properties = {
     display = L["Color"],
     setter = "Color",
     type = "color",
+  },
+  classColor = {
+    display = L["Class Color"],
+    setter = "Color",
+    type = "bool",
   },
   fontSize = {
     display = L["Font Size"],
@@ -192,8 +198,14 @@ local function modify(parent, region, data)
     if (r or g or b) then
       a = a or 1;
     end
-    text:SetTextColor(region.color_anim_r or r, region.color_anim_g or g, region.color_anim_b or b, region.color_anim_a or a);
+    if not data.classColor then
+      text:SetTextColor(region.color_anim_r or r, region.color_anim_g or g, region.color_anim_b or b, region.color_anim_a or a);
+    else
+      local col = RAID_CLASS_COLORS[select(2, UnitClass("player"))]
+      text:SetTextColor(col.r, col.g, col.b, col.a);
+    end
   end
+
 
   function region:ColorAnim(r, g, b, a)
     region.color_anim_r = r;

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -2362,6 +2362,7 @@ function WeakAuras.Modernize(data)
         data.text1 = data.displayStacks;
         data.displayStacks = nil;
         data.text1Color = data.textColor;
+        data.text1ClassColor = data.textColor
         data.textColor = nil;
         data.text1Point = data.stacksPoint;
         data.stacksPoint = nil;
@@ -2377,6 +2378,7 @@ function WeakAuras.Modernize(data)
         data.text2Enabled = false;
         data.text2 = "%p";
         data.text2Color = {1, 1, 1, 1};
+        data.text2ClassColor = data.textColor
         data.text2Point = "CENTER";
         data.text2Containment = "INSIDE";
         data.text2Font = "Friz Quadrata TT";

--- a/WeakAurasOptions/RegionOptions/AuraBar.lua
+++ b/WeakAurasOptions/RegionOptions/AuraBar.lua
@@ -474,6 +474,13 @@ local function createOptions(id, data)
       disabled = function() return not data.text end,
       hidden = function() return not data.text end,
     },
+    textClassColor = {
+      type = "toggle",
+      name = L["Class Color"],
+      order = 48.1,
+      disabled = function() return not data.text end,
+      hidden = function() return not data.text end,
+    },
     textFont = {
       type = "select",
       dialogControl = "LSM30_Font",
@@ -539,6 +546,13 @@ local function createOptions(id, data)
       disabled = function() return not data.timer end,
       hidden = function() return not data.timer end,
     },
+    timerClassColor = {
+      type = "toggle",
+      name = L["Class Color"],
+      order = 53.1,
+      disabled = function() return not data.timer end,
+      hidden = function() return not data.timer end,
+    },
     timerFont = {
       type = "select",
       dialogControl = "LSM30_Font",
@@ -581,6 +595,13 @@ local function createOptions(id, data)
       name = L["Text Color"],
       hasAlpha = true,
       order = 57.3,
+      disabled = function() return not data.stacks end,
+      hidden = function() return not data.stacks end,
+    },
+    stacksClassColor = {
+      type = "toggle",
+      name = L["Class Color"],
+      order = 57.4,
       disabled = function() return not data.stacks end,
       hidden = function() return not data.stacks end,
     },

--- a/WeakAurasOptions/RegionOptions/Icon.lua
+++ b/WeakAurasOptions/RegionOptions/Icon.lua
@@ -140,6 +140,12 @@ local function createOptions(id, data)
       order = 39.3,
       hidden = function() return not data.text1Enabled end,
     },
+    text1ClassColor = {
+      type = "toggle",
+      name = L["Class Color"],
+      order = 39.3,
+      hidden = function() return not data.text1Enabled end,
+    },
     text1Point = {
       type = "select",
       name = L["Text Position"],
@@ -204,6 +210,12 @@ local function createOptions(id, data)
       type = "color",
       name = L["Color"],
       hasAlpha = true,
+      order = 40.3,
+      hidden = function() return not data.text2Enabled end,
+    },
+    text2ClassColor = {
+      type = "toggle",
+      name = L["Class Color"],
       order = 40.3,
       hidden = function() return not data.text2Enabled end,
     },

--- a/WeakAurasOptions/RegionOptions/Text.lua
+++ b/WeakAurasOptions/RegionOptions/Text.lua
@@ -68,6 +68,11 @@ local function createOptions(id, data)
       hasAlpha = true,
       order = 40
     },
+    classColor = {
+      type = "toggle",
+      name = L["Class Color"],
+      order = 41
+    },
     justify = {
       type = "select",
       name = L["Justify"],
@@ -165,7 +170,12 @@ local function modifyThumbnail(parent, borderframe, data, fullModify, size)
   text:SetFont(fontPath, data.fontSize, data.outline and "OUTLINE" or nil);
   text:SetTextHeight(data.fontSize);
   text:SetText(data.displayText);
-  text:SetTextColor(data.color[1], data.color[2], data.color[3], data.color[4]);
+  if not data.ClassColor then
+    text:SetTextColor(data.color[1], data.color[2], data.color[3], data.color[4]);
+    else
+      local col = RAID_CLASS_COLORS[select(2, UnitClass("player"))]
+      text:SetTextColor(col.r, col.g, col.b, col.a)
+  end
   text:SetJustifyH(data.justify);
 
   text:ClearAllPoints();


### PR DESCRIPTION
I've added a Class Color toggle button to each region that supports texts, as some people don't have Colour picker addons or would use %c this is would be a easier way than doing custom code. I'm sure this could be implemented better and it only supports player class right now, not entirely sure how to access unit data for this toggle? 