### PR TITLE
adjust trigger.unitExists option name

### DIFF
--- a/WeakAurasOptions/BuffTrigger2.lua
+++ b/WeakAurasOptions/BuffTrigger2.lua
@@ -622,7 +622,7 @@ local function GetBuffTriggerOptions(data, optionTriggerChoices)
     },
     unitExists = {
       type = "toggle",
-      name = L["Show If Unit Is Invalid"],
+      name = L["Show If Unit Does Not Exist"],
       order = 73,
       hidden = function()
         return not (trigger.type == "aura2" and trigger.unit ~= "player" and not IsGroupTrigger(trigger))


### PR DESCRIPTION
Since 'invalid unit' can mean either nonexistent unit,
or that the unit exists but is not a valid target for the tracked aura.
So, explicitly call it a nonexistent unit, instead of just invalid.

Reported on discord.