### PR TITLE
Wago update support

### DIFF
--- a/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasDisplayButton.lua
+++ b/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasDisplayButton.lua
@@ -749,7 +749,7 @@ local methods = {
       if self.update.slug then
         local wago = WeakAurasWagoUpdate[self.update.slug]
         if wago then
-          WeakAuras.ImportString(wago.string)
+          WeakAuras.ImportString(wago.encoded)
         end
       end
     end
@@ -960,10 +960,10 @@ local methods = {
       local slug, version = self.data.url:match("wago.io/([^/]+)/([0-9]+)")
       if slug and version then
         local wago = WeakAurasWagoUpdate[slug]
-        if wago and wago.version > version then
+        if wago and wago.wagoVersion > version then
           self.update.slug = slug
           self.update.version = version
-          self.update.wagoVersion = wago.version
+          self.update.wagoVersion = wago.wagoVersion
           self.update.desc = L["From version "] .. self.update.version .. L[" To version "] .. self.update.wagoVersion;
           self.update:Show()
           self.update:Enable();

--- a/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasDisplayButton.lua
+++ b/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasDisplayButton.lua
@@ -745,7 +745,6 @@ local methods = {
     end
 
     function self.callbacks.OnUpdateClick()
-      if not WeakAurasWagoUpdate then return end;
       if self.update.slug then
         local wago = WeakAurasWagoUpdate[self.update.slug]
         if wago then
@@ -954,22 +953,24 @@ local methods = {
     self.ungroup:SetScript("OnClick", self.callbacks.OnUngroupClick);
     self.upgroup:SetScript("OnClick", self.callbacks.OnUpGroupClick);
     self.downgroup:SetScript("OnClick", self.callbacks.OnDownGroupClick);
-    self.update:SetScript("OnClick", self.callbacks.OnUpdateClick);
-
-    if WeakAurasWagoUpdate and self.data.url then
-      local slug, version = self.data.url:match("wago.io/([^/]+)/([0-9]+)")
-      if slug and version then
-        local wago = WeakAurasWagoUpdate[slug]
-        if wago and wago.wagoVersion and wago.wagoVersion > version then
-          self.update.slug = slug
-          self.update.version = version
-          self.update.name = wago.name
-          self.update.author = wago.author
-          self.update.wagoVersion = wago.wagoVersion
-          self.update.title = L["Update "] .. self.update.name .. L[" by "] .. self.update.author
-          self.update.desc = L["From version "] .. self.update.version .. L[" To version "] .. self.update.wagoVersion;
-          self.update:Show()
-          self.update:Enable();
+    
+    if WeakAurasWagoUpdate then
+      self.update:SetScript("OnClick", self.callbacks.OnUpdateClick);
+      if self.data.url then
+        local slug, version = self.data.url:match("wago.io/([^/]+)/([0-9]+)")
+        if slug and version then
+          local wago = WeakAurasWagoUpdate[slug]
+          if wago and wago.wagoVersion and wago.wagoVersion > version then
+            self.update.slug = slug
+            self.update.version = version
+            self.update.name = wago.name
+            self.update.author = wago.author
+            self.update.wagoVersion = wago.wagoVersion
+            self.update.title = L["Update "] .. self.update.name .. L[" by "] .. self.update.author
+            self.update.desc = L["From version "] .. self.update.version .. L[" To version "] .. self.update.wagoVersion;
+            self.update:Show()
+            self.update:Enable();
+          end
         end
       end
     end

--- a/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasDisplayButton.lua
+++ b/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasDisplayButton.lua
@@ -960,10 +960,13 @@ local methods = {
       local slug, version = self.data.url:match("wago.io/([^/]+)/([0-9]+)")
       if slug and version then
         local wago = WeakAurasWagoUpdate[slug]
-        if wago and wago.wagoVersion > version then
+        if wago and wago.wagoVersion and wago.wagoVersion > version then
           self.update.slug = slug
           self.update.version = version
+          self.update.name = wago.name
+          self.update.author = wago.author
           self.update.wagoVersion = wago.wagoVersion
+          self.update.title = L["Update "] .. self.update.name .. L[" by "] .. self.update.author
           self.update.desc = L["From version "] .. self.update.version .. L[" To version "] .. self.update.wagoVersion;
           self.update:Show()
           self.update:Enable();

--- a/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasDisplayButton.lua
+++ b/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasDisplayButton.lua
@@ -821,6 +821,9 @@ local methods = {
           if wago and wago.wagoVersion and wago.wagoVersion > version then
             self.update.title = L["Update "] .. wago.name .. L[" by "] .. wago.author
             self.update.desc = L["From version "] .. version .. L[" To version "] .. wago.wagoVersion
+            if wago.versionNote then
+              self.update.desc = ("%s\n\n%s"):print(self.update.desc, wago.versionNote)
+            end
             self.update:Show()
             self.update:Enable()
           end


### PR DESCRIPTION
From the field "url" extract version & slug, then search for the slug in a global Array "WeakAurasWagoUpdate".
Then compare versions and show update icon if a newer version of the aura is saved in WeakAurasWagoUpdate.
Clicking the icon call WeakAuras.ImportString()
Mouseover it show a tooltip with full aura name, author, old -> new version, and is ready to show some version note

It is possible to hide specific updates from the right click menu on auras, or group of aura, that information is (or will, i'm not sure if Ora has uploaded this modification on wago yet) remove from data by wago when importing the string.

Example data file for testing:
[WeakAurasWagoUpdate.zip](https://github.com/WeakAuras/WeakAuras2/files/2630390/WeakAurasWagoUpdate.zip)

![preview](https://i.imgur.com/nia0zJm.png)