### PR TITLE
Prepare for collapsible groups

### DIFF
--- a/WeakAurasOptions/RegionOptions/AuraBar.lua
+++ b/WeakAurasOptions/RegionOptions/AuraBar.lua
@@ -6,6 +6,8 @@ local function createOptions(id, data)
   -- Region options
   local screenWidth, screenHeight = math.ceil(GetScreenWidth() / 20) * 20, math.ceil(GetScreenHeight() / 20) * 20;
   local options = {
+    __title = L["Progress Bar Settings"],
+    __order = 1,
     texture = {
       type = "select",
       dialogControl = "LSM30_Statusbar",
@@ -716,8 +718,8 @@ local function createOptions(id, data)
 
   return {
     aurabar = options,
-    position = WeakAuras.PositionOptions(id, data),
-    border = WeakAuras.BorderOptions(id, data, true);
+    border = WeakAuras.BorderOptions(id, data, 2, true);
+    position = WeakAuras.PositionOptions(id, data, 3),
   };
 end
 

--- a/WeakAurasOptions/RegionOptions/DynamicGroup.lua
+++ b/WeakAurasOptions/RegionOptions/DynamicGroup.lua
@@ -2,6 +2,8 @@ local L = WeakAuras.L
 
 local function createOptions(id, data)
   local options = {
+    __title = L["Dynamic Group Settings"],
+    __order = 1,
     grow = {
       type = "select",
       width = WeakAuras.normalWidth,
@@ -199,7 +201,7 @@ local function createOptions(id, data)
 
   return {
     dynamicgroup = options,
-    position = WeakAuras.PositionOptions(id, data, true, true),
+    position = WeakAuras.PositionOptions(id, data, 2, true, true),
   };
 end
 

--- a/WeakAurasOptions/RegionOptions/Group.lua
+++ b/WeakAurasOptions/RegionOptions/Group.lua
@@ -38,6 +38,8 @@ end
 local function createOptions(id, data)
   -- Region options
   local options = {
+    __title = L["Group Settings"],
+    __order = 1,
     align_h = {
       type = "select",
       width = WeakAuras.normalWidth,
@@ -534,8 +536,8 @@ local function createOptions(id, data)
 
   return {
     group = options,
-    position = WeakAuras.PositionOptions(id, data, true, true),
-    border = WeakAuras.BorderOptions(id, data);
+    border = WeakAuras.BorderOptions(id, data, 2);
+    position = WeakAuras.PositionOptions(id, data, 3, true, true),
   };
 end
 

--- a/WeakAurasOptions/RegionOptions/Icon.lua
+++ b/WeakAurasOptions/RegionOptions/Icon.lua
@@ -3,6 +3,8 @@ local L = WeakAuras.L
 
 local function createOptions(id, data)
   local options = {
+    __title = L["Icon Settings"],
+    __order = 1,
     color = {
       type = "color",
       width = WeakAuras.normalWidth,
@@ -396,7 +398,7 @@ local function createOptions(id, data)
 
   return {
     icon = options,
-    position = WeakAuras.PositionOptions(id, data),
+    position = WeakAuras.PositionOptions(id, data, 2),
   };
 end
 

--- a/WeakAurasOptions/RegionOptions/Model.lua
+++ b/WeakAurasOptions/RegionOptions/Model.lua
@@ -2,6 +2,8 @@ local L = WeakAuras.L;
 
 local function createOptions(id, data)
   local options = {
+    __title = L["Model Settings"],
+    __order = 1,
     model_path = {
       type = "input",
       width = WeakAuras.doubleWidth,
@@ -188,8 +190,8 @@ local function createOptions(id, data)
 
   return {
     model = options,
-    position = WeakAuras.PositionOptions(id, data),
-    border = WeakAuras.BorderOptions(id, data);
+    border = WeakAuras.BorderOptions(id, data, 2);
+    position = WeakAuras.PositionOptions(id, data, 3),
   };
 end
 

--- a/WeakAurasOptions/RegionOptions/ProgressTexture.lua
+++ b/WeakAurasOptions/RegionOptions/ProgressTexture.lua
@@ -2,6 +2,8 @@ local L = WeakAuras.L;
 
 local function createOptions(id, data)
   local options = {
+    __title = L["Progress Texture Settings"],
+    __order = 1,
     foregroundTexture = {
       width = WeakAuras.normalWidth,
       type = "input",
@@ -322,7 +324,7 @@ local function createOptions(id, data)
 
   return {
     progresstexture = options,
-    position = WeakAuras.PositionOptions(id, data),
+    position = WeakAuras.PositionOptions(id, data, 2),
   };
 end
 

--- a/WeakAurasOptions/RegionOptions/Text.lua
+++ b/WeakAurasOptions/RegionOptions/Text.lua
@@ -5,6 +5,8 @@ local screenWidth, screenHeight = math.ceil(GetScreenWidth() / 20) * 20, math.ce
 
 local function createOptions(id, data)
   local options = {
+    __title = L["Text Settings"],
+    __order = 1,
     displayText = {
       type = "input",
       width = WeakAuras.doubleWidth,
@@ -133,7 +135,7 @@ local function createOptions(id, data)
 
   return {
     text = options;
-    position = WeakAuras.PositionOptions(id, data, true);
+    position = WeakAuras.PositionOptions(id, data, 2, true);
   };
 end
 

--- a/WeakAurasOptions/RegionOptions/Texture.lua
+++ b/WeakAurasOptions/RegionOptions/Texture.lua
@@ -2,6 +2,8 @@ local L = WeakAuras.L
 
 local function createOptions(id, data)
   local options = {
+    __title = L["Texture Settings"],
+    __order = 1,
     texture = {
       type = "input",
       width = WeakAuras.doubleWidth,
@@ -91,7 +93,7 @@ local function createOptions(id, data)
 
   return {
     texture = options,
-    position = WeakAuras.PositionOptions(id, data),
+    position = WeakAuras.PositionOptions(id, data, 2),
   };
 end
 

--- a/WeakAurasOptions/WeakAurasOptions.lua
+++ b/WeakAurasOptions/WeakAurasOptions.lua
@@ -2604,7 +2604,7 @@ local function copyOptionTable(input, orderAdjustment)
   return resultOption;
 end
 
-local function flattenRegionOptions(allOptions, withoutHeader)
+local function flattenRegionOptions(allOptions)
   local result = {};
   local base = 1000;
 

--- a/WeakAurasOptions/WeakAurasOptions.lua
+++ b/WeakAurasOptions/WeakAurasOptions.lua
@@ -3548,11 +3548,6 @@ function WeakAuras.PositionOptions(id, data, metaOrder, hideWidthHeight, disable
   local positionOptions = {
     __title = L["Position Settings"],
     __order = metaOrder,
-    position_header = {
-      type = "header",
-      name = L["Position Settings"],
-      order = 46.0,
-    },
     width = {
       type = "range",
       width = WeakAuras.normalWidth,
@@ -3939,11 +3934,6 @@ function WeakAuras.BorderOptions(id, data, metaOrder, showBackDropOptions)
   local borderOptions = {
     __title = L["Border Settings"],
     __order = metaOrder,
-    border_header = {
-      type = "header",
-      name = L["Border Settings"],
-      order = 46.0
-    },
     border = {
       type = "toggle",
       width = WeakAuras.normalWidth,

--- a/WeakAurasOptions/WeakAurasOptions.lua
+++ b/WeakAurasOptions/WeakAurasOptions.lua
@@ -2692,7 +2692,7 @@ function WeakAuras.AddOption(id, data)
           end
           WeakAuras.ResetMoverSizer();
         end,
-        args = flattenRegionOptions(regionOption, false);
+        args = flattenRegionOptions(regionOption);
       },
       trigger = {
         type = "group",
@@ -3352,7 +3352,7 @@ function WeakAuras.ReloadTriggerOptions(data)
       end,
       hidden = function() return false end,
       disabled = function() return false end,
-      args = flattenRegionOptions(regionOption, true);
+      args = flattenRegionOptions(regionOption);
     };
 
     data.load.use_class = getAll(data, {"load", "use_class"});
@@ -3468,13 +3468,11 @@ end
 
 function WeakAuras.ReloadGroupRegionOptions(data)
   local regionTypes = {};
-  local regionTypeCount = 0;
   for index, childId in ipairs(data.controlledChildren) do
     local childData = WeakAuras.GetData(childId);
     if(childData) then
       if (not regionTypes[childData.regionType]) then
         regionTypes[childData.regionType] = true;
-        regionTypeCount = regionTypeCount + 1;
       end
     end
   end
@@ -3503,7 +3501,7 @@ function WeakAuras.ReloadGroupRegionOptions(data)
   removeFuncs(allOptions);
   fixMetaOrders(allOptions);
 
-  local regionOption = flattenRegionOptions(allOptions, false);
+  local regionOption = flattenRegionOptions(allOptions);
 
   options.args.region.args = regionOption;
 end

--- a/WeakAurasOptions/WeakAurasOptions.lua
+++ b/WeakAurasOptions/WeakAurasOptions.lua
@@ -3497,13 +3497,13 @@ function WeakAuras.ReloadGroupRegionOptions(data)
     end
   end
 
+  replaceNameDescFuncs(allOptions, data);
+  replaceImageFuncs(allOptions, data);
+  replaceValuesFuncs(allOptions, data);
+  removeFuncs(allOptions);
   fixMetaOrders(allOptions);
-  local regionOption = flattenRegionOptions(allOptions, false);
 
-  replaceNameDescFuncs(regionOption, data);
-  replaceImageFuncs(regionOption, data);
-  replaceValuesFuncs(regionOption, data);
-  removeFuncs(regionOption);
+  local regionOption = flattenRegionOptions(allOptions, false);
 
   options.args.region.args = regionOption;
 end

--- a/WeakAurasOptions/WeakAurasOptions.lua
+++ b/WeakAurasOptions/WeakAurasOptions.lua
@@ -2606,29 +2606,21 @@ end
 
 local function flattenRegionOptions(allOptions, withoutHeader)
   local result = {};
+  local base = 1000;
 
-  local base = 100;
+  for optionGroup, options in pairs(allOptions) do
+    local groupBase = base * options.__order
 
-  for regionType, options in pairs(allOptions) do
-    if (regionType ~= "border" and regionType ~= "position") then
-      for optionName, option in pairs(options) do
-        result[regionType .. "." .. optionName] = copyOptionTable(option, base);
+    result[optionGroup]  = {
+      type = "header",
+      name = options.__title,
+      order = groupBase,
+    }
+
+    for optionName, option in pairs(options) do
+      if not optionName:find("^__") then
+        result[optionGroup .. "." .. optionName] = copyOptionTable(option, groupBase);
       end
-
-      base = base + 100;
-    end
-  end
-
-  if (allOptions["border"]) then
-    for optionName, option in pairs(allOptions["border"]) do
-      result["border." .. optionName] = copyOptionTable(option, base);
-    end
-    base = base + 100;
-  end
-
-  if (allOptions["position"]) then
-    for optionName, option in pairs(allOptions["position"]) do
-      result["position." .. optionName] = copyOptionTable(option, base);
     end
   end
 
@@ -3547,13 +3539,15 @@ function WeakAuras.ReloadGroupRegionOptions(data)
   options.args.region.args = regionOption;
 end
 
-function WeakAuras.PositionOptions(id, data, hideWidthHeight, disableSelfPoint)
+function WeakAuras.PositionOptions(id, data, metaOrder, hideWidthHeight, disableSelfPoint)
   local function IsParentDynamicGroup()
     return data.parent and db.displays[data.parent] and db.displays[data.parent].regionType == "dynamicgroup";
   end
 
   local screenWidth, screenHeight = math.ceil(GetScreenWidth() / 20) * 20, math.ceil(GetScreenHeight() / 20) * 20;
   local positionOptions = {
+    __title = L["Position Settings"],
+    __order = metaOrder,
     position_header = {
       type = "header",
       name = L["Position Settings"],
@@ -3945,8 +3939,10 @@ function WeakAuras.AddPositionOptions(input, id, data)
   return union(input, WeakAuras.PositionOptions(id, data));
 end
 
-function WeakAuras.BorderOptions(id, data, showBackDropOptions)
+function WeakAuras.BorderOptions(id, data, metaOrder, showBackDropOptions)
   local borderOptions = {
+    __title = L["Border Settings"],
+    __order = metaOrder,
     border_header = {
       type = "header",
       name = L["Border Settings"],

--- a/WeakAurasOptions/WeakAurasOptions.lua
+++ b/WeakAurasOptions/WeakAurasOptions.lua
@@ -3502,7 +3502,7 @@ function WeakAuras.ReloadGroupRegionOptions(data)
     if(childData) then
       if (not regionTypes[childData.regionType]) then
         regionTypes[childData.regionType] = true;
-        regionTypeCount = regionTypeCount +1;
+        regionTypeCount = regionTypeCount + 1;
       end
     end
   end

--- a/WeakAurasOptions/WeakAurasOptions.lua
+++ b/WeakAurasOptions/WeakAurasOptions.lua
@@ -3935,10 +3935,6 @@ function WeakAuras.PositionOptions(id, data, metaOrder, hideWidthHeight, disable
   return positionOptions;
 end
 
-function WeakAuras.AddPositionOptions(input, id, data)
-  return union(input, WeakAuras.PositionOptions(id, data));
-end
-
 function WeakAuras.BorderOptions(id, data, metaOrder, showBackDropOptions)
   local borderOptions = {
     __title = L["Border Settings"],
@@ -4045,11 +4041,6 @@ function WeakAuras.BorderOptions(id, data, metaOrder, showBackDropOptions)
 
   return borderOptions;
 end
-
-function WeakAuras.AddBorderOptions(input, id, data)
-  return union(input, WeakAuras.BorderOptions(id, data));
-end
-
 
 function WeakAuras.OpenTextEditor(...)
   frame.texteditor:Open(...);


### PR DESCRIPTION
This will cause a slight appearance change in the UI, when auras of disparate region types are Picked. Instead of a large font description header, an actual header type is chosen (this can of course be adjusted if necessary). Beyond that, there should be no user-facing changes from this pull request.