### PR TITLE
Fix login process

### DIFF
--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -1397,7 +1397,14 @@ loadedFrame:SetScript("OnEvent", function(self, event, addon)
         loginFinished = true;
       end
     )
-    WeakAuras.dynFrame:AddAction('login', loginThread)
+    local startTime = debugprofilestop()
+    local finishTime = debugprofilestop()
+    while coroutine.status(loginThread) ~= 'dead' and finishTime - startTime < 15000 do
+      coroutine.resume(loginThread)
+    end
+    if coroutine.status(loginThread) ~= 'dead' then
+      WeakAuras.dynFrame:AddAction('login', loginThread)
+    end
   elseif(event == "PLAYER_ENTERING_WORLD") then
     -- Schedule events that need to be handled some time after login
     timer:ScheduleTimer(function() squelch_actions = false; end, db.login_squelch_time);      -- No sounds while loading

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -2256,7 +2256,7 @@ function WeakAuras.ResolveCollisions(onFinished)
         -- Do the collision resolution
         local newId = self.editBox:GetText();
         if(WeakAuras.OptionsFrame and WeakAuras.OptionsFrame() and WeakAuras.displayButtons and WeakAuras.displayButtons[currentId]) then
-          WeakAuras.displayButtons[currentId].loginQueue.OnRenameAction(newId)
+          WeakAuras.displayButtons[currentId].callbacks.OnRenameAction(newId)
         else
           local data = WeakAuras.GetData(currentId);
           if(data) then
@@ -3174,8 +3174,8 @@ function WeakAuras.SetRegion(data, cloneId)
           data.parent = nil;
         end
       end
-
-      local anim_cancelled = WeakAuras.CancelAnimation(region, true, true, true, true, true);
+      local loginFinished = WeakAuras.IsLoginFinished();
+      local anim_cancelled = loginFinished and WeakAuras.CancelAnimation(region, true, true, true, true, true);
 
       regionTypes[regionType].modify(parent, region, data);
       WeakAuras.regionPrototype.AddSetDurationInfo(region);
@@ -3200,7 +3200,6 @@ function WeakAuras.SetRegion(data, cloneId)
       if(cloneId) then
         clonePool[regionType] = clonePool[regionType] or {};
       end
-
       if(anim_cancelled) then
         WeakAuras.Animate("display", data, "main", data.animation.main, region, false, nil, true, cloneId);
       end

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -2729,54 +2729,50 @@ function WeakAuras.SyncParentChildRelationships(silent)
 end
 
 function WeakAuras.AddMany(table)
-  local f = coroutine.create(function()
-    local idtable = {};
-    for _, data in ipairs(table) do
-      idtable[data.id] = data;
-    end
-    local loaded = {};
-    local function load(id, depends)
-      local data = idtable[id];
-      if(data.parent) then
-        if(idtable[data.parent]) then
-          if(tContains(depends, data.parent)) then
-            error("Circular dependency in WeakAuras.AddMany between "..table.concat(depends, ", "));
-          else
-            if not(loaded[data.parent]) then
-              local dependsOut = {};
-              for i,v in pairs(depends) do
-                dependsOut[i] = v;
-              end
-              tinsert(dependsOut, data.parent);
-              load(data.parent, dependsOut);
-            end
-          end
+  local idtable = {};
+  for _, data in ipairs(table) do
+    idtable[data.id] = data;
+  end
+  local loaded = {};
+  local function load(id, depends)
+    local data = idtable[id];
+    if(data.parent) then
+      if(idtable[data.parent]) then
+        if(tContains(depends, data.parent)) then
+          error("Circular dependency in WeakAuras.AddMany between "..table.concat(depends, ", "));
         else
-          data.parent = nil;
+          if not(loaded[data.parent]) then
+            local dependsOut = {};
+            for i,v in pairs(depends) do
+              dependsOut[i] = v;
+            end
+            tinsert(dependsOut, data.parent);
+            load(data.parent, dependsOut);
+          end
         end
-      end
-      if not(loaded[id]) then
-        WeakAuras.Add(data);
-        loaded[id] = true;
-      end
-    end
-    local groups = {}
-    for id, data in pairs(idtable) do
-      load(id, {});
-      if data.regionType == "dynamicgroup" or data.regionType == "group" then
-        groups[data] = true
-      end
-    end
-    for data in pairs(groups) do
-      if data.type == "dynamicgroup" then
-        regions[data.id].region:ControlChildren()
       else
-        WeakAuras.Add(data)
+        data.parent = nil;
       end
-      coroutine.yield()
     end
-  end)
-  WeakAuras.dynFrame:AddAction("addmany", f)
+    if not(loaded[id]) then
+      WeakAuras.Add(data);
+      loaded[id] = true;
+    end
+  end
+  local groups = {}
+  for id, data in pairs(idtable) do
+    load(id, {});
+    if data.regionType == "dynamicgroup" or data.regionType == "group" then
+      groups[data] = true
+    end
+  end
+  for data in pairs(groups) do
+    if data.type == "dynamicgroup" then
+      regions[data.id].region:ControlChildren()
+    else
+      WeakAuras.Add(data)
+    end
+  end
 end
 
 local function validateUserConfig(data)


### PR DESCRIPTION
# Description

This is a better fix of the login issue introduced with the WoW 8.1 patch (which seems to limit the amount of time that we have to perform the login process to 19 seconds).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ ] Login at 2.10.3 or earlier with this SV file: [8.1SVTest.zip](https://github.com/WeakAuras/WeakAuras2/files/2670700/8.1SVTest.zip) Note the errors that occur, which include "Script ran too Long"
- [ ] Login on this branch with the same SV: Note that WeakAuras successfully logs in.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Known issue: With extremely large SV files, there are a few seconds at login where all of the regions will be visible for a short time, before vanishing. This is due to regions being created in an expanded state, and needs to be rectified. But it does not impede the performance of WeakAuras after login, and will appear rarely for the average user.
