### PR TITLE
call WeakAuras.InitCustomTextUpdates() at the end of loginThread

### DIFF
--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -4207,7 +4207,6 @@ do
   end
 
   function WeakAuras.RegisterCustomTextUpdates(region)
-    WeakAuras.InitCustomTextUpdates();
     updateRegions[region] = true;
   end
 

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -1368,6 +1368,7 @@ local loginThread = coroutine.create(function()
     coroutine.yield();
     nextCallback = loginQueue[1];
   end
+  WeakAuras.InitCustomTextUpdates()
 end)
 
 function WeakAuras.IsLoginFinished()
@@ -1421,6 +1422,8 @@ loadedFrame:SetScript("OnEvent", function(self, event, addon)
     end
     if coroutine.status(loginThread) ~= 'dead' then
       WeakAuras.dynFrame:AddAction('login', loginThread)
+    else
+      WeakAuras.InitCustomTextUpdates()
     end
   elseif(event == "LOADING_SCREEN_ENABLED") then
     in_loading_screen = true;


### PR DESCRIPTION
# Description

call WeakAuras.InitCustomTextUpdates() at the end of loginThread
i added it twice
- at the end of the loginThread coroutine, this call will works only if the coroutine finish after login screen
- on "PLAYER_LOGIN" after the 15s loop over the coroutine, this will work if loginThread is finished on time

Fixes #1017

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] my normal account with reasonable size SV
- [x] test account with large SV

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

Can you test it with the giant SV you made @emptyrivers ?
