### PR TITLE
Companion: Indicator on group, match by uid, version field

### DIFF
--- a/WeakAuras/Transmission.lua
+++ b/WeakAuras/Transmission.lua
@@ -101,6 +101,7 @@ function GenerateUniqueID()
   end
   return table.concat(s)
 end
+WeakAuras.GenerateUniqueID = GenerateUniqueID
 
 function CompressDisplay(data)
   -- Clean up custom trigger fields that are unused
@@ -668,9 +669,7 @@ function WeakAuras.DisplayToString(id, forChat)
         if(childData) then
           if childData.uid then
             if uids[childData.uid] then
-              -- This should be pretty rare, but may cause some unexpected behavior.
-              -- The other option is to regenerate the uid in this case.B
-              childData.uid = nil
+              childData.uid = GenerateUniqueID()
             else
               uids[childData.uid] = true
             end

--- a/WeakAuras/Types.lua
+++ b/WeakAuras/Types.lua
@@ -1727,6 +1727,8 @@ WeakAuras.internal_fields = {
   expanded = true,
   parent = true,
   authorMode = true,
+  skipWagoUpdate = true,
+  ignoreWagoUpdate = true
 }
 
 WeakAuras.data_stub = {

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -1,4 +1,4 @@
-local internalVersion = 9;
+local internalVersion = 10;
 
 -- WoW APIs
 local GetTalentInfo, IsAddOnLoaded, InCombatLockdown = GetTalentInfo, IsAddOnLoaded, InCombatLockdown
@@ -2722,7 +2722,7 @@ function WeakAuras.Modernize(data)
   -- Version 8 was introduced in September 2018
   -- Changes are in PreAdd
 
-  -- Version 9 was introduced in September 2019
+  -- Version 9 was introduced in September 2018
   if data.internalVersion < 9 then
     local function repairCheck(check)
       if check and check.variable == "buffed" then
@@ -2748,6 +2748,17 @@ function WeakAuras.Modernize(data)
     for _, condition in pairs(data.conditions) do
       repairCheck(condition.check);
       recurseRepairChecks(condition.check.checks);
+    end
+  end
+
+  -- Version 10 was introduced in December 2018
+  if data.internalVersion < 10 then
+    if data.url and data.url ~= "" then
+      local slug, version = data.url:match("wago.io/([^/]+)/([0-9]+)")
+      if not slug and not version then
+        version = 1
+      end
+      data.version = version
     end
   end
 

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -2756,9 +2756,12 @@ function WeakAuras.Modernize(data)
     if data.url and data.url ~= "" then
       local slug, version = data.url:match("wago.io/([^/]+)/([0-9]+)")
       if not slug and not version then
+        slug = self.data.url:match("wago.io/([^/]+)$")
         version = 1
       end
-      data.version = version
+      if slug then
+        data.version = version
+      end
     end
   end
 

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -2753,10 +2753,10 @@ function WeakAuras.Modernize(data)
 
   -- Version 10 was introduced in December 2018
   if data.internalVersion < 10 then
-    if data.url and data.url ~= "" then
+    if not data.version and data.url and data.url ~= "" then
       local slug, version = data.url:match("wago.io/([^/]+)/([0-9]+)")
       if not slug and not version then
-        slug = self.data.url:match("wago.io/([^/]+)$")
+        slug = data.url:match("wago.io/([^/]+)$")
         version = 1
       end
       if slug then

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -2753,6 +2753,7 @@ function WeakAuras.Modernize(data)
 
   -- Version 10 was introduced in December 2018
   if data.internalVersion < 10 then
+    data.uid = data.uid or WeakAuras.GenerateUniqueID()
     if not data.version and data.url and data.url ~= "" then
       local slug, version = data.url:match("wago.io/([^/]+)/([0-9]+)")
       if not slug and not version then

--- a/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasDisplayButton.lua
+++ b/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasDisplayButton.lua
@@ -1634,7 +1634,7 @@ local methods = {
         end
       end
     end
-    -- no addon, or no uid, or no data, or ignore flag
+    -- no addon, or no data, or ignore flag
     return false, false, nil
   end,
   ["SetGroupOrder"] = function(self, order, max)

--- a/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasDisplayButton.lua
+++ b/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasDisplayButton.lua
@@ -827,6 +827,13 @@ local methods = {
         self.update:Show()
         self.update:Enable()
         self.updateLogo:Show()
+        -- show update on group
+        if self.data.parent then
+          local button = WeakAuras.GetDisplayButton(self.data.parent)
+          if button then
+            button:ShowGroupUpdate()
+          end
+        end
       end
       -- childs
       if self.data.controlledChildren then
@@ -854,6 +861,13 @@ local methods = {
         self.update:Hide()
         self.update:Disable()
         self.updateLogo:Hide()
+        -- update group icon if necessary
+        if self.data.parent then
+          local button = WeakAuras.GetDisplayButton(self.data.parent)
+          if button then
+            WeakAuras.RefreshGroupUpdateIcon(button)
+          end
+        end
       end
       -- childs
       if self.data.controlledChildren then
@@ -888,6 +902,13 @@ local methods = {
         self.update:Show()
         self.update:Enable()
         self.updateLogo:Show()
+        -- show update on group
+        if self.data.parent then
+          local button = WeakAuras.GetDisplayButton(self.data.parent)
+          if button then
+            button:ShowGroupUpdate()
+          end
+        end
       end
       -- childs
       if self.data.controlledChildren then
@@ -915,6 +936,13 @@ local methods = {
         self.update:Hide()
         self.update:Disable()
         self.updateLogo:Hide()
+        -- update group icon if necessary
+        if self.data.parent then
+          local button = WeakAuras.GetDisplayButton(self.data.parent)
+          if button then
+            WeakAuras.RefreshGroupUpdateIcon(button)
+          end
+        end
       end
       -- childs
       if self.data.controlledChildren then
@@ -1153,6 +1181,13 @@ local methods = {
                   notCheckable = 1,
                   func = self.callbacks.OnUpdateClick
                 });
+                -- show icon on group
+                if self.data.parent then
+                  local button = WeakAuras.GetDisplayButton(self.data.parent)
+                  if button then
+                    button:ShowGroupUpdate()
+                  end
+                end
               end
             end
           end
@@ -1581,6 +1616,29 @@ local methods = {
       self:Collapse();
     end
   end,
+  ["ShowGroupUpdate"] = function(self)
+    if self.groupUpdate.disable then
+      self.groupUpdate:Show()
+      self.groupUpdate.disable = false
+    end
+  end,
+  ["HideGroupUpdate"] = function(self)
+    if not self.groupUpdate.disable then
+      self.groupUpdate:Hide()
+      self.groupUpdate.disable = true
+    end
+  end,
+  ["HasUpdate"] = function(self)
+    if self.update
+    and self.update.slug
+    and not self.data.ignoreWagoUpdate
+    and not (self.data.skipWagoUpdate and self.data.skipWagoUpdate == self.update.wagoVersion)
+    then
+      return true
+    else
+      return false
+    end
+  end,
   ["SetGroupOrder"] = function(self, order, max)
     if(order == 1) then
       self:DisableUpGroup();
@@ -1922,6 +1980,7 @@ local function Constructor()
   expand:SetScript("OnLeave", Hide_Tooltip);
 
   local update, updateLogo
+  local groupUpdate
   if WeakAurasCompanion then
     update = CreateFrame("BUTTON", nil, button);
     button.update = update
@@ -1960,6 +2019,22 @@ local function Constructor()
     update:SetScript("OnLeave", Hide_Tooltip);
     update:Hide();
     updateLogo:Hide()
+
+    -- Update in group icon
+    groupUpdate = CreateFrame("Frame", nil, button);
+    button.groupUpdate = groupUpdate
+    local gtex = groupUpdate:CreateTexture(nil, "OVERLAY")
+    gtex:SetTexture([[Interface\AddOns\WeakAuras\Media\Textures\wagoupdate_logo.tga]])
+    gtex:SetAllPoints()
+    groupUpdate:SetSize(16, 16);
+    groupUpdate:SetPoint("BOTTOM", button, "BOTTOM");
+    groupUpdate:SetPoint("LEFT", icon, "RIGHT", 20, 0);
+    groupUpdate.disable = true
+    groupUpdate.title = L["Update in Group"];
+    groupUpdate.desc = L["Group contains updates from Wago"];
+    groupUpdate:SetScript("OnEnter", function() Show_Tooltip(button, groupUpdate.title, groupUpdate.desc) end);
+    groupUpdate:SetScript("OnLeave", Hide_Tooltip);
+    groupUpdate:Hide();
   end
 
   local widget = {
@@ -1980,6 +2055,7 @@ local function Constructor()
     background = background,
     expand = expand,
     update = update,
+    groupUpdate = groupUpdate,
     updateLogo = updateLogo,
     type = Type
   }

--- a/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasDisplayButton.lua
+++ b/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasDisplayButton.lua
@@ -745,9 +745,9 @@ local methods = {
     end
 
     function self.callbacks.OnUpdateClick()
-      local wago = WeakAurasCompanion[self.update.slug]
-      if wago then
-        WeakAuras.ImportString(wago.encoded)
+      local _,_,updateData = self:HasUpdate()
+      if updateData then
+        WeakAuras.ImportString(updateData.encoded)
       end
     end
 
@@ -807,7 +807,7 @@ local methods = {
       local wagoMenu = self.menu[8].menuList
       wagoMenu[1].func = self.callbacks.wagoIgnoreAll
       wagoMenu[1].text = L["Ignore all Updates"]
-      if self.update.slug then
+      if self:HasUpdate() then
         tinsert(wagoMenu, {
           text = L["Ignore this Update"],
           notCheckable = 1,
@@ -847,13 +847,11 @@ local methods = {
     end
 
     function self.callbacks.wagoIgnoreAll()
-      -- set ignore flag
-      self.data.ignoreWagoUpdate = true
       -- update menu entries
       local wagoMenu = self.menu[8].menuList
       wagoMenu[1].func = self.callbacks.wagoStopIgnoreAll
       wagoMenu[1].text = L["Stop ignoring Updates"]
-      if self.update.slug then
+      if self:HasUpdate() then
         tremove(wagoMenu, 2)
         tremove(wagoMenu, 2)
         tremove(wagoMenu, 2)
@@ -861,6 +859,8 @@ local methods = {
         self.update:Hide()
         self.update:Disable()
         self.updateLogo:Hide()
+        -- set ignore flag
+        self.data.ignoreWagoUpdate = true
         -- update group icon if necessary
         if self.data.parent then
           local button = WeakAuras.GetDisplayButton(self.data.parent)
@@ -883,7 +883,7 @@ local methods = {
     function self.callbacks.wagoStopIgnoreNext()
       -- remove skip flag
       self.data.skipWagoUpdate = nil
-      if self.update.slug then
+      if self:HasUpdate() then
         -- update menu entries
         local wagoMenu = self.menu[8].menuList
         wagoMenu[2].func = self.callbacks.wagoIgnoreNext
@@ -922,9 +922,8 @@ local methods = {
     end
 
     function self.callbacks.wagoIgnoreNext()
-      if self.update.slug then
-        -- skip wago version
-        self.data.skipWagoUpdate = self.update.wagoVersion
+      local hasUpdate, skipVersion, updateData = self:HasUpdate()
+      if hasUpdate then
         -- update menu entries
         local wagoMenu = self.menu[8].menuList
         wagoMenu[2].func = self.callbacks.wagoStopIgnoreNext
@@ -936,6 +935,8 @@ local methods = {
         self.update:Hide()
         self.update:Disable()
         self.updateLogo:Hide()
+        -- skip wago version
+        self.data.skipWagoUpdate = updateData.wagoVersion
         -- update group icon if necessary
         if self.data.parent then
           local button = WeakAuras.GetDisplayButton(self.data.parent)
@@ -1109,93 +1110,76 @@ local methods = {
     self.downgroup:SetScript("OnClick", self.callbacks.OnDownGroupClick);
 
     if WeakAurasCompanion then
-      if self.data.url and self.data.url ~= "" then
-        local slug, version = self.data.url:match("wago.io/([^/]+)/([0-9]+)")
-        if not slug and not version then
-          slug = self.data.url:match("wago.io/([^/]+)$")
-          version = 1
-        end
-        if slug and version then
-          local wago = WeakAurasCompanion[slug]
-          -- add sync entry in menu
-          tinsert(self.menu, 8, {
-            text = '|TInterface\\OptionsFrame\\UI-OptionsFrame-NewFeatureIcon:0|t' .. L["Wago Update"],
+      -- add sync entry in menu
+      tinsert(self.menu, 8, {
+        text = '|TInterface\\OptionsFrame\\UI-OptionsFrame-NewFeatureIcon:0|t' .. L["Wago Update"],
+        notCheckable = 1,
+        hasArrow = true,
+        menuList = {
+          {
+            text = self.data.ignoreWagoUpdate and L["Stop ignoring Updates"] or L["Ignore all Updates"],
             notCheckable = 1,
-            hasArrow = true,
-            menuList = {
-              {
-                text = self.data.ignoreWagoUpdate and L["Stop ignoring Updates"] or L["Ignore all Updates"],
-                notCheckable = 1,
-                func = self.data.ignoreWagoUpdate and self.callbacks.wagoStopIgnoreAll or self.callbacks.wagoIgnoreAll
-              }
-            }
+            func = self.data.ignoreWagoUpdate and self.callbacks.wagoStopIgnoreAll or self.callbacks.wagoIgnoreAll
+          }
+        }
+      });
+      local wagoMenu = self.menu[8].menuList
+      local hasUpdate, skipVersion, updateData = self:HasUpdate()
+      -- there is a string for this aura
+      if hasUpdate then
+        self.update.title = L["Update "] .. updateData.name .. L[" by "] .. updateData.author
+        self.update.desc = L["From version "] .. self.data.version .. L[" to version "] .. updateData.wagoVersion
+        if updateData.versionNote then
+          self.update.desc = ("%s\n\n%s"):print(self.update.desc, updateData.versionNote)
+        end
+        self.update:SetScript("OnClick", self.callbacks.OnUpdateClick);
+
+        -- add skip version entry in menu
+        if skipVersion then
+          tinsert(wagoMenu, {
+            text =  L["Stop ignoring this Update"],
+            notCheckable = 1,
+            func = self.callbacks.wagoStopIgnoreNext
           });
-          local wagoMenu = self.menu[8].menuList
-          -- there is a string for this aura
-          if wago and wago.wagoVersion then
-            self.update.wagoVersion = tonumber(wago.wagoVersion)
-            self.update.version = tonumber(version)
-            -- string is newer
-            if self.update.wagoVersion > self.update.version then
-              self.update.title = L["Update "] .. wago.name .. L[" by "] .. wago.author
-              self.update.desc = L["From version "] .. version .. L[" to version "] .. wago.wagoVersion
-              self.update.slug = slug
-              if wago.versionNote then
-                self.update.desc = ("%s\n\n%s"):print(self.update.desc, wago.versionNote)
-              end
-              self.update:SetScript("OnClick", self.callbacks.OnUpdateClick);
+        else
+          tinsert(wagoMenu, {
+            text = L["Ignore this Update"],
+            notCheckable = 1,
+            func = self.callbacks.wagoIgnoreNext
+          });
+        end
+      end
 
-              -- add skip version entry in menu
-              if not self.data.ignoreWagoUpdate then
-                if self.update.wagoVersion == self.data.skipWagoUpdate then
-                  tinsert(wagoMenu, {
-                    text =  L["Stop ignoring this Update"],
-                    notCheckable = 1,
-                    func = self.callbacks.wagoStopIgnoreNext
-                  });
-                else
-                  tinsert(wagoMenu, {
-                    text = L["Ignore this Update"],
-                    notCheckable = 1,
-                    func = self.callbacks.wagoIgnoreNext
-                  });
-                end
-              end
-
-              -- show or hide update icon
-              if self.update.wagoVersion == self.data.skipWagoUpdate or self.data.ignoreWagoUpdate then
-                self.update:Hide()
-                self.update:Disable()
-                self.updateLogo:Hide()
-              else
-                self.update:Show()
-                self.update:Enable()
-                self.updateLogo:Show()
-                tinsert(wagoMenu, {
-                  text = " ",
-                  notClickable = 1,
-                  notCheckable = 1,
-                });
-                tinsert(wagoMenu, {
-                  text = L["Update this Aura"],
-                  notCheckable = 1,
-                  func = self.callbacks.OnUpdateClick
-                });
-                -- show icon on group
-                if self.data.parent then
-                  local button = WeakAuras.GetDisplayButton(self.data.parent)
-                  if button then
-                    button:ShowGroupUpdate()
-                  end
-                end
-              end
-            end
+      -- show or hide update icon
+      if skipVersion or not hasUpdate then
+        self.update:Hide()
+        self.update:Disable()
+        self.updateLogo:Hide()
+      else
+        self.update:Show()
+        self.update:Enable()
+        self.updateLogo:Show()
+        tinsert(wagoMenu, {
+          text = " ",
+          notClickable = 1,
+          notCheckable = 1,
+        });
+        tinsert(wagoMenu, {
+          text = L["Update this Aura"],
+          notCheckable = 1,
+          func = self.callbacks.OnUpdateClick
+        });
+        -- show icon on group
+        if self.data.parent then
+          local button = WeakAuras.GetDisplayButton(self.data.parent)
+          if button then
+            button:ShowGroupUpdate()
           end
         end
       end
     end
 
-    if(data.parent) then
+    if data.parent then
       local parentData = WeakAuras.GetData(data.parent);
       local index;
       for childIndex, childId in pairs(parentData.controlledChildren) do
@@ -1617,27 +1601,41 @@ local methods = {
     end
   end,
   ["ShowGroupUpdate"] = function(self)
-    if self.groupUpdate.disable then
+    if self.groupUpdate and self.groupUpdate.disable then
       self.groupUpdate:Show()
       self.groupUpdate.disable = false
     end
   end,
   ["HideGroupUpdate"] = function(self)
-    if not self.groupUpdate.disable then
+    if self.groupUpdate and not self.groupUpdate.disable then
       self.groupUpdate:Hide()
       self.groupUpdate.disable = true
     end
   end,
   ["HasUpdate"] = function(self)
-    if self.update
-    and self.update.slug
+    -- return hasUpdate, skipVersion, updateData
+    if WeakAurasCompanion
+    and self.data.uid
     and not self.data.ignoreWagoUpdate
-    and not (self.data.skipWagoUpdate and self.data.skipWagoUpdate == self.update.wagoVersion)
     then
-      return true
-    else
-      return false
+      local slug = WeakAurasCompanion.uids[self.data.uid]
+      if slug then
+        local updateData = WeakAurasCompanion.slugs[slug]
+        if updateData then
+          if not (self.data.skipWagoUpdate and self.data.skipWagoUpdate == updateData.wagoVersion) then
+            if tonumber(updateData.wagoVersion) > tonumber(self.data.version) then
+              -- got update
+              return true, false, updateData
+            end
+          else
+            -- version skip flag
+            return true, true, updateData
+          end
+        end
+      end
     end
+    -- no addon, or no uid, or no data, or ignore flag
+    return false, false, nil
   end,
   ["SetGroupOrder"] = function(self, order, max)
     if(order == 1) then

--- a/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasDisplayButton.lua
+++ b/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasDisplayButton.lua
@@ -2,7 +2,7 @@ local tinsert, tconcat, tremove, wipe = table.insert, table.concat, table.remove
 local select, pairs, next, type, unpack = select, pairs, next, type, unpack
 local tostring, error = tostring, error
 
-local Type, Version = "WeakAurasDisplayButton", 41
+local Type, Version = "WeakAurasDisplayButton", 42
 local AceGUI = LibStub and LibStub("AceGUI-3.0", true)
 if not AceGUI or (AceGUI:GetWidgetVersion(Type) or 0) >= Version then return end
 

--- a/WeakAurasOptions/WeakAurasOptions.lua
+++ b/WeakAurasOptions/WeakAurasOptions.lua
@@ -4460,7 +4460,23 @@ function WeakAuras.UpdateDisplayButton(data)
   local button = displayButtons[id];
   if (button) then
     button:SetIcon(WeakAuras.SetThumbnail(data));
+    if button:IsGroup() then
+      WeakAuras.RefreshGroupUpdateIcon(button)
+    end
   end
+end
+
+function WeakAuras.RefreshGroupUpdateIcon(button)
+  local parentId = button.data.id
+  for id, child in pairs(displayButtons) do
+    if child.data.parent == parentId then
+      if child:HasUpdate() then
+        button:ShowGroupUpdate()
+        return
+      end
+    end
+  end
+  button:HideGroupUpdate()
 end
 
 function WeakAuras.SetThumbnail(data)

--- a/WeakAurasOptions/WeakAurasOptions.lua
+++ b/WeakAurasOptions/WeakAurasOptions.lua
@@ -4460,7 +4460,7 @@ function WeakAuras.UpdateDisplayButton(data)
   local button = displayButtons[id];
   if (button) then
     button:SetIcon(WeakAuras.SetThumbnail(data));
-    if button:IsGroup() then
+    if WeakAurasCompanion and button:IsGroup() then
       WeakAuras.RefreshGroupUpdateIcon(button)
     end
   end
@@ -4470,7 +4470,8 @@ function WeakAuras.RefreshGroupUpdateIcon(button)
   local parentId = button.data.id
   for id, child in pairs(displayButtons) do
     if child.data.parent == parentId then
-      if child:HasUpdate() then
+      local hasUpdate, skipVersion = child:HasUpdate()
+      if hasUpdate and not skipVersion then
         button:ShowGroupUpdate()
         return
       end

--- a/WeakAurasOptions/WeakAurasOptions.lua
+++ b/WeakAurasOptions/WeakAurasOptions.lua
@@ -363,66 +363,6 @@ function WeakAuras.MultipleDisplayTooltipDesc()
   return desc;
 end
 
-function WeakAuras.DuplicateAura(data)
-  local base_id = data.id .. " ";
-  local num = 2;
-
-  -- if the old id ends with a number increment the number
-  local matchName, matchNumber = string.match(data.id, "^(.-)(%d*)$")
-  matchNumber = tonumber(matchNumber)
-  if (matchName ~= "" and matchNumber ~= nil) then
-    base_id = matchName;
-    num = matchNumber + 1
-  end
-
-  local new_id = base_id .. num;
-  while(WeakAuras.GetData(new_id)) do
-    new_id = base_id .. num;
-    num = num + 1;
-  end
-
-  local newData = {};
-  WeakAuras.DeepCopy(data, newData);
-  newData.id = new_id;
-  newData.parent = nil;
-  newData.uid = WeakAuras.GenerateUniqueID;
-  WeakAuras.Add(newData);
-  WeakAuras.NewDisplayButton(newData);
-  if(data.parent) then
-    local parentData = WeakAuras.GetData(data.parent);
-    local index;
-    for i, childId in pairs(parentData.controlledChildren) do
-      if(childId == data.id) then
-        index = i;
-        break;
-      end
-    end
-    if(index) then
-      local newIndex = index + 1;
-      if(newIndex > #parentData.controlledChildren) then
-        tinsert(parentData.controlledChildren, newData.id);
-      else
-        tinsert(parentData.controlledChildren, index + 1, newData.id);
-      end
-      newData.parent = data.parent;
-      WeakAuras.Add(parentData);
-      WeakAuras.Add(newData);
-
-      for index, id in pairs(parentData.controlledChildren) do
-        local childButton = WeakAuras.GetDisplayButton(id);
-        childButton:SetGroup(parentData.id, parentData.regionType == "dynamicgroup");
-        childButton:SetGroupOrder(index, #parentData.controlledChildren);
-      end
-
-      local button = WeakAuras.GetDisplayButton(parentData.id);
-      button.callbacks.UpdateExpandButton();
-      WeakAuras.UpdateDisplayButton(parentData);
-      WeakAuras.ReloadGroupRegionOptions(parentData);
-    end
-  end
-  return newData.id;
-end
-
 function WeakAuras.ConstructOptions(prototype, data, startorder, triggernum, triggertype, unevent)
   local trigger, untrigger;
   if(data.controlledChildren) then

--- a/WeakAurasOptions/WeakAurasOptions.lua
+++ b/WeakAurasOptions/WeakAurasOptions.lua
@@ -94,7 +94,7 @@ function WeakAuras.DuplicateAura(data)
   WeakAuras.DeepCopy(data, newData);
   newData.id = new_id;
   newData.parent = nil;
-  newData.uid = nil
+  newData.uid = WeakAuras.GenerateUniqueID();
   WeakAuras.Add(newData);
   WeakAuras.NewDisplayButton(newData);
   if(data.parent) then
@@ -385,7 +385,7 @@ function WeakAuras.DuplicateAura(data)
   WeakAuras.DeepCopy(data, newData);
   newData.id = new_id;
   newData.parent = nil;
-  newData.uid = nil
+  newData.uid = WeakAuras.GenerateUniqueID;
   WeakAuras.Add(newData);
   WeakAuras.NewDisplayButton(newData);
   if(data.parent) then
@@ -4621,7 +4621,7 @@ function WeakAuras.NewAura(sourceData, regionType, targetId)
     return t and k and v and t[k] == v
   end
   local new_id = WeakAuras.FindUnusedId("New")
-  local data = {id = new_id, regionType = regionType}
+  local data = {id = new_id, regionType = regionType, uid = WeakAuras.GenerateUniqueID()}
   WeakAuras.DeepCopy(WeakAuras.data_stub, data);
   if (sourceData) then
     WeakAuras.DeepCopy(sourceData, data);


### PR DESCRIPTION
# Description

- Show a small icon on groups when there is an aura in the group that can be updated

   This give a way to see where you have updates when groups are collapsed and the group itself doesn't have update data.

   The icon position and look can probably be improved

![preview](https://i.imgur.com/O2Iw8GX.png)

- Match updataData with companion addon's data by uid instead of "slug"

   It make the assumption that an uid is set on every aura, which require a patch **TODO**

- Move version information from url to it's own field, added migration and bumped internalVersion to 10

   We want Wago to add the version field on each aura now **TODO**

These 2 points require to use a branch of the Companion that i have not merged yet https://github.com/WeakAuras/WeakAuras-Companion/tree/uidkey it's ready for merge tho.


- Moved matching and update data retrieval to method button:HasUpdate()

   version, wagoVersion and slug isn't cached in the button anymore, the cost to get that information has increased a bit


The version field change and the HasUpdate() change are a (small) step in making the update system more open in future development. 


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Show WeakAurasOptions after reload
- [x] Aura with update deleted
- [x] Aura with update moved to another group
- [x] Aura with update marked as ignore for next (and all) updates, and unmarked

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

# TODO:

- [ ] Merge Companion's uidkey branch (ready)
- [x] Update Wago to add version field on every existing aura
- [ ] Update transmission to match data with uid of the item clicked
- [ ] Update transmission for update a specific aura in a group (is it really something we want ????)