### PR TITLE
Teach SetRegion to create regions initially hidden

### DIFF
--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -3189,11 +3189,12 @@ function WeakAuras.SetRegion(data, cloneId)
         if((not regions[id]) or (not regions[id].region) or regions[id].regionType ~= regionType) then
           region = regionTypes[regionType].create(frame, data);
           region.regionType = regionType;
-          region.toShow = true;
+          region.toShow = false;
           regions[id] = {
             regionType = regionType,
             region = region
           };
+          region:Hide()
         else
           region = regions[id].region;
         end


### PR DESCRIPTION
# Description

If a user has enough auras that the login thread takes > 15 seconds to finish, then the game will begin properly before login is done. So ensure that the regions created by SetRegion do not start out shown.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Install the SV file in #1015, and then log in.
- [x] Note that there are no regions visible when they should not be.

# Checklist:
<!-- These can be checked off after the pull request is submitted, in case you want discussion before they’re completely ready -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
