### PR TITLE
add glow option to regionType=aurabar GitHub Ticket #970

### DIFF
--- a/WeakAurasOptions/RegionOptions/AuraBar.lua
+++ b/WeakAurasOptions/RegionOptions/AuraBar.lua
@@ -326,6 +326,38 @@ local function createOptions(id, data)
       bigStep = 0.01,
       isPercent = true
     },
+    glowHeader = {
+      type = "header",
+      order = 41.1,
+      name = WeakAuras.newFeatureString .. L["Glow Settings"],
+    },
+    glow = {
+      type = "toggle",
+      width = WeakAuras.normalWidth,
+      name = L["Show Glow Effect"],
+      order = 41.2,
+    },
+    glowType = {
+      type = "select",
+      width = WeakAuras.normalWidth,
+      name = L["Glow Type"],
+      order = 41.3,
+      values = WeakAuras.glow_types,
+    },
+    useGlowColor = {
+      type = "toggle",
+      width = WeakAuras.normalWidth,
+      name = L["Glow Color"],
+      desc = L["If unchecked, then a default color will be used (usually yellow)"],
+      order = 41.4,
+    },
+    glowColor = {
+      type = "color",
+      width = WeakAuras.normalWidth,
+      name = L["Glow Color"],
+      order = 41.5,
+      disabled = function() return not data.useGlowColor end,
+    },
     spark_header = {
       type = "header",
       name = L["Spark Settings"],


### PR DESCRIPTION
# Description
Add glow option to bars

![preview](https://i.imgur.com/kGbBXnM.png)

Fixes #970

To be honest, it's just a big copy pasta from Icon.lua in WeakAuras & WeakAurasOptions, the only thing i have edited is the order of fields in options.
I have not extensively audited every lines of the code but it's working and doesn't produce any error.

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update (maybe?)

# How Has This Been Tested?
- [x] All Glow Types
- [x] Color
- [x] Conditions

# Checklist:
- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
