### PR TITLE
make RefreshGroupUpdateIcon iterate only on its children

### DIFF
--- a/WeakAurasOptions/WeakAurasOptions.lua
+++ b/WeakAurasOptions/WeakAurasOptions.lua
@@ -4407,10 +4407,10 @@ function WeakAuras.UpdateDisplayButton(data)
 end
 
 function WeakAuras.RefreshGroupUpdateIcon(button)
-  local parentId = button.data.id
-  for id, child in pairs(displayButtons) do
-    if child.data.parent == parentId then
-      local hasUpdate, skipVersion = child:HasUpdate()
+  for index, childId in pairs(button.data.controlledChildren) do
+    local childButton = WeakAuras.GetDisplayButton(childId);
+    if childButton then
+      local hasUpdate, skipVersion = childButton:HasUpdate()
       if hasUpdate and not skipVersion then
         button:ShowGroupUpdate()
         return


### PR DESCRIPTION
# Description
fix https://github.com/WeakAuras/WeakAuras2/pull/1030/files#r242282479


