### PR TITLE
Fix ordering of options on multi-selection

### DIFF
--- a/WeakAurasOptions/RegionOptions/AuraBar.lua
+++ b/WeakAurasOptions/RegionOptions/AuraBar.lua
@@ -718,8 +718,8 @@ local function createOptions(id, data)
 
   return {
     aurabar = options,
-    border = WeakAuras.BorderOptions(id, data, 2, true);
-    position = WeakAuras.PositionOptions(id, data, 3),
+    border = WeakAuras.BorderOptions(id, data, nil, true);
+    position = WeakAuras.PositionOptions(id, data),
   };
 end
 

--- a/WeakAurasOptions/RegionOptions/DynamicGroup.lua
+++ b/WeakAurasOptions/RegionOptions/DynamicGroup.lua
@@ -201,7 +201,7 @@ local function createOptions(id, data)
 
   return {
     dynamicgroup = options,
-    position = WeakAuras.PositionOptions(id, data, 2, true, true),
+    position = WeakAuras.PositionOptions(id, data, nil, true, true),
   };
 end
 

--- a/WeakAurasOptions/RegionOptions/Group.lua
+++ b/WeakAurasOptions/RegionOptions/Group.lua
@@ -536,8 +536,8 @@ local function createOptions(id, data)
 
   return {
     group = options,
-    border = WeakAuras.BorderOptions(id, data, 2);
-    position = WeakAuras.PositionOptions(id, data, 3, true, true),
+    border = WeakAuras.BorderOptions(id, data);
+    position = WeakAuras.PositionOptions(id, data, nil, true, true),
   };
 end
 

--- a/WeakAurasOptions/RegionOptions/Icon.lua
+++ b/WeakAurasOptions/RegionOptions/Icon.lua
@@ -398,7 +398,7 @@ local function createOptions(id, data)
 
   return {
     icon = options,
-    position = WeakAuras.PositionOptions(id, data, 2),
+    position = WeakAuras.PositionOptions(id, data),
   };
 end
 

--- a/WeakAurasOptions/RegionOptions/Model.lua
+++ b/WeakAurasOptions/RegionOptions/Model.lua
@@ -190,8 +190,8 @@ local function createOptions(id, data)
 
   return {
     model = options,
-    border = WeakAuras.BorderOptions(id, data, 2);
-    position = WeakAuras.PositionOptions(id, data, 3),
+    border = WeakAuras.BorderOptions(id, data);
+    position = WeakAuras.PositionOptions(id, data),
   };
 end
 

--- a/WeakAurasOptions/RegionOptions/ProgressTexture.lua
+++ b/WeakAurasOptions/RegionOptions/ProgressTexture.lua
@@ -324,7 +324,7 @@ local function createOptions(id, data)
 
   return {
     progresstexture = options,
-    position = WeakAuras.PositionOptions(id, data, 2),
+    position = WeakAuras.PositionOptions(id, data),
   };
 end
 

--- a/WeakAurasOptions/RegionOptions/Text.lua
+++ b/WeakAurasOptions/RegionOptions/Text.lua
@@ -135,7 +135,7 @@ local function createOptions(id, data)
 
   return {
     text = options;
-    position = WeakAuras.PositionOptions(id, data, 2, true);
+    position = WeakAuras.PositionOptions(id, data, nil, true);
   };
 end
 

--- a/WeakAurasOptions/RegionOptions/Texture.lua
+++ b/WeakAurasOptions/RegionOptions/Texture.lua
@@ -93,7 +93,7 @@ local function createOptions(id, data)
 
   return {
     texture = options,
-    position = WeakAuras.PositionOptions(id, data, 2),
+    position = WeakAuras.PositionOptions(id, data),
   };
 end
 

--- a/WeakAurasOptions/WeakAurasOptions.lua
+++ b/WeakAurasOptions/WeakAurasOptions.lua
@@ -3467,20 +3467,24 @@ local function fixMetaOrders(allOptions)
   -- shifts __order fields such that each optionGroup is ordered correctly relative
   -- to its peers, but has a unique __order number in the combined option table.
   local groupOrders = {}
+  local maxGroupOrder = 0
   for optionGroup, options in pairs(allOptions) do
     local metaOrder = options.__order
     groupOrders[metaOrder] = groupOrders[metaOrder] or {}
+    maxGroupOrder = max(maxGroupOrder, metaOrder)
     tinsert(groupOrders[metaOrder], optionGroup)
   end
 
   local index = 0
   local newOrder = 1
-  while index < #groupOrders do
+  while index <= maxGroupOrder do
     index = index + 1
-    table.sort(groupOrders[index])
-    for _, optionGroup in ipairs(groupOrders[index]) do
-      allOptions[optionGroup].__order = newOrder
-      newOrder = newOrder + 1
+    if groupOrders[index] then
+      table.sort(groupOrders[index])
+      for _, optionGroup in ipairs(groupOrders[index]) do
+        allOptions[optionGroup].__order = newOrder
+        newOrder = newOrder + 1
+      end
     end
   end
 end
@@ -3523,7 +3527,8 @@ function WeakAuras.ReloadGroupRegionOptions(data)
   options.args.region.args = regionOption;
 end
 
-function WeakAuras.PositionOptions(id, data, metaOrder, hideWidthHeight, disableSelfPoint)
+function WeakAuras.PositionOptions(id, data, _, hideWidthHeight, disableSelfPoint)
+  local metaOrder = 100
   local function IsParentDynamicGroup()
     return data.parent and db.displays[data.parent] and db.displays[data.parent].regionType == "dynamicgroup";
   end
@@ -3722,7 +3727,8 @@ function WeakAuras.PositionOptions(id, data, metaOrder, hideWidthHeight, disable
   return positionOptions;
 end
 
-function WeakAuras.BorderOptions(id, data, metaOrder, showBackDropOptions)
+function WeakAuras.BorderOptions(id, data, _, showBackDropOptions)
+  local metaOrder = 99
   local borderOptions = {
     __title = L["Border Settings"],
     __order = metaOrder,


### PR DESCRIPTION
We merge the options of various different region types with a simple
union, thus if e.g.:

Icon returns
  icon.__index == 1
  position.__index == 2

And Aurabar returns
  aurabar.__index == 1
  border.__index == 2
  position.__index == 3

Then the merged list will contain
  aurabar.__index == 1
  icon.__index == 1
  border.__index == 2
  position._index either 2 or 3, depending on which gets unioned last

This means that fixMetaOrder can not figure out which of border or
position should come first. (It does that correctly only due to sorting
border/position alphabetically.)

Fix that by usign the same __index for Position and Border settings.
This is not ideal, but the correct algorithm is rather complicated.

And keep the api stable, as the stop motion plugin depends on it.

