### PR TITLE
add warning icon on auras with legacy aura trigger

### DIFF
--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -1410,8 +1410,6 @@ loadedFrame:SetScript("OnEvent", function(self, event, addon)
 
       db.minimap = db.minimap or { hide = false };
       LDBIcon:Register("WeakAuras", Broker_WeakAuras, db.minimap);
-
-      WeakAuras.AdvertiseBT2Upgrade()
     end
   elseif(event == "PLAYER_LOGIN") then
     local startTime = debugprofilestop()
@@ -5451,23 +5449,4 @@ function WeakAuras.FindUnusedId(prefix)
     num = num + 1;
   end
   return id
-end
-
-function WeakAuras.AdvertiseBT2Upgrade()
-  local count = 0
-  for id, aura in pairs(WeakAurasSaved.displays) do
-      if not aura.controlledChildren and aura.triggers then
-          for i, t in pairs(aura.triggers) do
-              if type(i) == "number" then
-                  if t.trigger and t.trigger.type == "aura" then
-                  	count = count + 1
-                  	break
-                  end
-              end
-          end
-      end
-  end
-  if count > 0 then
-    WeakAuras.prettyPrint((L["You have %d auras still using the legacy aura trigger, they are marked with a %s in WeakAuras Options"]):format(count, WeakAuras.newFeatureString))
-  end
 end

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -1410,6 +1410,8 @@ loadedFrame:SetScript("OnEvent", function(self, event, addon)
 
       db.minimap = db.minimap or { hide = false };
       LDBIcon:Register("WeakAuras", Broker_WeakAuras, db.minimap);
+
+      WeakAuras.AdvertiseBT2Upgrade()
     end
   elseif(event == "PLAYER_LOGIN") then
     local startTime = debugprofilestop()
@@ -5449,4 +5451,23 @@ function WeakAuras.FindUnusedId(prefix)
     num = num + 1;
   end
   return id
+end
+
+function WeakAuras.AdvertiseBT2Upgrade()
+  local count = 0
+  for id, aura in pairs(WeakAurasSaved.displays) do
+      if not aura.controlledChildren and aura.triggers then
+          for i, t in pairs(aura.triggers) do
+              if type(i) == "number" then
+                  if t.trigger and t.trigger.type == "aura" then
+                  	count = count + 1
+                  	break
+                  end
+              end
+          end
+      end
+  end
+  if count > 0 then
+    WeakAuras.prettyPrint((L["You have %d auras still using the legacy aura trigger, they are marked with a %s in WeakAuras's Options"]):format(count, WeakAuras.newFeatureString))
+  end
 end

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -5468,6 +5468,6 @@ function WeakAuras.AdvertiseBT2Upgrade()
       end
   end
   if count > 0 then
-    WeakAuras.prettyPrint((L["You have %d auras still using the legacy aura trigger, they are marked with a %s in WeakAuras's Options"]):format(count, WeakAuras.newFeatureString))
+    WeakAuras.prettyPrint((L["You have %d auras still using the legacy aura trigger, they are marked with a %s in WeakAuras Options"]):format(count, WeakAuras.newFeatureString))
   end
 end

--- a/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasDisplayButton.lua
+++ b/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasDisplayButton.lua
@@ -1530,6 +1530,19 @@ local methods = {
     -- no addon, or no data, or ignore flag
     return false, false, nil, nil
   end,
+  ["RefreshBT2UpgradeIcon"] = function(self)
+    if not self.data.controlledChildren and self.data.triggers then
+      for i, t in pairs(self.data.triggers) do
+          if type(i) == "number" then
+              if t.trigger and t.trigger.type == "aura" then
+                self.bt2upgrade:Show()
+                return
+              end
+          end
+      end
+    end
+    self.bt2upgrade:Hide()
+  end,
   ["RefreshUpdate"] = function(self, actionFunc)
     if self.data.parent then
       -- is in a group
@@ -1975,6 +1988,23 @@ local function Constructor()
     groupUpdate:Hide()
   end
 
+  local bt2upgrade = CreateFrame("BUTTON", nil, button);
+  button.bt2upgrade = bt2upgrade
+  bt2upgrade.func = function() end
+  bt2upgrade:SetNormalTexture([[interface\optionsframe\ui-optionsframe-newfeatureicon.blp]])
+  bt2upgrade:SetWidth(16)
+  bt2upgrade:SetHeight(16)
+  bt2upgrade:SetPoint("RIGHT", button, "RIGHT", -60, 0)
+  bt2upgrade:SetScript("OnEnter", function()
+    Show_Tooltip(
+      button,
+      L["Legacy Aura Trigger"],
+      L["This aura has legacy aura trigger(s). Convert them to the new system to benefit from enhanced performance and features"]
+    )
+  end)
+  bt2upgrade:SetScript("OnLeave", Hide_Tooltip)
+  bt2upgrade:Hide()
+
   local widget = {
     frame = button,
     title = title,
@@ -1993,6 +2023,7 @@ local function Constructor()
     background = background,
     expand = expand,
     update = update,
+    bt2upgrade = bt2upgrade,
     groupUpdate = groupUpdate,
     updateLogo = updateLogo,
     type = Type

--- a/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasDisplayButton.lua
+++ b/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasDisplayButton.lua
@@ -2,7 +2,7 @@ local tinsert, tconcat, tremove, wipe = table.insert, table.concat, table.remove
 local select, pairs, next, type, unpack = select, pairs, next, type, unpack
 local tostring, error = tostring, error
 
-local Type, Version = "WeakAurasDisplayButton", 46
+local Type, Version = "WeakAurasDisplayButton", 47
 local AceGUI = LibStub and LibStub("AceGUI-3.0", true)
 if not AceGUI or (AceGUI:GetWidgetVersion(Type) or 0) >= Version then return end
 
@@ -1532,13 +1532,11 @@ local methods = {
   end,
   ["RefreshBT2UpgradeIcon"] = function(self)
     if not self.data.controlledChildren and self.data.triggers then
-      for i, t in pairs(self.data.triggers) do
-          if type(i) == "number" then
-              if t.trigger and t.trigger.type == "aura" then
-                self.bt2upgrade:Show()
-                return
-              end
-          end
+      for _, t in ipairs(self.data.triggers) do
+        if t.trigger and t.trigger.type == "aura" then
+          self.bt2upgrade:Show()
+          return
+        end
       end
     end
     self.bt2upgrade:Hide()
@@ -1991,7 +1989,7 @@ local function Constructor()
   local bt2upgrade = CreateFrame("BUTTON", nil, button);
   button.bt2upgrade = bt2upgrade
   bt2upgrade.func = function() end
-  bt2upgrade:SetNormalTexture([[interface\optionsframe\ui-optionsframe-newfeatureicon.blp]])
+  bt2upgrade:SetNormalTexture([[Interface\DialogFrame\UI-Dialog-Icon-AlertNew]])
   bt2upgrade:SetWidth(16)
   bt2upgrade:SetHeight(16)
   bt2upgrade:SetPoint("RIGHT", button, "RIGHT", -60, 0)

--- a/WeakAurasOptions/WeakAurasOptions.lua
+++ b/WeakAurasOptions/WeakAurasOptions.lua
@@ -4314,6 +4314,7 @@ function WeakAuras.UpdateDisplayButton(data)
     if WeakAurasCompanion and button:IsGroup() then
       button:RefreshUpdate()
     end
+    button:RefreshBT2UpgradeIcon()
   end
 end
 


### PR DESCRIPTION
# Description

On login, show this message :
![preview](https://i.imgur.com/p9Wyc4P.png)

Add icon on weakauras's button if there is a legacy trigger 
![preview](https://i.imgur.com/VaIJC8n.png)

Fixes #1049

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

# Know issue:
Deleting the legacy trigger doesn't refresh the button