### PR TITLE
Update ImportString API

### DIFF
--- a/WeakAuras/AuraEnvironment.lua
+++ b/WeakAuras/AuraEnvironment.lua
@@ -135,7 +135,6 @@ function WeakAuras.ActivateAuraEnvironment(id, cloneId, state)
       current_aura_env.cloneId = cloneId
       current_aura_env.state = state
       current_aura_env.region = WeakAuras.GetRegion(id, cloneId)
-      current_aura_env.config = CopyTable(data.config)
       -- Push the new environment onto the stack
       tinsert(aura_env_stack, current_aura_env)
     else

--- a/WeakAuras/Transmission.lua
+++ b/WeakAuras/Transmission.lua
@@ -315,6 +315,9 @@ local function install(data, oldData, patch, mode, isParent)
       end
     end
     WeakAuras.Update(oldData, patch)
+    if data.uid and data.uid ~= oldData.uid then
+      oldData.uid = data.uid
+    end
     data = oldData
   end
   return WeakAuras.GetData(data.id)

--- a/WeakAuras/Transmission.lua
+++ b/WeakAuras/Transmission.lua
@@ -436,6 +436,7 @@ local function importPendingData()
                 local data = toInsert[index][i]
                 local id = data.id
                 data.id = WeakAuras.FindUnusedId(id)
+                data.parent = parentData.id;
                 WeakAuras.Add(data)
                 tinsert(installedData, index, data)
                 if hybridTables and hybridTables.new[id] then

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -3221,8 +3221,7 @@ function WeakAuras.SetRegion(data, cloneId)
 
       regionTypes[regionType].modify(parent, region, data);
       WeakAuras.regionPrototype.AddSetDurationInfo(region);
-      local parentRegionType = data.parent and db.displays[data.parent] and db.displays[data.parent].regionType;
-      WeakAuras.regionPrototype.AddExpandFunction(data, region, id, cloneId, parent, parentRegionType)
+      WeakAuras.regionPrototype.AddExpandFunction(data, region, id, cloneId, parent, parent.regionType)
 
 
       data.animation = data.animation or {};

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -3067,7 +3067,6 @@ local function pAdd(data)
     return;
   end
 
-  data.uid = data.uid or WeakAuras.GenerateUniqueID();
   db.displays[id] = data;
   WeakAuras.ClearAuraEnvironment(id);
 

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -2754,7 +2754,6 @@ function WeakAuras.Modernize(data)
 
   -- Version 10 was introduced in December 2018
   if data.internalVersion < 10 then
-    data.uid = data.uid or WeakAuras.GenerateUniqueID()
     if not data.version and data.url and data.url ~= "" then
       local slug, version = data.url:match("wago.io/([^/]+)/([0-9]+)")
       if not slug and not version then
@@ -3068,6 +3067,7 @@ local function pAdd(data)
     return;
   end
 
+  data.uid = data.uid or WeakAuras.GenerateUniqueID();
   db.displays[id] = data;
   WeakAuras.ClearAuraEnvironment(id);
 

--- a/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasDisplayButton.lua
+++ b/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasDisplayButton.lua
@@ -2,7 +2,7 @@ local tinsert, tconcat, tremove, wipe = table.insert, table.concat, table.remove
 local select, pairs, next, type, unpack = select, pairs, next, type, unpack
 local tostring, error = tostring, error
 
-local Type, Version = "WeakAurasDisplayButton", 44
+local Type, Version = "WeakAurasDisplayButton", 45
 local AceGUI = LibStub and LibStub("AceGUI-3.0", true)
 if not AceGUI or (AceGUI:GetWidgetVersion(Type) or 0) >= Version then return end
 
@@ -61,6 +61,15 @@ local function copyAuraPart(source, destination, part)
     destination.animation = {};
     WeakAuras.DeepCopy(source.animation, destination.animation);
   end
+  if (part == "authorOptions" or all) and not IsRegionAGroup(source) then
+    destination.authorOptions = {};
+    WeakAuras.DeepCopy(source.authorOptions, destination.authorOptions);
+  end
+  if (part == "config" or all) and not IsRegionAGroup(source) then
+    destination.config = {};
+    WeakAuras.DeepCopy(source.config, destination.config);
+  end
+
 end
 
 local function CopyToClipboard(part, description)
@@ -1488,23 +1497,19 @@ local methods = {
   end,
   ["HasUpdate"] = function(self)
     -- return hasUpdate, skipVersion, updateData, key
-    if WeakAurasCompanion
-    and self.data.uid
-    and not self.data.ignoreWagoUpdate
-    then
-      local slug = WeakAurasCompanion.uids[self.data.uid]
-      if slug then
-        local updateData = WeakAurasCompanion.slugs[slug]
-        if updateData then
-          if not (self.data.skipWagoUpdate and self.data.skipWagoUpdate == updateData.wagoVersion) then
-            if tonumber(updateData.wagoVersion) > tonumber(self.data.version) then
-              -- got update
-              return true, false, updateData, slug
-            end
-          else
-            -- version skip flag
-            return true, true, updateData, slug
+    if not WeakAurasCompanion or self.data.ignoreWagoUpdate then return end
+    local slug = self.data.uid and WeakAurasCompanion.uids[self.data.uid] or WeakAurasCompanion.ids[self.data.id]
+    if slug then
+      local updateData = WeakAurasCompanion.slugs[slug]
+      if updateData then
+        if not (self.data.skipWagoUpdate and self.data.skipWagoUpdate == updateData.wagoVersion) then
+          if tonumber(updateData.wagoVersion) > tonumber(self.data.version) then
+            -- got update
+            return true, false, updateData, slug
           end
+        else
+          -- version skip flag
+          return true, true, updateData, slug
         end
       end
     end

--- a/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasDisplayButton.lua
+++ b/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasDisplayButton.lua
@@ -747,7 +747,7 @@ local methods = {
     function self.callbacks.OnUpdateClick()
       local _,_,updateData = self:HasUpdate()
       if updateData then
-        WeakAuras.ImportString(updateData.encoded)
+        WeakAuras.Import(updateData.encoded, self.data)
       end
     end
 

--- a/WeakAurasOptions/OptionsFrames/ImportExport.lua
+++ b/WeakAurasOptions/OptionsFrames/ImportExport.lua
@@ -71,7 +71,7 @@ local function ConstructImportExport(frame)
         input.editBox:ClearFocus();
         pasted = pasted:match( "^%s*(.-)%s*$" );
         if (#pasted > 20) then
-          WeakAuras.ImportString(pasted);
+          WeakAuras.Import(pasted);
           input:SetLabel(L["Processed %i chars"]:format(i));
           input.editBox:SetMaxBytes(2500);
           input.editBox:SetText(strsub(pasted, 1, 2500));


### PR DESCRIPTION
# Description

Fixes #1029 by updating the Import API to accept a target. Additionally, fix a bug where importing old auras with no uid would cause them to always be interpreted as a new aura, and never as an update.

Specifically, `WeakAuras.Import` has been introduced, which accepts either an encoded string, or the equivalent decoded lua table, and optionally a uid or data table which functions as a target for the update. If a valid target is provided, then the imported data will always be interpreted as an update. If no valid target is provided, then the database will be searched for a match as usual.

For the sake of backwards compatibility, `WeakAuras.ImportString` is provided as an alias for `WeakAuras.Import`. Any addon which currently calls `WeakAuras.ImportString` will be unaffected by this change.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Follow the reproduction steps in #1029 with this branch checked out
- Note that the import correctly updates the aura the button was on.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings