### PR TITLE
Allow custom options to format text

### DIFF
--- a/WeakAuras/Transmission.lua
+++ b/WeakAuras/Transmission.lua
@@ -733,7 +733,7 @@ function WeakAuras.DisplayToTableString(id)
     local lines = {"{"};
     recurseStringify(data, 1, lines);
     tinsert(lines, "}")
-    return table.concat(lines, "\n");
+    return table.concat(lines, "\n"):gsub("|", "||");
   end
 end
 


### PR DESCRIPTION
# Description
![image](https://user-images.githubusercontent.com/24878501/50576350-e1437380-0dd5-11e9-946f-208fe32ec570.png)

User-facing strings in custom options now accept [UI escape sequence](https://wow.gamepedia.com/UI_escape_sequences) patterns. In particular, option name, description text, and tooltip text now can be formatted.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires documentation
# How Has This Been Tested?

1. Add any option, and then write `|cFFFF8800Orange|r|cFFFF0000Red|r!` into the name, description text, or tooltip text.
2. Enter `User Mode`. You should see the string you entered colored appropriately.

# Checklist:
<!-- These can be checked off after the pull request is submitted, in case you want discussion before they’re completely ready -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
