### PR TITLE
Migration 10 did not update "version" if field was already set

### DIFF
--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -1,4 +1,4 @@
-local internalVersion = 10;
+local internalVersion = 11;
 
 -- WoW APIs
 local GetTalentInfo, IsAddOnLoaded, InCombatLockdown = GetTalentInfo, IsAddOnLoaded, InCombatLockdown
@@ -2752,16 +2752,15 @@ function WeakAuras.Modernize(data)
     end
   end
 
-  -- Version 10 was introduced in December 2018
-  if data.internalVersion < 10 then
-    if not data.version and data.url and data.url ~= "" then
+  -- Version 11 was introduced in January 2018
+  if data.internalVersion < 11 then
+    if data.url and data.url ~= "" then
       local slug, version = data.url:match("wago.io/([^/]+)/([0-9]+)")
       if not slug and not version then
-        slug = data.url:match("wago.io/([^/]+)$")
         version = 1
       end
-      if slug then
-        data.version = version
+      if version and tonumber(version) then
+        data.version = tonumber(version)
       end
     end
   end


### PR DESCRIPTION
# Description

After migration to internalVersion 10, auras can have their "version" field not matching the version taken from wago url, and keep their outdated number.
It can lead to problem like https://github.com/WeakAuras/WeakAuras-Companion/issues/53 where companion wants to updates childs with broken version field while parent has correct version.

Also previous migration didn't convert the version to type number.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
- [x] Tested with my auras, everything fine.
- [x] Tested with Hekili's auras, it fixed his problem.