### PR TITLE
fix default values for multiselect

### DIFF
--- a/WeakAurasOptions/AuthorOptions.lua
+++ b/WeakAurasOptions/AuthorOptions.lua
@@ -831,6 +831,7 @@ local typeControlAdders = {
               local insertPoint = math.min(j, #childOption.values + 1)
               if value == "" then
                 tremove(childOption.values, insertPoint)
+                tremove(childOption.default, insertPoint)
               else
                 childOption.values[insertPoint] = value
               end
@@ -840,6 +841,7 @@ local typeControlAdders = {
           else
             if value == "" then
               tremove(values, j)
+              tremove(option.default, j, false)
             else
               values[j] = value
             end
@@ -860,11 +862,13 @@ local typeControlAdders = {
               local childData = data[childID]
               local childOption = childData.authorOptions[optionID]
               tremove(childOption.values, j)
+              tremove(childOption.default, j)
               WeakAuras.Add(childData)
             end
             WeakAuras.ReloadTriggerOptions(data[0])
           else
             tremove(values, j)
+            tremove(option.default, j)
             WeakAuras.Add(data)
             WeakAuras.ReloadTriggerOptions(data)
           end
@@ -897,11 +901,13 @@ local typeControlAdders = {
             local childData = data[childID]
             local childOption = childData.authorOptions[optionID]
             childOption.values[#childOption.values + 1] = value
+            childOption.default[#childOption.values + 1] = false
             WeakAuras.Add(childData)
           end
           WeakAuras.ReloadTriggerOptions(data[0])
         else
           values[#values + 1] = value
+          option.default[#option.default + 1] = false
           WeakAuras.Add(data)
           WeakAuras.ReloadTriggerOptions(data)
         end


### PR DESCRIPTION
# Description

Fixes #1092.

This is not a retroactive fix, since it's a data issue and the relevant feature hasn't yet been released beyond beta. New auras will be correct automatically. Older auras with this problem can be fixed by cycling the defaults to generate the correct data.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Non-retroactive

# How Has This Been Tested?

1. Import the test case in #1092
2. Change the default values on all of the elements of the toggle list option at the end of the Custom Options.
3. `User Mode` works correctly now.

# Checklist:
<!-- These can be checked off after the pull request is submitted, in case you want discussion before they’re completely ready -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

<!-- Is there any additional work that needs to be done? If so, add it to the above list -->
