### PR TITLE
More improvements for Custom Options

### DIFF
--- a/WeakAuras/Types.lua
+++ b/WeakAuras/Types.lua
@@ -1794,6 +1794,7 @@ WeakAuras.author_option_types = {
   select = L["Dropdown Menu"],
   space = L["Space"],
   multiselect = L["Toggle List"],
+  header = L["Separator"],
 }
 
 WeakAuras.author_option_fields = {
@@ -1845,12 +1846,11 @@ WeakAuras.author_option_fields = {
   multiselect = {
     default = {true},
     values = {"val1"},
-  }
-}
-
-WeakAuras.space_types = {
-  multi = L["Multi-Line"],
-  single = L["Single-Line"]
+  },
+  header = {
+    useName = false,
+    text = "",
+  },
 }
 
 WeakAuras.difficulty_info = {


### PR DESCRIPTION
# Description

A few things which didn't make it into 2.11:
- Merge `User Mode` of multiple auras, instead of rendering them separately, done for usability reasons in large groups with Custom Options. **This is a breaking UI change!**
- Separator Option type
- Option key field in `Author Mode` now turns red and warns you if you have duplicate keys

## Type of change

- [x] New feature
- [x] Breaking change
- [x] Documentation Required

# How Has This Been Tested?

Basic usage tests:

- Merged `User Mode`:
	1. Create any aura, add any number of options to it.
	2. Duplicate the aura.
	3. Select both, and then navigate to Custom Options in `User Mode`.
	4. Notice that the options are no longer separated, but are instead merged.
	5. Change or add options on just one of the auras.
	6. Repeat step 3.
	7. Notice that the options are now merged in a similar fashion as in the rest of the addon.
- Separator Option type
	1. Create any aura, and then create a new option with type "Separator"
	2. Switch to `User Mode`.
	3. Notice that there is now an AceConfig header widget in the place that the Separator type option was added.
	4. Switch to `Author Mode`.
	5. Enable the "Separator Text" checkbox, and enter some text into the input widget.
	6. Switch to `User Mode`.
	7. Notice that the header widget now has text displayed in the center. Notice also that this text obeys the formatting found in all of the user-facing strings of Custom Options.
- Duplicate Key Warning:
	1. Create any aura, and add any interactive option (i.e. not a space, separator, or description)
	2. Duplicate the option.
	3. Notice that the `Option Key` field in both the original and the copied options are now colored red. Additionally, the tooltip describes which options have the same key.
	4. Change the key in one of the options with a duplicated key.
	5. Notice that the `Option Key` field is no longer red, and the tooltip no longer describes any options which have the same key.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
	- [x] Document the new `User Mode` rendering
	- [x] Document the Separator Option Type
	- [x] Document the new warning for duplicate keys
- [x] My changes generate no new warnings
