### PR TITLE
improve coroutine error handling

### DIFF
--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -4377,9 +4377,9 @@ do
 
         -- Resume or remove
         if coroutine.status(func) ~= "dead" then
-          local err,ret1,ret2 = assert(coroutine.resume(func))
-          if err then
-            debug(debugstack(func))
+          local ok, msg = coroutine.resume(func)
+          if not ok then
+            geterrorhandler()(msg .. '\n' .. debugstack(func))
           end
         else
           dynFrame:RemoveAction(name);


### PR DESCRIPTION
# Description

This way, we can actually see what the stack trace is.
This:
![image](https://user-images.githubusercontent.com/24878501/51432541-0f5eeb00-1bff-11e9-9590-80830d038bc0.png)
is much better than this:
![image](https://user-images.githubusercontent.com/24878501/51432549-23a2e800-1bff-11e9-9663-e9622861c2b1.png)


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
1. Cause an error in one of our coroutines (like, for example, attempting to reproduce #1107)
2. Notice that the reported error is much more informative.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
