### PR TITLE
guard against invalid inputs to auraspellids

### DIFF
--- a/WeakAurasOptions/WeakAurasOptions.lua
+++ b/WeakAurasOptions/WeakAurasOptions.lua
@@ -20,7 +20,7 @@ local ADDON_NAME = "WeakAurasOptions";
 local prettyPrint = WeakAuras.prettyPrint
 
 local ValidateNumeric = function(info, val)
-  if val ~= nil and val ~= "" and not tonumber(val) then
+  if val ~= nil and val ~= "" and (not tonumber(val) or tonumber(val) >= 2^31) then
     return false;
   end
   return true


### PR DESCRIPTION
# Description

fixes #1107

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Non-retroactive (fix for a data issue that does not fix existing data)

# How Has This Been Tested?

1. Create any aura
2. Go to trigger tab, ensure that the trigger type is `Aura`.
3. Enable "Exact Spell ID", then enter `2147483648` into the input field and click OK.
4. Notice that the field does not accept this value, and reverts to its previous value.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings