### PR TITLE
reset glow on size change

### DIFF
--- a/WeakAuras/RegionTypes/Icon.lua
+++ b/WeakAuras/RegionTypes/Icon.lua
@@ -509,7 +509,6 @@ local function modify(parent, region, data)
   function region:UpdateSize()
     local width = region.width * math.abs(region.scalex);
     local height = region.height * math.abs(region.scaley);
-
     region:SetWidth(width);
     region:SetHeight(height);
     if MSQ then
@@ -520,6 +519,9 @@ local function modify(parent, region, data)
     icon:SetAllPoints();
 
     region:UpdateTexCoords();
+    if region.glow then
+      region:SetGlow(true);
+    end
   end
 
   function region:UpdateTexCoords()

--- a/WeakAuras/Transmission.lua
+++ b/WeakAuras/Transmission.lua
@@ -1617,7 +1617,7 @@ function WeakAuras.ShowDisplayTooltip(data, children, matchInfo, icon, icons, im
       else
         data.desc = nil;
       end
-      WeakAuras.ShowDisplayTooltip(data, children, nil, nil, import, nil, "desc");
+      WeakAuras.ShowDisplayTooltip(data, children, nil, nil, nil, import, nil, "desc");
       if(WeakAuras.GetDisplayButton) then
         local button = WeakAuras.GetDisplayButton(data.id);
         if(button) then
@@ -1831,7 +1831,7 @@ Comm:RegisterComm("WeakAuras", function(prefix, message, distribution, sender)
           WeakAuras.PreAdd(child)
         end
       end
-      WeakAuras.ShowDisplayTooltip(data, children, icon, icons, sender, true)
+      WeakAuras.ShowDisplayTooltip(data, children, nil, icon, icons, sender, true)
     elseif(received.m == "dR") then
       --if(WeakAuras.linked[received.d]) then
       TransmitDisplay(received.d, sender);


### PR DESCRIPTION
# Description

Fixes #1123

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Follow the steps to reproduce in #1123. The expected behavior is now the actual behavior.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

# Additional Work

The starting animation will play again on size change, which is unfortunate. But that is a problem best solved upstream in LibCustomGlow.
