### PR TITLE
Partily revert 7f62571f434c, Masque integration fixes

### DIFF
--- a/WeakAuras/RegionTypes/Icon.lua
+++ b/WeakAuras/RegionTypes/Icon.lua
@@ -326,12 +326,11 @@ local function modify(parent, region, data)
 
   if MSQ then
     local masqueId = data.id:lower():gsub(" ", "_");
-    if masqueId ~= region.masqueId then
+    -- TODO -- This should check if the masque id is different instead of always keeping the same masqueId
+    -- But currently masque behaves strangely when a button was already part of a group and the new group is disabled
+    -- In that case the button gets a Blizzard skin
+    if not masqueId then
       region.masqueId = masqueId
-      if region.MSQGroup then
-        region.MSQGroup:RemoveButton(button);
-      end
-
       region.MSQGroup = MSQ:Group("WeakAuras", region.masqueId);
       region.MSQGroup:AddButton(button, {Icon = icon, Cooldown = cooldown});
 


### PR DESCRIPTION
Masque doesn't unskin buttons correctly.

We reuse buttons e.g. two buff triggers checking for buffs on
focus/target will reuse the same button. If a button was already in a
group and we change the masqueId and thus want to add the button to a
new group, but the new group is disabled, masque applies a "Blizzard"
skin.

So revert that for now, and report a bug for masque

Fixes: #1127

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
<!-- If it is a GitHub ticket, then #ticketNum will be sufficient. A WowAce ticket should include a URL. -->
Fixes #(issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:
<!-- These can be checked off after the pull request is submitted, in case you want discussion before they’re completely ready -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

<!-- Is there any additional work that needs to be done? If so, add it to the above list -->
