### PR TITLE
Don't show a default value for unit type condition #1135

### DIFF
--- a/WeakAurasOptions/ConditionOptions.lua
+++ b/WeakAurasOptions/ConditionOptions.lua
@@ -1172,7 +1172,7 @@ local function addControlsForIfLine(args, order, data, conditionVariable, condit
             order = order,
             values = currentConditionTemplate.values,
             get = function()
-              return not check.value and "player" or currentConditionTemplate.values[check.value] and check.value or "member"
+              return currentConditionTemplate.values[check.value] and check.value or (check.value and "member")
             end,
             set = setValue
           }


### PR DESCRIPTION
# Description
When adding a new condition with type="Unit", it show a value on initialization which is not set in aura's data. Select an other value, and re-select previous value fixed it.

With this change default value is empty to force user to select a value. (like it is for any "select" condition)

Fixes #1135

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
- [ ] Test A
- [ ] Test B

# Checklist:
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings