### PR TITLE
Fix cast trigger not untriggering correctly

### DIFF
--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -4469,7 +4469,7 @@ WeakAuras.event_prototypes = {
         "UNIT_SPELLCAST_INTERRUPTED"
       };
       AddUnitChangeEvents(trigger.unit, result)
-      if trigger.target ~= "" then
+      if trigger.target and trigger.target ~= "" then
         tinsert(result, "UNIT_TARGET")
       end
       return result
@@ -4564,7 +4564,12 @@ WeakAuras.event_prototypes = {
               }
             else
               local state = states[cloneId]
-              if state and state.show and state.sourceGUID == sourceGUID then
+              if state and state.show
+              and (
+                trigger_unit ~= "multi"
+                or (trigger_unit == "multi" and state.sourceGUID == sourceGUID)
+              )
+              then
                 state.show = false
                 state.changed = true
                 state.resort = true


### PR DESCRIPTION
# Description
Fix cast trigger not untriggering correctly => regression from #1143 => Fix #1155
Fix UNIT_TARGET event registered when not needed (with current blizzard bug on this event duplicating this is very bad)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
- [x] unit=target, select self > cast > switch target during cast > bar hide (fixed)
- [x] unit=multi, same test, doesn't hide (good)

# Checklist:
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
