### PR TITLE
BuffTrigger2: Fix Multi Target clearing too much data

### DIFF
--- a/WeakAuras/BuffTrigger2.lua
+++ b/WeakAuras/BuffTrigger2.lua
@@ -2560,8 +2560,8 @@ local function RemoveMatchDataMulti(base, destGUID, key, sourceGUID)
         matchDataChanged[id][triggernum] = true
       end
     end
+    base[key][sourceGUID] = nil
   end
-  base[key] = nil
 end
 
 local function CleanUpMulti(guid)


### PR DESCRIPTION
On a CLEU SPELL_AURA_REMOVED too much data was removed, so that later
events would not correctly know what to remove.

Fixes: #1159

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
<!-- If it is a GitHub ticket, then #ticketNum will be sufficient. A WowAce ticket should include a URL. -->
Fixes #(issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:
<!-- These can be checked off after the pull request is submitted, in case you want discussion before they’re completely ready -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

<!-- Is there any additional work that needs to be done? If so, add it to the above list -->
