### PR TITLE
Icon: Make "Show Cooldown Text" toggle work with OmniCC

### DIFF
--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -2071,9 +2071,7 @@ WeakAuras.event_prototypes = {
     },
     internal_events = function(trigger, untrigger)
       local events = {
-        "SPELL_COOLDOWN_READY",
         "SPELL_COOLDOWN_CHANGED",
-        "SPELL_COOLDOWN_STARTED",
         "COOLDOWN_REMAINING_CHECK",
         "WA_DELAYED_PLAYER_ENTERING_WORLD"
       };
@@ -3501,9 +3499,7 @@ WeakAuras.event_prototypes = {
       "RUNE_POWER_UPDATE",
     },
     internal_events = {
-      "SPELL_COOLDOWN_READY",
       "SPELL_COOLDOWN_CHANGED",
-      "SPELL_COOLDOWN_STARTED",
     },
     force_events = "SPELL_UPDATE_USABLE",
     name = L["Action Usable"],


### PR DESCRIPTION
Turns out that there's indeed a way to tell OmniCC that information,
as pointed via the ticket.

Also rename and inverse the option to "Hide Cooldown Text" and make it
always visible.

We used to hide the option also for the case where the user was using
Blizzard's cooldowns but with the text option not enabled. In that case
the option obviously had no effect.

But, showing the option allows aura authors to use it to disable the
cooldown text for all users.

For the same setup - Blizzard without Text -, having the option be
"Show Cooldown Text" would have been odd, as enabling it would not have
shown any text. The renaming fixes that.

Ticket-Nr: 1320

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
<!-- If it is a GitHub ticket, then #ticketNum will be sufficient. A WowAce ticket should include a URL. -->
Fixes #(issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:
<!-- These can be checked off after the pull request is submitted, in case you want discussion before they’re completely ready -->

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

<!-- Is there any additional work that needs to be done? If so, add it to the above list -->
