### PR TITLE
BT2upgrade icon update

### DIFF
--- a/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasDisplayButton.lua
+++ b/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasDisplayButton.lua
@@ -1533,8 +1533,12 @@ local methods = {
   -- TODO: remove this once legacy aura trigger is removed
   ["RefreshBT2UpgradeIcon"] = function(self)
     if not self.data.controlledChildren and self.data.triggers then
-      for _, t in ipairs(self.data.triggers) do
+      for index, t in ipairs(self.data.triggers) do
         if t.trigger and t.trigger.type == "aura" then
+          self.bt2upgrade:SetScript("OnClick", function()
+            WeakAuras.optionTriggerChoices[self.data.id] = index
+            WeakAuras.PickDisplay(self.data.id, "trigger")
+          end)
           self.bt2upgrade:Show()
           return
         end

--- a/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasDisplayButton.lua
+++ b/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasDisplayButton.lua
@@ -1530,6 +1530,7 @@ local methods = {
     -- no addon, or no data, or ignore flag
     return false, false, nil, nil
   end,
+  -- TODO: remove this once legacy aura trigger is removed
   ["RefreshBT2UpgradeIcon"] = function(self)
     if not self.data.controlledChildren and self.data.triggers then
       for _, t in ipairs(self.data.triggers) do
@@ -1986,6 +1987,7 @@ local function Constructor()
     groupUpdate:Hide()
   end
 
+  -- TODO: remove this once legacy aura trigger is removed
   local bt2upgrade = CreateFrame("BUTTON", nil, button);
   button.bt2upgrade = bt2upgrade
   bt2upgrade.func = function() end

--- a/WeakAurasOptions/OptionsFrames/OptionsFrame.lua
+++ b/WeakAurasOptions/OptionsFrames/OptionsFrame.lua
@@ -633,6 +633,7 @@ function WeakAuras.CreateFrame()
   frame.FillOptions = function(self, optionTable, selected)
     AceConfig:RegisterOptionsTable("WeakAuras", optionTable);
     AceConfigDialog:Open("WeakAuras", container);
+    -- TODO: remove this once legacy aura trigger is removed
     if selected then
       container.content.obj.children[1]:SelectTab(selected)
     end
@@ -813,7 +814,7 @@ function WeakAuras.CreateFrame()
     end
   end
 
-  frame.PickDisplay = function(self, id, tab)
+  frame.PickDisplay = function(self, id, tab) -- TODO: remove tab parametter once legacy aura trigger is removed
     self:ClearPicks();
     local data = WeakAuras.GetData(id);
 
@@ -822,7 +823,7 @@ function WeakAuras.CreateFrame()
       self.pickedDisplay = id;
       local data = db.displays[id];
       WeakAuras.ReloadTriggerOptions(data);
-      self:FillOptions(displayOptions[id], tab);
+      self:FillOptions(displayOptions[id], tab); -- TODO: remove tab parametter once legacy aura trigger is removed
       WeakAuras.regions[id].region:Collapse();
       WeakAuras.regions[id].region:Expand();
       self.moversizer:SetToRegion(WeakAuras.regions[id].region, db.displays[id]);

--- a/WeakAurasOptions/OptionsFrames/OptionsFrame.lua
+++ b/WeakAurasOptions/OptionsFrames/OptionsFrame.lua
@@ -630,9 +630,10 @@ function WeakAuras.CreateFrame()
   unloadedButton:SetViewDescription(L["Toggle the visibility of all non-loaded displays"]);
   frame.unloadedButton = unloadedButton;
 
-  frame.FillOptions = function(self, optionTable)
+  frame.FillOptions = function(self, optionTable, selected)
     AceConfig:RegisterOptionsTable("WeakAuras", optionTable);
     AceConfigDialog:Open("WeakAuras", container);
+    AceConfigDialog:SelectGroup("WeakAuras", selected);
     container:SetTitle("");
   end
 
@@ -810,7 +811,7 @@ function WeakAuras.CreateFrame()
     end
   end
 
-  frame.PickDisplay = function(self, id)
+  frame.PickDisplay = function(self, id, tab)
     self:ClearPicks();
     local data = WeakAuras.GetData(id);
 
@@ -819,7 +820,7 @@ function WeakAuras.CreateFrame()
       self.pickedDisplay = id;
       local data = db.displays[id];
       WeakAuras.ReloadTriggerOptions(data);
-      self:FillOptions(displayOptions[id]);
+      self:FillOptions(displayOptions[id], tab);
       WeakAuras.regions[id].region:Collapse();
       WeakAuras.regions[id].region:Expand();
       self.moversizer:SetToRegion(WeakAuras.regions[id].region, db.displays[id]);

--- a/WeakAurasOptions/OptionsFrames/OptionsFrame.lua
+++ b/WeakAurasOptions/OptionsFrames/OptionsFrame.lua
@@ -633,7 +633,9 @@ function WeakAuras.CreateFrame()
   frame.FillOptions = function(self, optionTable, selected)
     AceConfig:RegisterOptionsTable("WeakAuras", optionTable);
     AceConfigDialog:Open("WeakAuras", container);
-    AceConfigDialog:SelectGroup("WeakAuras", selected);
+    if selected then
+      container.content.obj.children[1]:SelectTab(selected)
+    end
     container:SetTitle("");
   end
 

--- a/WeakAurasOptions/WeakAurasOptions.lua
+++ b/WeakAurasOptions/WeakAurasOptions.lua
@@ -2890,6 +2890,10 @@ function WeakAuras.ReloadTriggerOptions(data)
     optionTriggerChoices[id] = min(optionTriggerChoices[id] or 1, #data.triggers);
     local triggerChoice = optionTriggerChoices[id]
     -- TODO: remove this once legacy aura trigger is removed
+    local button = displayButtons[id]
+    if (button) then
+      button:RefreshBT2UpgradeIcon()
+    end
   end
 
   local function deleteTrigger()

--- a/WeakAurasOptions/WeakAurasOptions.lua
+++ b/WeakAurasOptions/WeakAurasOptions.lua
@@ -2889,6 +2889,7 @@ function WeakAuras.ReloadTriggerOptions(data)
   else
     optionTriggerChoices[id] = min(optionTriggerChoices[id] or 1, #data.triggers);
     local triggerChoice = optionTriggerChoices[id]
+    -- TODO: remove this once legacy aura trigger is removed
   end
 
   local function deleteTrigger()
@@ -4314,6 +4315,7 @@ function WeakAuras.UpdateDisplayButton(data)
     if WeakAurasCompanion and button:IsGroup() then
       button:RefreshUpdate()
     end
+    -- TODO: remove this once legacy aura trigger is removed
     button:RefreshBT2UpgradeIcon()
   end
 end

--- a/WeakAurasOptions/WeakAurasOptions.lua
+++ b/WeakAurasOptions/WeakAurasOptions.lua
@@ -4102,7 +4102,7 @@ function WeakAuras.IsDisplayPicked(id)
   end
 end
 
-function WeakAuras.PickDisplay(id, tab)
+function WeakAuras.PickDisplay(id, tab) -- TODO: remove tab parametter once legacy aura trigger is removed
   frame:PickDisplay(id, tab);
   WeakAuras.UpdateButtonsScroll()
 end

--- a/WeakAurasOptions/WeakAurasOptions.lua
+++ b/WeakAurasOptions/WeakAurasOptions.lua
@@ -4102,8 +4102,8 @@ function WeakAuras.IsDisplayPicked(id)
   end
 end
 
-function WeakAuras.PickDisplay(id)
-  frame:PickDisplay(id);
+function WeakAuras.PickDisplay(id, tab)
+  frame:PickDisplay(id, tab);
   WeakAuras.UpdateButtonsScroll()
 end
 


### PR DESCRIPTION
# Description
fix icon not hiding after converting to BT2 or on removing trigger
show trigger on icon click

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## To Do
Need to click a second time to show the "trigger" tab when triggers options were not loaded (ace3 bug??)