### PR TITLE
Fix tooltip frame not having a parent and thus eating mouse events

### DIFF
--- a/WeakAuras/RegionTypes/AuraBar.lua
+++ b/WeakAuras/RegionTypes/AuraBar.lua
@@ -1271,7 +1271,7 @@ local function modify(parent, region, data)
 
   -- Update tooltip availability
   local tooltipType = WeakAuras.CanHaveTooltip(data);
-  if icon:IsVisible() and tooltipType and data.useTooltip then
+  if tooltipType and data.useTooltip then
     -- Create and enable tooltip-hover frame
     if not region.tooltipFrame then
       region.tooltipFrame = CreateFrame("frame");

--- a/WeakAuras/RegionTypes/Icon.lua
+++ b/WeakAuras/RegionTypes/Icon.lua
@@ -363,9 +363,9 @@ local function modify(parent, region, data)
   icon:SetDesaturated(data.desaturate);
 
   local tooltipType = WeakAuras.CanHaveTooltip(data);
-  if region:IsVisible() and tooltipType and data.useTooltip then
+  if(tooltipType and data.useTooltip) then
     if not region.tooltipFrame then
-      region.tooltipFrame = CreateFrame("frame");
+      region.tooltipFrame = CreateFrame("frame", nil, region);
       region.tooltipFrame:SetAllPoints(region);
       region.tooltipFrame:SetScript("OnEnter", function()
         WeakAuras.ShowMouseoverTooltip(region, region);


### PR DESCRIPTION
This reverts commit dc684ec89f4aca49c6fdc9a6aa39c4692e7eb8cd,
and fixes the issue differently.

Github-Issue: #1284


