### PR TITLE
Fix Anchoring issue with dynamic group when using children that have SELECTFRAME anchorFrameType

### DIFF
--- a/WeakAuras/RegionTypes/DynamicGroup.lua
+++ b/WeakAuras/RegionTypes/DynamicGroup.lua
@@ -48,8 +48,6 @@ local function releaseControlPoint(self, controlPoint)
   if regionData then
     controlPoint.regionData = nil
     regionData.controlPoint = nil
-    local parent = regionData.data.parent and WeakAuras.GetRegion(regionData.data.parent) or WeakAurasFrame
-    WeakAuras.AnchorFrame(regionData.data, regionData.region, parent)
   end
 end
 


### PR DESCRIPTION
# Description

A bug that is fixed by removing code! This was reported on discord

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Import this:
```
!T3zFtjosta8Vlw1tvAvEUqqq92N9QcbwLBrWIG3E(C1fjegG5mKWMmG6(h(z)P7zsc5LjHGVFkNxHyyET7E6PNF0jRwrTEAQt1uhQP6QPwNSaFlCP76mAKlHP1U4HhSxXkhDKc8MYAQlioUuBl46AQ6wgtSD(QJ(usV7Mr0uvR1TrJ24hqNQZWIHnUoL)BgViw2wWRdN7W)8Rex0LyyBn0vJbVLP7WYFXhrTOUtYD5HAysNsHPfmvMtHjTYVx(Nnu)Fh3y)lHR4yQPoHXM5(RF6t3Op2EpQ9NQEO9r)5GZwu6t4u2XOfXAmBIw7svka1WL0I3Gd0uV1xK9lkhD4Ehw5GdlF4HWVu0unSnNp1sDMUbXtYHcicwl95mqi2zgoEDHjcmeD0hsN7Q1wPa0do23SSEo2mHCTn8j4W)uciUM4YGP99975OBCnXrtDa87Xo2ZTGs0MlrG)6gq9257G2HAXiow6M)rGQCFOk2odXQkkUqZEUnuun1AnA3Rrx)IeyxubNwwG(YI9vDdMnu5UvR38cvuGpDb2yf3RWEWa11guPEQgO8JhdFgobCiJH(xy6m8ol9PudCupdkLHUPygJAoAizd0tE)bmpOmXf9nAcBqWv2JDOdfTF36HflnT4ZHc82FeDSOUM26CBFdtDxEpmDUjJ63wU0FssEXzeJ4xehLM0XwlLCmhkoPX2SnFb3ClVlj64L)b2GMMnh6nBf2V6G5Scwjy(QoZu)ou2swqqLdyaycwJQG0J4vj35d4FO68rJO3QPEvTQQ9UsTx1U9w(HN7q4FO65nA1ce)KbqPfIQtB068VErl)5IlXCKNLqVoNlKPFNoexcalIgHR(HjGotNRVCf2QkynxGMwkOsmyIh4wPquxjmYTSIXS3gBAFJyenyodSW7avaM8VTDVCnHmRkAvW6ILbxHhsagyqatxLA2wmyWpLRh7Crp1M1BKlFqMZM4jSzuJRVRU3Wb7lUC8R2yl(h0B1DqdCBZH23y1y4yU)guQwZ202rOtW)xH)Aj(R7JVYIU2KcZpp3L9Qv2CHA7kNqkgYHxbrZInF41tEZYv2xXCxiXJiFAfrE1STqC5p9Im5vXLQWoxEdHWwVti0XtGHCjfVY3WsFGjzO2XAQ)02Ekmz2RKM6ncdC)sPerKIcITp3MTZ99RoMAsz3fQuF1uFmStAVtBw7BGsTvZ2HgL9GsvN6g0JgZbx3tXREXSH4gcQZ9(TuN0ZCSh7qCDHfVgux)9b4DDOPrWqXtmuof)5WExlng8eFW89)yezND(lAQFNOFDvWqZ9xHjo0Z333E099p3bQS1yYq4T23qCUV)NbHIY99lXFvHRmT9huftv(e3lc3IdQ1qQl6VRj3aSCPdpy)YX2sq4wXycX4A(YuppPGfM6cDhkku0uTTQ5BMax1CoXZWZyIom4x2mG8DgXXxDwuiz8Qrsl4cbwWm8QrQ)qIRodxxs8R)XE(tfLm5awj8a2DcUDD(gQY7Q4dO8mHeljl4nqXfjYhQfFOd10gefwFPQ3iCF5JW9FAfME7eUC1kyXo3IhjY27C)VFFFXpoeOQWkJtiSMmY0AqKgSTlwPKIsPDVVVf1eEL5mNavHyneQxSFw6Na8)mJeSSbwtod9iGByY9H7hOYqkSdVbe6XDRmAfXwxhJHwrSardFr5mDCsJVzXmrVXx1ncIx7UP683ZUbC3E3Y3nIUWxMOosemwI(oi(jxQ1yud89QD72St3qJMUDo5IgyREwN2Fd)9PxWDkbVRE3lAwhFJ6PvpRAB(LAaflOe8(GbbiAXs01oy0hPfKM3WbxQ5)5W79AqWB4vIb(amoBZKnJOlvsCDSMweChSbOwsecB8cbsy5dzPX06zQHAAisy0YAm3N7xUVpgm4veRf75DnWUr8U94(V)1AMWrcQAAYD27IMNr(yvcJ)jBVLyBGT2nwdU7wh3PxVoNT1Uf2T4oFgmYSVYB0miZyTxJGCrjgdm1z0zOmtwWN8Yi(GA(Af)yCrhqTjoZhq1bzsTjWMbwyp4hxgejbgxid8l4Qcl(7yjCc0XQkiPxqIeLn3jiFnkxvanr4Ur5GJkwwXtl3g3j8ymC0rJK3UZT8clNrNcBgRoMyrCOgPuyxYjOTYvgOJcrWtthqTiNjg6IY3c2x1LLiE)iNm4HeXFKttS0zByLwGvyGZoEdfYJhDK4sGLjyAU15TQEzJUx1TXjnAFvJ2vpUvJ6BTdBcXAzvI7SeDig66bLJ7HuQBYiUmtAyPpaoV5GZShY1vsTTeZlruf5WrowWTXtYu8GD(mFqHXhRBQIwrCJc(jjLkS2DV92lIadMzHKyx0UjOOqnIqLbRj3cwJdt7(nHGwMoqN1Y24ACpbya2xUO0ZjbQr39k4hH1DDU7cO7twbqTHf2BmiSb872Lvg(mfLJukujfnOunzIsjuHRLsn))4TSawQirqURmZrHnc34pi(B)ZXXGT(D9dNWFbx0tDN5cArZ4Bhe4lGhcCSd2h64644XnWs64GoU2YWCtBnCMR7X2LAzWTH4hdnS1AW(oli9elF4lyA)lfl4f2xehbUHMVvnVr)oymrHvgIMtS0qYsXGICSSLM4vIkp9UOdbpupStkoSFuQROLm0iw4WpUosI21F2UCmPw(Oq)5vyKJ6C6x)3qQoryC8diXpX2993g9KSZdxv6giIcVn3YGGJOVYHUrSPtSMlMalSSpZbiVXcjk(YxYJSn8(MH1AXnD8AhuacB3Zh3PjgtmXfdnn1csSa5lcGJy(pCp2lcT21lsFHeRL9yQri)6mj7uW(RI)nCKy4aWBBzZW)w5V9COY(Rs)9oIpt4HmN()4RqtqyVrRg1691UvpRrKJtL1PtdFOgEqgRciJFSaHH1fTn(GHRB1ISey240YCp(F(2Pv6(hZ61mFW6YjCoF8iVpo4qyoWYqkUc0APIqB1yfLZt7PePOuWB5fU4XZDaJgRXW7mTThMfg0K4Atd5OuWIHP0TkuIb0NFr4hgIj76HqmVWN3GyCdIXxzeJdESiglRuUsHNheJrGB9VnOI(fHJqSAVt)w7MNCAVuWnEE1wvR3S9BrYJPcpmvCJzqgofmMSyF3DVO08cVNq8D9EOG9KrZRCXsfRSHM3gAEBO5THM3kwqhgrxwO8sWVlkgWn08sJMxOUKhaZ6GYtQQ(btZltj)dNPxkqcF5O59qm0ssqlSoBDG6jhkOKCylcyVy65i07Y0c8TpnVvNAx5LO3Q5ckp7Y8pW1hX0WJtK77l(gP6jx6C8Lk5nNT8j6jfLtEG6LTY69bdpj4HdHrktQEljF5r181kDadF8NK80cG2Txb4)oQCPkhSpwRCISDnqihNyNpCUxSKfCdHVhlfQhjBU1hMygDyPCqV8vof5kRS)r7)AWVkm3QrMKBPO0axY5axpkPkFuxEuTcJZkG4LhQRNuOwlzyLjWhP4NslJ1Ynwk8mqPsLk4GpxB55XDLuNwR0IlhHlLfKQn8ocX7OC5IkFWODi8Q82L2HWDw8Z1VM8mICCVyholRCmkc(aP30rr4xSwizEQiEKBunPW7mBmh4kIxAihG9y2qosHyqwA58t5qQ5uoOBeTcRrIkjxRVmOKuGCitZKi)GwlGhjvcsOm8ysFjXIyZ5dj1MO7GXnniFPXuKL7bSowPmoj4J1MXHpzJIljBOKGSHuQIkYXSWs9oDlpencL2dIVue88cc9AM4m2)JkoJhwAkT6yQ4yswC5P)W50zNCR9GNcghRjOL3ferKX8qww6SK5WQ5EKobGNYCwso4GmtAP0bYKR78WN)CvYNTuCgcVcymcbrztokTjhL(xsok9KCBqQSjhLoR6jn8snPwDQXZsPZ72SHAp536JVZZ4OCcp)LnzKAAC399R7abhzjEoK8OV1cvs9wlS4MKrAdCoHLWhm8CBsgPn3AHVntgjHh7m1vzkDEDP19yYfPiD2luYifvW(0L9rXnswsxB1zD06FVo(VVKrssgBSEy6Acho30KyWwbHUYBi09OVrczNEZ2)4hf)ZfhSD(4Xfv7((GO2Qzx6t5zvpyYY5XoERaKlB8PR8Uj8etk)r7OuuCbjx06GG7zi1IEVcM7bZlPWrfoOYZdVKuE(wk5rzzsAk(zgZsoc(rbMzE5LDMAKEurRBGFPEEFPrdkj4pUypRWywghrgXYfpgHF7ljURbs97Q)z6zir8uLp2r0tlI9NShcbj)UpYmQHkBIA4j6PfAMAVNWhkbzVl17Kqq4pvhO)8Uk)S7L6dMkpuJypVnEepGcs)26)15HtWdi(1SFgl88)n(92kNLJh2ZMCt(nEUjJjJ0R)dVZn5P8kYtz)V9Vutuz)mzozsl)aYm5CFJYV5R54JDoixrPIYB3VIJnzG8hRmqM3HVA3K1VPEKjUM5FCYhlIYHdex)fx2NYm5zi)Jx1tSX8NmYsSbtap4nr2h79VhoME)7Ht(rtKxAFPI3IldWtF3eC(eC6B4IA))d
```
and then edit the group somehow. Without these changes, the children should collapse in on themselves after 1 second. With this change, they should remain where they are supposed to be.