### PR TITLE
remove stale feature indicators

### DIFF
--- a/WeakAuras/RegionTypes/Icon.lua
+++ b/WeakAuras/RegionTypes/Icon.lua
@@ -78,23 +78,23 @@ local properties = {
     default = 32
   },
   glow = {
-    display = { WeakAuras.newFeatureString .. L["Glow"], L["Visibility"] },
+    display = { L["Glow"], L["Visibility"] },
     setter = "SetGlow",
     type = "bool"
   },
   glowType = {
-    display = { WeakAuras.newFeatureString .. L["Glow"], L["Type"] },
+    display = { L["Glow"], L["Type"] },
     setter = "SetGlowType",
     type = "list",
     values = WeakAuras.glow_types,
   },
   useGlowColor = {
-    display = { WeakAuras.newFeatureString .. L["Glow"], L["Use Custom Color"] },
+    display = { L["Glow"], L["Use Custom Color"] },
     setter = "SetUseGlowColor",
     type = "bool"
   },
   glowColor = {
-    display = { WeakAuras.newFeatureString .. L["Glow"], L["Color"]},
+    display = { L["Glow"], L["Color"]},
     setter = "SetGlowColor",
     type = "color"
   },

--- a/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasDisplayButton.lua
+++ b/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasDisplayButton.lua
@@ -175,7 +175,7 @@ clipboard.copyAnimationsEntry = {
 };
 
 clipboard.copyAuthorOptionsEntry = {
-  text = WeakAuras.newFeatureString .. L["Author Options"],
+  text = L["Author Options"],
   notCheckable = true,
   func = function()
     WeakAuras_DropDownMenu:Hide();
@@ -184,7 +184,7 @@ clipboard.copyAuthorOptionsEntry = {
 };
 
 clipboard.copyUserConfigEntry = {
-  text = WeakAuras.newFeatureString .. L["Custom Configuration"],
+  text = L["Custom Configuration"],
   notCheckable = true,
   func = function()
     WeakAuras_DropDownMenu:Hide();

--- a/WeakAurasOptions/ActionOptions.lua
+++ b/WeakAurasOptions/ActionOptions.lua
@@ -201,7 +201,7 @@ function WeakAuras.AddActionOption(id, data)
       start_do_glow = {
         type = "toggle",
         width = WeakAuras.normalWidth,
-        name = WeakAuras.newFeatureString .. L["Button Glow"],
+        name = L["Button Glow"],
         order = 10.1
       },
       start_glow_action = {
@@ -392,7 +392,7 @@ function WeakAuras.AddActionOption(id, data)
       finish_do_glow = {
         type = "toggle",
         width = WeakAuras.normalWidth,
-        name = WeakAuras.newFeatureString .. L["Button Glow"],
+        name = L["Button Glow"],
         order = 30.1
       },
       finish_glow_action = {

--- a/WeakAurasOptions/OptionsFrames/OptionsFrame.lua
+++ b/WeakAurasOptions/OptionsFrames/OptionsFrame.lua
@@ -722,7 +722,7 @@ function WeakAuras.CreateFrame()
         containerScroll:AddChild(simpleLabel);
 
         local button = AceGUI:Create("WeakAurasNewButton");
-        button:SetTitle(WeakAuras.newFeatureString .. L["From Template"]);
+        button:SetTitle(L["From Template"]);
         button:SetDescription(L["Offer a guided way to create auras for your class"])
         button:SetIcon("Interface\\Icons\\INV_Misc_Book_06");
         button:SetClick(function()

--- a/WeakAurasOptions/RegionOptions/Icon.lua
+++ b/WeakAurasOptions/RegionOptions/Icon.lua
@@ -75,7 +75,7 @@ local function createOptions(id, data)
     cooldownSwipe = {
       type = "toggle",
       width = WeakAuras.normalWidth,
-      name = WeakAuras.newFeatureString .. L["Cooldown Swipe"],
+      name = L["Cooldown Swipe"],
       order = 6.3,
       disabled = function() return not WeakAuras.CanHaveDuration(data) end,
       hidden = function() return not data.cooldown end,
@@ -83,7 +83,7 @@ local function createOptions(id, data)
     cooldownEdge = {
       type = "toggle",
       width = WeakAuras.normalWidth,
-      name = WeakAuras.newFeatureString .. L["Cooldown Edge"],
+      name = L["Cooldown Edge"],
       order = 6.4,
       disabled = function() return not WeakAuras.CanHaveDuration(data) end,
       hidden = function() return not data.cooldown end,
@@ -99,7 +99,7 @@ local function createOptions(id, data)
     glowHeader = {
       type = "header",
       order = 19,
-      name = WeakAuras.newFeatureString .. L["Glow Settings"],
+      name = L["Glow Settings"],
     },
     glow = {
       type = "toggle",

--- a/WeakAurasOptions/WeakAurasOptions.lua
+++ b/WeakAurasOptions/WeakAurasOptions.lua
@@ -2623,7 +2623,7 @@ function WeakAuras.AddOption(id, data)
       },
       authorOptions = {
         type = "group",
-        name = WeakAuras.newFeatureString .. L["Custom Options"],
+        name = L["Custom Options"],
         order = 100
       }
     }

--- a/WeakAurasTemplates/TriggerTemplates.lua
+++ b/WeakAurasTemplates/TriggerTemplates.lua
@@ -1608,7 +1608,7 @@ function WeakAuras.CreateTemplateView(frame)
   local batchModeLabelString = batchModeLabel:CreateFontString(nil, "ARTWORK");
   batchModeLabelString:SetFont(STANDARD_TEXT_FONT, 10); -- "OUTLINE"
   batchModeLabelString:SetTextColor(1,1,1,1);
-  batchModeLabelString:SetText(WeakAuras.newFeatureString .. L["Hold CTRL to create multiple auras at once"]);
+  batchModeLabelString:SetText(L["Hold CTRL to create multiple auras at once"]);
   batchModeLabelString:SetJustifyH("LEFT")
   batchModeLabelString:SetAllPoints(batchModeLabel);
   batchModeLabel:SetPoint("BOTTOMLEFT", 10, -23);


### PR DESCRIPTION
I think in 2.13, these features will have aged enough to not count as "new" anymore.

Templates from 2.7.3
Custom Options, Glow, Cooldown Settings from 2.10.0