### PR TITLE
move travis to a better layout and also deploy to WowInterface

### DIFF
--- a/.pkgmeta
+++ b/.pkgmeta
@@ -1,4 +1,5 @@
 package-as: WeakAuras
+wowi-archive-previous: no
 
 externals:
  WeakAuras/Libs/LibStub: https://repos.wowace.com/wow/libstub/trunk

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,30 +3,26 @@ language: minimal
 addons:
   apt:
     packages:
-    - luarocks
+      - luarocks
 
 git:
   depth: 150
 
 install: luarocks install --local luacheck
 
-before_script: /home/travis/.luarocks/bin/luacheck . --no-color -q
+script: /home/travis/.luarocks/bin/luacheck . --no-color -q
 
-script:
+after_success:
   - if [[ "$TRAVIS_BRANCH" == "master" && "$TRAVIS_PULL_REQUEST" == "false" ]]; then ./wowace_translations.sh; fi
-  - |
-    ./generate_changelog.sh
-    sed -i "s/@build-time@/`date +%Y%m%d%H%M%S`/" WeakAuras/Init.lua
-    if [[ "$TRAVIS_TAG" == "8.0-"* ]]; then
-      curl -s https://raw.githubusercontent.com/BigWigsMods/packager/master/release.sh | bash -s -- -o -p 65387 -g 8.0.1
-    else
-      curl -s https://raw.githubusercontent.com/BigWigsMods/packager/master/release.sh | bash -s -- -o -p 65387
-    fi
+  - ./generate_changelog.sh
+  - sed -i "s/@build-time@/`date +%Y%m%d%H%M%S`/" WeakAuras/Init.lua
 
-after_failure:
-  - wget https://raw.githubusercontent.com/DiscordHooks/travis-ci-discord-webhook/master/send.sh
-  - chmod +x send.sh
-  - ./send.sh failure $WEBHOOK_URL
+deploy:
+  skip_cleanup: true
+  provider: script
+  script: curl -s https://raw.githubusercontent.com/BigWigsMods/packager/master/release.sh | bash
+
+after_script: if [[ "$TRAVIS_TEST_RESULT" == 1 ]]; then curl -s https://raw.githubusercontent.com/DiscordHooks/travis-ci-discord-webhook/master/send.sh | bash -s -- failure $WEBHOOK_URL; fi
 
 notifications:
   email:

--- a/WeakAuras/WeakAuras.toc
+++ b/WeakAuras/WeakAuras.toc
@@ -11,6 +11,7 @@
 ## Globe-Post: WeakAurasOptions, WeakAurasModelPaths, WeakAurasTemplates
 ## X-Website: https://www.curseforge.com/wow/addons/weakauras-2
 ## X-Curse-Project-ID: 65387
+## X-WoWI-ID: 24910
 ## DefaultState: Enabled
 ## LoadOnDemand: 0
 ## SavedVariables: WeakAurasSaved


### PR DESCRIPTION
# Description

Our build stages were a bit out of order, resulting in the `after_failure` step we previously used to trigger a Discord notification on build failure to never trigger.

I also removed the previous workaround we had for in-expansion-work tags and added automatic uploads to WoWInterface at https://www.wowinterface.com/downloads/info24910-2.12.0.html. I still need to fix the description text over there. The packager, by default, only updates tags there, so we don't have to worry about alpha builds.
