### PR TITLE
New glow options for icons

### DIFF
--- a/WeakAuras/RegionTypes/Icon.lua
+++ b/WeakAuras/RegionTypes/Icon.lua
@@ -44,6 +44,14 @@ local default = {
   useglowColor = false,
   glowColor = {1, 1, 1, 1},
   glowType = "buttonOverlay",
+  glowLines = 8,
+  glowFrequency = 0.25,
+  glowLength = 10,
+  glowThickness = 4,
+  glowScale = 1,
+  glowBorder = false,
+  glowXOffset = 0,
+  glowYOffset = 0,
   cooldownTextDisabled = false,
   cooldownSwipe = true,
   cooldownEdge = false,
@@ -97,6 +105,75 @@ local properties = {
     display = { WeakAuras.newFeatureString .. L["Glow"], L["Color"]},
     setter = "SetGlowColor",
     type = "color"
+  },
+  glowLines = {
+    display = { WeakAuras.newFeatureString .. L["Glow"], L["Lines & Particules"]},
+    setter = "SetGlowLines",
+    type = "number",
+    min = 1,
+    softMax = 30,
+    bigStep = 1,
+    default = 4
+  },
+  glowFrequency = {
+    display = { WeakAuras.newFeatureString .. L["Glow"], L["Frequency"]},
+    setter = "SetGlowFrequency",
+    type = "number",
+    softMin = -2,
+    softMax = 2,
+    bigStep = 0.1,
+    default = 0.25
+  },
+  glowLength = {
+    display = { WeakAuras.newFeatureString .. L["Glow"], L["Length"]},
+    setter = "SetGlowLength",
+    type = "number",
+    min = 1,
+    softMax = 20,
+    bigStep = 1,
+    default = 10
+  },
+  glowThickness = {
+    display = { WeakAuras.newFeatureString .. L["Glow"], L["Thickness"]},
+    setter = "SetGlowThickness",
+    type = "number",
+    min = 1,
+    softMax = 20,
+    bigStep = 1,
+    default = 4
+  },
+  glowScale = {
+    display = { WeakAuras.newFeatureString .. L["Glow"], L["Scale"]},
+    setter = "SetGlowScale",
+    type = "number",
+    min = 0.05,
+    softMax = 10,
+    bigStep = 0.05,
+    default = 1,
+    isPercent = true
+  },
+  glowBorder = {
+    display = { WeakAuras.newFeatureString .. L["Glow"], L["Border"]},
+    setter = "SetGlowBorder",
+    type = "bool"
+  },
+  glowXOffset = {
+    display = { WeakAuras.newFeatureString .. L["Glow"], L["X-Offset"]},
+    setter = "SetGlowXOffset",
+    type = "number",
+    softMin = -100,
+    softMax = 100,
+    bigStep = 1,
+    default = 0
+  },
+  glowYOffset = {
+    display = { WeakAuras.newFeatureString .. L["Glow"], L["Y-Offset"]},
+    setter = "SetGlowYOffset",
+    type = "number",
+    softMin = 1,
+    softMax = -100,
+    bigStep = 100,
+    default = 0
   },
   text1Color = {
     display = { L["1. Text"] , L["Color"] },
@@ -669,15 +746,91 @@ local function modify(parent, region, data)
     end
   end
 
+  function region:SetGlowLines(lines)
+    region.glowLines = lines
+    if region.glow then
+      region:SetGlow(true)
+    end
+  end
+  function region:SetGlowFrequency(frequency)
+    region.glowFrequency = frequency
+    if region.glow then
+      region:SetGlow(true)
+    end
+  end
+  function region:SetGlowLength(length)
+    region.glowLength = length
+    if region.glow then
+      region:SetGlow(true)
+    end
+  end
+  function region:SetGlowThickness(thickness)
+    region.glowThickness = thickness
+    if region.glow then
+      region:SetGlow(true)
+    end
+  end
+  function region:SetGlowScale(scale)
+    region.glowScale = scale
+    if region.glow then
+      region:SetGlow(true)
+    end
+  end
+  function region:SetGlowBorder(border)
+    region.glowBorder = border
+    if region.glow then
+      region:SetGlow(true)
+    end
+  end
+  function region:SetGlowXOffset(xoffset)
+    region.glowXOffset = xoffset
+    if region.glow then
+      region:SetGlow(true)
+    end
+  end
+  function region:SetGlowYOffset(yoffset)
+    region.glowYOffset = yoffset
+    if region.glow then
+      region:SetGlow(true)
+    end
+  end
+
   function region:SetGlow(showGlow)
-    region.glow = showGlow
     local color
+    local function glowStart(frame)
+      if region.glowType == "buttonOverlay" then
+        region.glowStart(frame, color, region.glowFrequency)
+      elseif region.glowType == "Pixel" then
+        region.glowStart(
+          frame,
+          color,
+          region.glowLines,
+          region.glowFrequency,
+          region.glowLength,
+          region.glowThickness,
+          region.glowXOffset,
+          region.glowYOffset,
+          region.glowBorder
+        )
+      elseif region.glowType == "ACShine" then
+        region.glowStart(
+          frame,
+          color,
+          region.glowParticules,
+          region.glowFrequency,
+          region.glowScale,
+          region.glowXOffset,
+          region.glowYOffset
+        )
+      end
+    end
+    region.glow = showGlow
     if region.useGlowColor then
       color = region.glowColor
     end
     if MSQ then
       if (showGlow) then
-        region.glowStart(region.button, color);
+        glowStart(region.button);
       else
         region.glowStop(region.button);
       end
@@ -687,7 +840,7 @@ local function modify(parent, region, data)
         region.__WAGlowFrame:SetAllPoints();
         region.__WAGlowFrame:SetSize(region.width, region.height);
       end
-      region.glowStart(region.__WAGlowFrame, color);
+      glowStart(region.__WAGlowFrame);
     else
       if (region.__WAGlowFrame) then
         region.glowStop(region.__WAGlowFrame);
@@ -704,8 +857,24 @@ local function modify(parent, region, data)
 
   region.useGlowColor = data.useGlowColor
   region.glowColor = data.glowColor
+  region.glowLines = data.glowLines
+  region.glowFrequency = data.glowFrequency
+  region.glowLength = data.glowLength
+  region.glowThickness = data.glowThickness
+  region.glowScale = data.glowScale
+  region.glowBorder = data.glowBorder
+  region.glowXOffset = data.glowXOffset
+  region.glowYOffset = data.glowYOffset
   region:SetGlowType(data.glowType)
   region:SetGlow(data.glow)
+  region:SetGlowLines(data.glowLines)
+  region:SetGlowFrequency(data.glowFrequency)
+  region:SetGlowLength(data.glowLength)
+  region:SetGlowThickness(data.glowThickness)
+  region:SetGlowScale(data.glowScale)
+  region:SetGlowBorder(data.glowBorder)
+  region:SetGlowXOffset(data.glowXOffset)
+  region:SetGlowYOffset(data.glowYOffset)
 
   if(data.cooldown) then
     function region:SetValue(value, total)

--- a/WeakAuras/RegionTypes/Icon.lua
+++ b/WeakAuras/RegionTypes/Icon.lua
@@ -867,14 +867,6 @@ local function modify(parent, region, data)
   region.glowYOffset = data.glowYOffset
   region:SetGlowType(data.glowType)
   region:SetGlow(data.glow)
-  region:SetGlowLines(data.glowLines)
-  region:SetGlowFrequency(data.glowFrequency)
-  region:SetGlowLength(data.glowLength)
-  region:SetGlowThickness(data.glowThickness)
-  region:SetGlowScale(data.glowScale)
-  region:SetGlowBorder(data.glowBorder)
-  region:SetGlowXOffset(data.glowXOffset)
-  region:SetGlowYOffset(data.glowYOffset)
 
   if(data.cooldown) then
     function region:SetValue(value, total)

--- a/WeakAuras/RegionTypes/Icon.lua
+++ b/WeakAuras/RegionTypes/Icon.lua
@@ -107,7 +107,7 @@ local properties = {
     type = "color"
   },
   glowLines = {
-    display = { WeakAuras.newFeatureString .. L["Glow"], L["Lines & Particules"]},
+    display = { WeakAuras.newFeatureString .. L["Glow"], L["Lines & Particles"]},
     setter = "SetGlowLines",
     type = "number",
     min = 1,

--- a/WeakAuras/RegionTypes/Icon.lua
+++ b/WeakAuras/RegionTypes/Icon.lua
@@ -749,6 +749,9 @@ local function modify(parent, region, data)
   function region:SetGlowLines(lines)
     region.glowLines = lines
     if region.glow then
+      if region.glowType == "ACShine" then -- workaround ACShine not updating numbers of dots
+        region:SetGlow(false)
+      end
       region:SetGlow(true)
     end
   end

--- a/WeakAuras/RegionTypes/Icon.lua
+++ b/WeakAuras/RegionTypes/Icon.lua
@@ -816,7 +816,7 @@ local function modify(parent, region, data)
         region.glowStart(
           frame,
           color,
-          region.glowParticules,
+          region.glowLines,
           region.glowFrequency,
           region.glowScale,
           region.glowXOffset,

--- a/WeakAurasOptions/RegionOptions/Icon.lua
+++ b/WeakAurasOptions/RegionOptions/Icon.lua
@@ -96,38 +96,6 @@ local function createOptions(id, data)
       disabled = function() return not WeakAuras.CanHaveDuration(data); end,
       hidden = function() return not data.cooldown end,
     },
-    glowHeader = {
-      type = "header",
-      order = 19,
-      name = WeakAuras.newFeatureString .. L["Glow Settings"],
-    },
-    glow = {
-      type = "toggle",
-      width = WeakAuras.normalWidth,
-      name = L["Show Glow Effect"],
-      order = 20,
-    },
-    glowType = {
-      type = "select",
-      width = WeakAuras.normalWidth,
-      name = L["Glow Type"],
-      order = 21,
-      values = WeakAuras.glow_types,
-    },
-    useGlowColor = {
-      type = "toggle",
-      width = WeakAuras.normalWidth,
-      name = L["Glow Color"],
-      desc = L["If unchecked, then a default color will be used (usually yellow)"],
-      order = 23,
-    },
-    glowColor = {
-      type = "color",
-      width = WeakAuras.normalWidth,
-      name = L["Glow Color"],
-      order = 24,
-      disabled = function() return not data.useGlowColor end,
-    },
     textHeader1 = {
       type = "header",
       order = 39,
@@ -398,6 +366,7 @@ local function createOptions(id, data)
 
   return {
     icon = options,
+    glow = WeakAuras.GlowOptions(id, data, 10),
     position = WeakAuras.PositionOptions(id, data),
   };
 end

--- a/WeakAurasOptions/RegionOptions/Icon.lua
+++ b/WeakAurasOptions/RegionOptions/Icon.lua
@@ -364,9 +364,12 @@ local function createOptions(id, data)
 
   WeakAuras.AddCodeOption(options, data, L["Custom Function"], "customText", 43.2,  hideCustomTextEditor, {"customText"}, false);
 
+  for k, v in pairs(WeakAuras.GlowOptions(id, data, 10)) do
+    options[k] = v
+  end
+
   return {
     icon = options,
-    glow = WeakAuras.GlowOptions(id, data, 10),
     position = WeakAuras.PositionOptions(id, data),
   };
 end

--- a/WeakAurasOptions/WeakAurasOptions.lua
+++ b/WeakAurasOptions/WeakAurasOptions.lua
@@ -3649,7 +3649,7 @@ end
 
 function WeakAuras.GlowOptions(id, data, order)
   local hiddenGlowExtra = function()
-    return WeakAuras.IsCollapsed("glow", "glow", "glowflags", true);
+    return WeakAuras.IsCollapsed("glow", "glow", "glowextra", true);
   end
 
   local glowOptions = {
@@ -3666,25 +3666,73 @@ function WeakAuras.GlowOptions(id, data, order)
     },
     glowType = {
       type = "select",
-      width = WeakAuras.normalWidth - 0.25,
+      width = WeakAuras.normalWidth,
       name = L["Type"],
       order = order + 0.03,
       values = WeakAuras.glow_types,
     },
+    glowExtraDescription = {
+      type = "description",
+      name = function()
+        local line = L["|cFFffcc00Glow:|r"]
+        local color = L["Default Color"]
+        if data.useGlowColor then
+          color = L["|c%02x%02x%02x%02xColor|r"]:format(
+            data.glowColor[4] * 255,
+            data.glowColor[1] * 255,
+            data.glowColor[2] * 255,
+            data.glowColor[3] * 255
+          )
+        end
+        if data.glowType == "buttonOverlay" then
+          line = ("%s %s"):format(line, color)
+        elseif data.glowType == "ACShine" then
+          line = L["%s %s, particules: %d, frequency: %d, scale: %d"]:format(
+            line,
+            color,
+            data.glowLines,
+            data.glowFrequency,
+            data.glowScale
+          )
+          if data.glowXOffset ~= 0 or data.glowYOffset ~= 0 then
+            line = L["%s, offset: %d;%d"]:format(line, data.glowXOffset, data.glowYOffset)
+          end
+        elseif data.glowType == "Pixel" then
+          line = L["%s %s, lines: %d, frequency: %d, length: %d, thickness: %d"]:format(
+            line,
+            color,
+            data.glowLines,
+            data.glowFrequency,
+            data.glowLength,
+            data.glowThickness
+          )
+          if data.glowXOffset ~= 0 or data.glowYOffset ~= 0 then
+            line = L["%s, offset: %d;%d"]:format(line, data.glowXOffset, data.glowYOffset)
+          end
+          if data.glowBorder then
+            line = L["%s, border"]:format(line)
+          end
+        end
+        return line
+      end,
+      width = WeakAuras.doubleWidth - 0.15,
+      order = order + 1,
+      fontSize = "medium"
+    },
     glowExpand = {
       type = "execute",
       name = "",
-      order = order + 1,
-      width = 0.2,
+      order = order + 1.01,
+      width = 0.15,
       image = function()
-        local collapsed = WeakAuras.IsCollapsed("glow", "glow", "glowflags", true);
+        local collapsed = WeakAuras.IsCollapsed("glow", "glow", "glowextra", true);
         return collapsed and "Interface\\AddOns\\WeakAuras\\Media\\Textures\\edit" or "Interface\\AddOns\\WeakAuras\\Media\\Textures\\editdown"
       end,
       imageWidth = 24,
       imageHeight = 24,
       func = function()
-        local collapsed = WeakAuras.IsCollapsed("glow", "glow", "glowflags", true);
-        WeakAuras.SetCollapsed("glow", "glow", "glowflags", not collapsed);
+        local collapsed = WeakAuras.IsCollapsed("glow", "glow", "glowextra", true);
+        WeakAuras.SetCollapsed("glow", "glow", "glowextra", not collapsed);
       end
     },
     useGlowColor = {

--- a/WeakAurasOptions/WeakAurasOptions.lua
+++ b/WeakAurasOptions/WeakAurasOptions.lua
@@ -3754,7 +3754,7 @@ function WeakAuras.GlowOptions(id, data, order)
     glowLines = {
       type = "range",
       width = WeakAuras.normalWidth,
-      name = L["Lines & Particules"],
+      name = L["Lines & Particles"],
       order = order + 1.06,
       min = 1,
       softMax = 30,

--- a/WeakAurasOptions/WeakAurasOptions.lua
+++ b/WeakAurasOptions/WeakAurasOptions.lua
@@ -3647,6 +3647,120 @@ function WeakAuras.PositionOptions(id, data, _, hideWidthHeight, disableSelfPoin
   return positionOptions;
 end
 
+function WeakAuras.GlowOptions(id, data, order)
+  local glowOptions = {
+    __title = WeakAuras.newFeatureString .. L["Glow Settings"],
+    __order = order,
+    glow = {
+      type = "toggle",
+      width = WeakAuras.normalWidth,
+      name = L["Show Glow Effect"],
+      order = order + 0.02,
+    },
+    glowType = {
+      type = "select",
+      width = WeakAuras.normalWidth,
+      name = L["Type"],
+      order = order + 0.03,
+      values = WeakAuras.glow_types,
+    },
+    useGlowColor = {
+      type = "toggle",
+      width = WeakAuras.normalWidth,
+      name = L["Color"],
+      desc = L["If unchecked, then a default color will be used (usually yellow)"],
+      order = order + 0.04,
+    },
+    glowColor = {
+      type = "color",
+      width = WeakAuras.normalWidth,
+      name = L["Color"],
+      order = order + 0.05,
+      disabled = function() return not data.useGlowColor end,
+    },
+    glowLines = {
+      type = "range",
+      width = WeakAuras.normalWidth,
+      name = L["Lines & Particules"],
+      order = order + 0.06,
+      min = 1,
+      softMax = 30,
+      step = 1,
+      hidden = function() return data.glowType == "buttonOverlay" end,
+    },
+    glowFrequency = {
+      type = "range",
+      width = WeakAuras.normalWidth,
+      name = L["Frequency"],
+      order = order + 0.07,
+      softMin = -2,
+      softMax = 2,
+      step = 0.05,
+      hidden = function() return data.glowType == "buttonOverlay" end,
+    },
+    glowLength = {
+      type = "range",
+      width = WeakAuras.normalWidth,
+      name = L["Length"],
+      order = order + 0.08,
+      min = 1,
+      softMax = 20,
+      step = 0.05,
+      hidden = function() return data.glowType ~= "Pixel" end,
+    },
+    glowThickness = {
+      type = "range",
+      width = WeakAuras.normalWidth,
+      name = L["Thickness"],
+      order = order + 0.09,
+      min = 0.05,
+      softMax = 20,
+      step = 0.05,
+      hidden = function() return data.glowType ~= "Pixel" end,
+    },
+    glowXOffset = {
+      type = "range",
+      width = WeakAuras.normalWidth,
+      name = L["X-Offset"],
+      order = order + 0.10,
+      softMin = -100,
+      softMax = 100,
+      step = 0.5,
+      hidden = function() return data.glowType == "buttonOverlay" end,
+    },
+    glowYOffset = {
+      type = "range",
+      width = WeakAuras.normalWidth,
+      name = L["Y-Offset"],
+      order = order + 0.11,
+      softMin = -100,
+      softMax = 100,
+      step = 0.5,
+      hidden = function() return data.glowType == "buttonOverlay" end,
+    },
+    glowScale = {
+      type = "range",
+      width = WeakAuras.normalWidth,
+      name = L["Scale"],
+      order = order + 0.12,
+      min = 0.05,
+      softMax = 10,
+      step = 0.05,
+      isPercent = true,
+      hidden = function() return data.glowType ~= "ACShine" end,
+    },
+    glowBorder = {
+      type = "toggle",
+      width = WeakAuras.normalWidth,
+      name = L["Border"],
+      order = order + 0.13,
+      hidden = function() return data.glowType ~= "Pixel" end,
+    }
+  }
+
+  return glowOptions
+end
+
 -- TODO: update this function to not have an unused parameter
 function WeakAuras.BorderOptions(id, data, _, showBackDropOptions)
   local metaOrder = 99

--- a/WeakAurasOptions/WeakAurasOptions.lua
+++ b/WeakAurasOptions/WeakAurasOptions.lua
@@ -3652,6 +3652,8 @@ function WeakAuras.GlowOptions(id, data, order)
     return WeakAuras.IsCollapsed("glow", "glow", "glowextra", true);
   end
 
+  local indentWidth = 0.1
+
   local glowOptions = {
     glowHeader = {
       type = "header",
@@ -3735,27 +3737,41 @@ function WeakAuras.GlowOptions(id, data, order)
         WeakAuras.SetCollapsed("glow", "glow", "glowextra", not collapsed);
       end
     },
+    glow_space1 = {
+      type = "description",
+      name = "",
+      width = indentWidth,
+      order = order + 1.10,
+      hidden = hiddenGlowExtra,
+    },
     useGlowColor = {
       type = "toggle",
-      width = WeakAuras.normalWidth,
+      width = WeakAuras.normalWidth - indentWidth,
       name = L["Color"],
       desc = L["If unchecked, then a default color will be used (usually yellow)"],
-      order = order + 1.04,
+      order = order + 1.11,
       hidden = hiddenGlowExtra
     },
     glowColor = {
       type = "color",
       width = WeakAuras.normalWidth,
       name = L["Color"],
-      order = order + 1.05,
+      order = order + 1.12,
       disabled = function() return not data.useGlowColor end,
       hidden = hiddenGlowExtra
     },
+    glow_space2 = {
+      type = "description",
+      name = "",
+      width = indentWidth,
+      order = order + 1.20,
+      hidden = hiddenGlowExtra,
+    },
     glowLines = {
       type = "range",
-      width = WeakAuras.normalWidth,
+      width = WeakAuras.normalWidth - indentWidth,
       name = L["Lines & Particles"],
-      order = order + 1.06,
+      order = order + 1.21,
       min = 1,
       softMax = 30,
       step = 1,
@@ -3765,17 +3781,24 @@ function WeakAuras.GlowOptions(id, data, order)
       type = "range",
       width = WeakAuras.normalWidth,
       name = L["Frequency"],
-      order = order + 1.07,
+      order = order + 1.22,
       softMin = -2,
       softMax = 2,
       step = 0.05,
       hidden = function() return hiddenGlowExtra() or data.glowType == "buttonOverlay" end,
     },
+    glow_space3 = {
+      type = "description",
+      name = "",
+      width = indentWidth,
+      order = order + 1.30,
+      hidden = hiddenGlowExtra,
+    },
     glowLength = {
       type = "range",
-      width = WeakAuras.normalWidth,
+      width = WeakAuras.normalWidth - indentWidth,
       name = L["Length"],
-      order = order + 1.08,
+      order = order + 1.31,
       min = 1,
       softMax = 20,
       step = 0.05,
@@ -3785,17 +3808,24 @@ function WeakAuras.GlowOptions(id, data, order)
       type = "range",
       width = WeakAuras.normalWidth,
       name = L["Thickness"],
-      order = order + 1.09,
+      order = order + 1.32,
       min = 0.05,
       softMax = 20,
       step = 0.05,
       hidden = function() return hiddenGlowExtra() or data.glowType ~= "Pixel" end,
     },
+    glow_space4 = {
+      type = "description",
+      name = "",
+      width = indentWidth,
+      order = order + 1.40,
+      hidden = hiddenGlowExtra,
+    },
     glowXOffset = {
       type = "range",
-      width = WeakAuras.normalWidth,
+      width = WeakAuras.normalWidth - indentWidth,
       name = L["X-Offset"],
-      order = order + 1.10,
+      order = order + 1.41,
       softMin = -100,
       softMax = 100,
       step = 0.5,
@@ -3805,17 +3835,24 @@ function WeakAuras.GlowOptions(id, data, order)
       type = "range",
       width = WeakAuras.normalWidth,
       name = L["Y-Offset"],
-      order = order + 1.11,
+      order = order + 1.42,
       softMin = -100,
       softMax = 100,
       step = 0.5,
       hidden = function() return hiddenGlowExtra() or data.glowType == "buttonOverlay" end,
     },
+    glow_space5 = {
+      type = "description",
+      name = "",
+      width = indentWidth,
+      order = order + 1.50,
+      hidden = hiddenGlowExtra,
+    },
     glowScale = {
       type = "range",
-      width = WeakAuras.normalWidth,
+      width = WeakAuras.normalWidth - indentWidth,
       name = L["Scale"],
-      order = order + 1.12,
+      order = order + 1.52,
       min = 0.05,
       softMax = 10,
       step = 0.05,
@@ -3824,9 +3861,9 @@ function WeakAuras.GlowOptions(id, data, order)
     },
     glowBorder = {
       type = "toggle",
-      width = WeakAuras.normalWidth,
+      width = WeakAuras.normalWidth - indentWidth,
       name = L["Border"],
-      order = order + 1.13,
+      order = order + 1.53,
       hidden = function() return hiddenGlowExtra() or data.glowType ~= "Pixel" end,
     }
   }

--- a/WeakAurasOptions/WeakAurasOptions.lua
+++ b/WeakAurasOptions/WeakAurasOptions.lua
@@ -3792,7 +3792,7 @@ function WeakAuras.GlowOptions(id, data, order)
       name = "",
       width = indentWidth,
       order = order + 1.30,
-      hidden = hiddenGlowExtra,
+      hidden = function() return hiddenGlowExtra() or data.glowType ~= "Pixel" end,
     },
     glowLength = {
       type = "range",

--- a/WeakAurasOptions/WeakAurasOptions.lua
+++ b/WeakAurasOptions/WeakAurasOptions.lua
@@ -3648,9 +3648,16 @@ function WeakAuras.PositionOptions(id, data, _, hideWidthHeight, disableSelfPoin
 end
 
 function WeakAuras.GlowOptions(id, data, order)
+  local hiddenGlowExtra = function()
+    return WeakAuras.IsCollapsed("glow", "glow", "glowflags", true);
+  end
+
   local glowOptions = {
-    __title = WeakAuras.newFeatureString .. L["Glow Settings"],
-    __order = order,
+    glowHeader = {
+      type = "header",
+      order = order,
+      name = L["Glow Settings"]
+    },
     glow = {
       type = "toggle",
       width = WeakAuras.normalWidth,
@@ -3659,102 +3666,120 @@ function WeakAuras.GlowOptions(id, data, order)
     },
     glowType = {
       type = "select",
-      width = WeakAuras.normalWidth,
+      width = WeakAuras.normalWidth - 0.25,
       name = L["Type"],
       order = order + 0.03,
       values = WeakAuras.glow_types,
+    },
+    glowExpand = {
+      type = "execute",
+      name = "",
+      order = order + 1,
+      width = 0.2,
+      image = function()
+        local collapsed = WeakAuras.IsCollapsed("glow", "glow", "glowflags", true);
+        return collapsed and "Interface\\AddOns\\WeakAuras\\Media\\Textures\\edit" or "Interface\\AddOns\\WeakAuras\\Media\\Textures\\editdown"
+      end,
+      imageWidth = 24,
+      imageHeight = 24,
+      func = function()
+        local collapsed = WeakAuras.IsCollapsed("glow", "glow", "glowflags", true);
+        WeakAuras.SetCollapsed("glow", "glow", "glowflags", not collapsed);
+      end
     },
     useGlowColor = {
       type = "toggle",
       width = WeakAuras.normalWidth,
       name = L["Color"],
       desc = L["If unchecked, then a default color will be used (usually yellow)"],
-      order = order + 0.04,
+      order = order + 1.04,
+      hidden = hiddenGlowExtra
     },
     glowColor = {
       type = "color",
       width = WeakAuras.normalWidth,
       name = L["Color"],
-      order = order + 0.05,
+      order = order + 1.05,
       disabled = function() return not data.useGlowColor end,
+      hidden = hiddenGlowExtra
     },
     glowLines = {
       type = "range",
       width = WeakAuras.normalWidth,
       name = L["Lines & Particules"],
-      order = order + 0.06,
+      order = order + 1.06,
       min = 1,
       softMax = 30,
       step = 1,
-      hidden = function() return data.glowType == "buttonOverlay" end,
+      hidden = function() return hiddenGlowExtra() or data.glowType == "buttonOverlay" end,
     },
     glowFrequency = {
       type = "range",
       width = WeakAuras.normalWidth,
       name = L["Frequency"],
-      order = order + 0.07,
+      order = order + 1.07,
       softMin = -2,
       softMax = 2,
       step = 0.05,
-      hidden = function() return data.glowType == "buttonOverlay" end,
+      hidden = function() return hiddenGlowExtra() or data.glowType == "buttonOverlay" end,
     },
     glowLength = {
       type = "range",
       width = WeakAuras.normalWidth,
       name = L["Length"],
-      order = order + 0.08,
+      order = order + 1.08,
       min = 1,
       softMax = 20,
       step = 0.05,
-      hidden = function() return data.glowType ~= "Pixel" end,
+      hidden = function() return hiddenGlowExtra() or data.glowType ~= "Pixel" end,
     },
     glowThickness = {
       type = "range",
       width = WeakAuras.normalWidth,
       name = L["Thickness"],
-      order = order + 0.09,
+      order = order + 1.09,
       min = 0.05,
       softMax = 20,
       step = 0.05,
-      hidden = function() return data.glowType ~= "Pixel" end,
+      hidden = function() return hiddenGlowExtra() or data.glowType ~= "Pixel" end,
     },
     glowXOffset = {
       type = "range",
       width = WeakAuras.normalWidth,
       name = L["X-Offset"],
-      order = order + 0.10,
+      order = order + 1.10,
       softMin = -100,
       softMax = 100,
       step = 0.5,
-      hidden = function() return data.glowType == "buttonOverlay" end,
+      hidden = function() return hiddenGlowExtra() or data.glowType == "buttonOverlay" end,
     },
     glowYOffset = {
       type = "range",
       width = WeakAuras.normalWidth,
       name = L["Y-Offset"],
-      order = order + 0.11,
+      order = order + 1.11,
       softMin = -100,
       softMax = 100,
       step = 0.5,
-      hidden = function() return data.glowType == "buttonOverlay" end,
+      hidden = function() return hiddenGlowExtra() or data.glowType == "buttonOverlay" end,
     },
     glowScale = {
       type = "range",
       width = WeakAuras.normalWidth,
       name = L["Scale"],
-      order = order + 0.12,
+      order = order + 1.12,
       min = 0.05,
       softMax = 10,
       step = 0.05,
       isPercent = true,
-      hidden = function() return data.glowType ~= "ACShine" end,
+      hidden = function() return hiddenGlowExtra() or data.glowType ~= "ACShine" end,
     },
     glowBorder = {
       type = "toggle",
       width = WeakAuras.normalWidth,
       name = L["Border"],
-      order = order + 0.13,
-      hidden = function() return data.glowType ~= "Pixel" end,
+      order = order + 1.13,
+      hidden = function() return hiddenGlowExtra() or data.glowType ~= "Pixel" end,
     }
   }
 

--- a/WeakAurasOptions/WeakAurasOptions.lua
+++ b/WeakAurasOptions/WeakAurasOptions.lua
@@ -3687,7 +3687,7 @@ function WeakAuras.GlowOptions(id, data, order)
         if data.glowType == "buttonOverlay" then
           line = ("%s %s"):format(line, color)
         elseif data.glowType == "ACShine" then
-          line = L["%s %s, particules: %d, frequency: %d, scale: %d"]:format(
+          line = L["%s %s, particules: %d, frequency: %0.2f, scale: %0.2f"]:format(
             line,
             color,
             data.glowLines,
@@ -3695,10 +3695,10 @@ function WeakAuras.GlowOptions(id, data, order)
             data.glowScale
           )
           if data.glowXOffset ~= 0 or data.glowYOffset ~= 0 then
-            line = L["%s, offset: %d;%d"]:format(line, data.glowXOffset, data.glowYOffset)
+            line = L["%s, offset: %0.2f;%0.2f"]:format(line, data.glowXOffset, data.glowYOffset)
           end
         elseif data.glowType == "Pixel" then
-          line = L["%s %s, lines: %d, frequency: %d, length: %d, thickness: %d"]:format(
+          line = L["%s %s, lines: %d, frequency: %0.2f, length: %d, thickness: %d"]:format(
             line,
             color,
             data.glowLines,
@@ -3707,7 +3707,7 @@ function WeakAuras.GlowOptions(id, data, order)
             data.glowThickness
           )
           if data.glowXOffset ~= 0 or data.glowYOffset ~= 0 then
-            line = L["%s, offset: %d;%d"]:format(line, data.glowXOffset, data.glowYOffset)
+            line = L["%s, offset: %0.2f;%0.2f"]:format(line, data.glowXOffset, data.glowYOffset)
           end
           if data.glowBorder then
             line = L["%s, border"]:format(line)

--- a/WeakAurasOptions/WeakAurasOptions.lua
+++ b/WeakAurasOptions/WeakAurasOptions.lua
@@ -3687,7 +3687,7 @@ function WeakAuras.GlowOptions(id, data, order)
         if data.glowType == "buttonOverlay" then
           line = ("%s %s"):format(line, color)
         elseif data.glowType == "ACShine" then
-          line = L["%s %s, particules: %d, frequency: %0.2f, scale: %0.2f"]:format(
+          line = L["%s %s, particles: %d, frequency: %0.2f, scale: %0.2f"]:format(
             line,
             color,
             data.glowLines,


### PR DESCRIPTION
# Description
Move glow options in a collapsible group and add more options supported by libcustomglow
Fixes #1299

demo: https://i.imgur.com/Ba9lZiI.gif (border option for pixel glow is out of the screenshot window)
new conditions: https://i.imgur.com/ScQZSOz.png

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# Tests
- [x] Tested all options
- [ ] Tested all conditions => one is not working yet

# TODO:
- [ ] Condition for changing number of particules with ACShine is not working
- [ ] Update wiki


Rivers talked about using the pencil button for collapsible options, i didn't manage to use it but made it with a collapsible group, should i go back to the drawing board and get it work with pencil collapse ?
I could check how infus did it with the new text options PR.