### PR TITLE
Add a Exact Spell Id option to Spell Known triggers

### DIFF
--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -5261,11 +5261,18 @@ WeakAuras.event_prototypes = {
     force_events = "WA_SPELL_CHECK",
     name = L["Spell Known"],
     init = function(trigger)
+      local spellName = trigger.spellName or ""
+      if (trigger.use_exact_spellName) then
+        spellName = trigger.spellName;
+      else
+        local name = type(trigger.spellName) == "number" and GetSpellInfo(trigger.spellName) or trigger.spellName;
+        spellName = select(7, GetSpellInfo(name)) or ""
+      end
       local ret = [[
         local spellName = tonumber(%q);
         local usePet = %s;
       ]]
-      return ret:format(trigger.spellName or "", trigger.use_petspell and "true" or "false");
+      return ret:format(spellName, trigger.use_petspell and "true" or "false");
     end,
     args = {
       {
@@ -5273,7 +5280,8 @@ WeakAuras.event_prototypes = {
         required = true,
         display = L["Spell"],
         type = "spell",
-        test = "true"
+        test = "true",
+        showExactOption = true,
       },
       {
         name = "petspell",

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -1,4 +1,4 @@
-local internalVersion = 14;
+local internalVersion = 15;
 
 -- WoW APIs
 local GetTalentInfo, IsAddOnLoaded, InCombatLockdown = GetTalentInfo, IsAddOnLoaded, InCombatLockdown
@@ -2865,6 +2865,17 @@ function WeakAuras.Modernize(data)
           local idx = triggerData.trigger.debuffClass
           data.triggers[triggerId].trigger.debuffClass = { [idx] = true }
         end
+      end
+    end
+  end
+
+  -- Version 14 was introduced April 2019 in BFA
+  if data.internalVersion < 15 then
+    if data.triggers then
+      for triggerId, triggerData in ipairs(data.triggers) do
+          if triggerData.trigger.type == "status" and triggerData.trigger.event == "Spell Known" then
+            triggerData.trigger.use_exact_spellName = true
+          end
       end
     end
   end


### PR DESCRIPTION
The old code defaulted to a exact check, but sometimes a check on the
spell name is more useful.

Fixes: #1309