### PR TITLE
fix WatchUnitChange sending lowercase unit event #1313

### DIFF
--- a/WeakAuras/GenericTrigger.lua
+++ b/WeakAuras/GenericTrigger.lua
@@ -2142,6 +2142,7 @@ local watchUnitChange
 local unitChangeGUIDS
 
 function WeakAuras.WatchUnitChange(unit)
+  unit = string.upper(unit)
   if not watchUnitChange then
     watchUnitChange = CreateFrame("FRAME");
     WeakAuras.frames["Unit Change Frame"] = watchUnitChange;
@@ -2150,8 +2151,6 @@ function WeakAuras.WatchUnitChange(unit)
     watchUnitChange:RegisterEvent("UNIT_TARGET");
     watchUnitChange:RegisterEvent("INSTANCE_ENCOUNTER_ENGAGE_UNIT");
     watchUnitChange:RegisterEvent("GROUP_ROSTER_UPDATE");
-
-    unit = string.upper(unit)
 
     watchUnitChange:SetScript("OnEvent", function(self, event)
       WeakAuras.StartProfileSystem("generictrigger");


### PR DESCRIPTION
# Description

AddUnitChangeInternalEvents register event with uppercase unit
`tinsert(t, "UNIT_CHANGED_" .. string.upper(unit))`

WeakAuras.WatchUnitChange was sending events without ensuring uppercase

Fixes #1313

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
- [x] Health trigger with unit=targettarget