### PR TITLE
Eternal Palace encounter ids

### DIFF
--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -70,6 +70,15 @@ WeakAuras.encounter_table = {
   -- Crucible of Storms
   [2328] = 2269, -- The Restless Cabal
   [2332] = 2273, -- Uu'nat, Harbinger of the Void
+  -- The Eternal Palace
+  [2352] = 2298, -- Abyssal Commander Sivara
+  [2353] = 2305, -- Radiance of Ashara
+  [2347] = 2289, -- Blackwater Behemoth
+  [2354] = 2304, -- Lady Ashvane
+  [2351] = 2303, -- The Hatchery (Orgozoa)
+  [2359] = 2311, -- The Queen's Court
+  [2349] = 2293, -- Za'qul, Herald of N'zoth
+  [2361] = 2299, -- Queen Azshara
 }
 
 local function get_encounters_list()


### PR DESCRIPTION
# Description
Fixes #1326

![tooltip](https://i.imgur.com/O4ELygR.png)

Command to get journal's ids
```Lua
local function get_encounter_list()
   local encounter_list = ""
   EJ_SelectTier(EJ_GetNumTiers())
   for _,inRaid in ipairs({false, true}) do
      local instance_index = 1
      local instance_id
      local title = inRaid and "Raids" or "Dungeons"
      encounter_list = ("%s|cffffd200%s|r\n"):format(encounter_list, title)
      repeat
         instance_id, dungeon_name = EJ_GetInstanceByIndex(instance_index, inRaid)
         instance_index = instance_index + 1
         if instance_id then
            EJ_SelectInstance(instance_id)
            local encounter_index = 1
            encounter_list = ("%s|cffffd200%s|r\n"):format(encounter_list, dungeon_name)
            repeat
               local encounter_name,_, encounter_id = EJ_GetEncounterInfoByIndex(encounter_index)
               encounter_index = encounter_index + 1
               if encounter_id then
                  encounter_list = ("%s%s: %d\n"):format(encounter_list, encounter_name, encounter_id)
               end
            until not encounter_id
         end
      until not instance_id
      encounter_list = encounter_list .. "\n"
   end
   return ("%s\n%s"):format(encounter_list, "Supports multiple entries, separated by commas\n")
end

print(get_encounter_list())
```