### PR TITLE
Fix cast trigger event + force enable WeakAurasCompanion addon

### DIFF
--- a/WeakAuras/Init.lua
+++ b/WeakAuras/Init.lua
@@ -36,6 +36,9 @@ end
 WeakAuras.PowerAurasPath = "Interface\\Addons\\WeakAuras\\PowerAurasMedia\\Auras\\"
 WeakAuras.PowerAurasSoundPath = "Interface\\Addons\\WeakAuras\\PowerAurasMedia\\Sounds\\"
 
+-- force enable WeakAurasCompanion because some addon manager interfere with it
+EnableAddOn("WeakAurasCompanion")
+
 --These function stubs are defined here to reduce the number of errors that occur if WeakAuras.lua fails to compile
 function WeakAuras.RegisterRegionType()
 end

--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -4715,7 +4715,7 @@ WeakAuras.event_prototypes = {
         "UNIT_SPELLCAST_INTERRUPTED"
       };
       AddUnitChangeEvents(trigger.unit, result)
-      if trigger.target and trigger.target ~= "" then
+      if trigger.use_destUnit and trigger.destUnit and trigger.destUnit ~= "" then
         tinsert(result, "UNIT_TARGET")
       end
       return result


### PR DESCRIPTION
# Description
Fixes #1343

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Disable companion -> reload -> icons show in waoptions
New icon -> cast trigger -> unit="player", caster's target="player" -> select pnj, cast HS, select self (not working on master)