### PR TITLE
Event filtering fix for unit=pet + one new little feature

### DIFF
--- a/WeakAuras/GenericTrigger.lua
+++ b/WeakAuras/GenericTrigger.lua
@@ -1050,6 +1050,10 @@ function GenericTrigger.Add(data, region)
               internal_events = prototype.internal_events;
               force_events = prototype.force_events;
               trigger_unit_events = prototype.unit_events;
+              trigger_subevents = prototype.subevents;
+              if trigger_subevents and type(trigger_subevents) == "function" then
+                trigger_subevents = trigger_subevents(trigger, untrigger)
+              end
               if (type(trigger_all_events) == "function") then
                 trigger_all_events = trigger_all_events(trigger, untrigger);
               end

--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -1112,23 +1112,6 @@ WeakAuras.load_prototype = {
   }
 };
 
-local function AddUnitChangeEvents(unit, t)
-  if (unit == "player" or unit == "multi") then
-
-  elseif (unit == "target") then
-    if not t.events then t.events = {} end
-    tinsert(t.events, "PLAYER_TARGET_CHANGED");
-  elseif (unit == "focus") then
-    if not t.events then t.events = {} end
-    tinsert(t.events, "PLAYER_FOCUS_CHANGED");
-  elseif (unit == "pet") then
-    if not t.unit_events then t.unit_events = {} end
-    tinsert(t.unit_events, "UNIT_PET")
-  else
-    -- Handled by WatchUnitChange
-  end
-end
-
 local function AddUnitChangeInternalEvents(unit, t)
   if (unit == "player" or unit == "multi" or unit == "target" or unit == "focus" or unit == "pet") then
     -- Handled by normal events
@@ -1139,7 +1122,7 @@ local function AddUnitChangeInternalEvents(unit, t)
 end
 
 local function AddUnitEventForEvents(result, unit, event)
-  if not WeakAuras.baseUnitId[unit] then
+  if not unit or not WeakAuras.baseUnitId[unit] then
     if not result.events then
       result.events = {}
     end
@@ -1152,6 +1135,20 @@ local function AddUnitEventForEvents(result, unit, event)
       result.unit_events[unit] = {}
     end
     tinsert(result.unit_events[unit], event)
+  end
+end
+
+local function AddUnitChangeEvents(unit, t)
+  if (unit == "player" or unit == "multi") then
+
+  elseif (unit == "target") then
+    AddUnitEventForEvents(t, nil, "PLAYER_TARGET_CHANGED")
+  elseif (unit == "focus") then
+    AddUnitEventForEvents(t, nil, "PLAYER_FOCUS_CHANGED")
+  elseif (unit == "pet") then
+    AddUnitEventForEvents(t, unit, "UNIT_PET")
+  else
+    -- Handled by WatchUnitChange
   end
 end
 


### PR DESCRIPTION
# Description
- fix AddUnitChangeEvents for "pet"
- support CLEU with subevent filtering by generic triggers, this is not used yet, but i use it for the cast trigger on target for classic branch 

Fixes https://www.wowace.com/projects/weakauras-2/issues/1340

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
- [ ] AddUnitChangeEvents not tested, user didn't provide his SV
- [x] CLEU subbevent for generic trigger tested on classic branch