### PR TITLE
fix nil error while inserting in prototype.subevents

### DIFF
--- a/WeakAuras/GenericTrigger.lua
+++ b/WeakAuras/GenericTrigger.lua
@@ -1050,9 +1050,11 @@ function GenericTrigger.Add(data, region)
               internal_events = prototype.internal_events;
               force_events = prototype.force_events;
               trigger_unit_events = prototype.unit_events;
-              trigger_subevents = prototype.subevents;
-              if trigger_subevents and type(trigger_subevents) == "function" then
-                trigger_subevents = trigger_subevents(trigger, untrigger)
+              if prototype.subevents then
+                trigger_subevents = prototype.subevents
+                if trigger_subevents and type(trigger_subevents) == "function" then
+                  trigger_subevents = trigger_subevents(trigger, untrigger)
+                end
               end
               if (type(trigger_all_events) == "function") then
                 trigger_all_events = trigger_all_events(trigger, untrigger);


### PR DESCRIPTION
# Description
Fixes 

```
1x WeakAuras\GenericTrigger.lua:1174: bad argument #1 to 'tinsert' (table expected, got nil)
[C]: ?
WeakAuras\GenericTrigger.lua:1174: in function `Add'
WeakAuras\WeakAuras-@project-version@.lua:3280: in function <WeakAuras\WeakAuras.lua:3260>
WeakAuras\WeakAuras.lua:3343: in function `Add'
WeakAuras\WeakAuras.lua:3030: in function `load'
WeakAuras\WeakAuras.lua:3037: in function `AddMany'
WeakAuras\WeakAuras.lua:1346: in function <WeakAuras\WeakAuras.lua:1334>
```

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)