### PR TITLE
fix DBM and BW Timers message filter

### DIFF
--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -3123,7 +3123,7 @@ WeakAuras.event_prototypes = {
                 end
               end
             end
-            local bar = WeakAuras.GetDBMTimer(triggerId, triggerTextOperator, triggerText, triggerSpellId, extendTimer, triggerDbmType, triggerCount)
+            local bar = WeakAuras.GetDBMTimer(triggerId, triggerText, triggerTextOperator, triggerSpellId, extendTimer, triggerDbmType, triggerCount)
             if bar then
               if extendTimer == 0
                 or not (state and state.show)
@@ -3359,7 +3359,7 @@ WeakAuras.event_prototypes = {
                 end
               end
             end
-            local bar = WeakAuras.GetBigWigsTimer(triggerTextOperator, triggerText, triggerSpellId, extendTimer, triggerEmphasized, triggerCount, triggerCast)
+            local bar = WeakAuras.GetBigWigsTimer(triggerText, triggerTextOperator, triggerSpellId, extendTimer, triggerEmphasized, triggerCount, triggerCast)
             if bar then
               if extendTimer == 0
                 or not (state and state.show)


### PR DESCRIPTION
# Description
Forgot to swap text and text operator parameters in `WeakAuras.GetDBMTimer` and `WeakAuras.GetBigWigsTimer`
Fixes #1358

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
- [x] bigwigs: filter on "Angelic" + test bars on priest
- [x] dbm: filter on "Adds" + test bars