### PR TITLE
use sane values for y offset parameters

### DIFF
--- a/WeakAuras/RegionTypes/Icon.lua
+++ b/WeakAuras/RegionTypes/Icon.lua
@@ -170,9 +170,9 @@ local properties = {
     display = { WeakAuras.newFeatureString .. L["Glow"], L["Y-Offset"]},
     setter = "SetGlowYOffset",
     type = "number",
-    softMin = 1,
-    softMax = -100,
-    bigStep = 100,
+    softMin = -100,
+    softMax = 100,
+    bigStep = 1,
     default = 0
   },
   text1Color = {


### PR DESCRIPTION
# Description

Fixes #1363

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Confirmed that Glow Y offset is now a usable property change.
