### PR TITLE
Item Slot Cooldown: Use our own cooldown tracking for durationFunc

### DIFF
--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -2871,7 +2871,7 @@ WeakAuras.event_prototypes = {
       }
     },
     durationFunc = function(trigger)
-      local startTime, duration = GetInventoryItemCooldown("player", trigger.itemSlot or 0);
+      local startTime, duration = WeakAuras.GetItemSlotCooldown(trigger.itemSlot or 0);
       startTime = startTime or 0;
       duration = duration or 0;
       return duration, startTime + duration;


### PR DESCRIPTION
I can't reproduce the problem described in the Ticket, but the code
appeared to have a small race, since we only recheck the conditions at
the event.

Fixes: #1365

