### PR TITLE
WeakAuras.CountWagoUpdates: don't count skipped versions

### DIFF
--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -1211,7 +1211,11 @@ function WeakAuras.CountWagoUpdates()
       end
       if slug and version then
         local wago = WeakAurasCompanion.slugs[slug]
-        if wago and wago.wagoVersion and tonumber(wago.wagoVersion) > tonumber(version) then
+        if wago and wago.wagoVersion
+        and tonumber(wago.wagoVersion) > (
+          aura.skipWagoUpdate and tonumber(aura.skipWagoUpdate) or tonumber(version)
+        )
+        then
           if not updatedSlugs[slug] then
             updatedSlugs[slug] = true
             updatedSlugsCount = updatedSlugsCount + 1


### PR DESCRIPTION
# Description
Fix Companion nag & minimap icon update counter wrongly includes auras with "Skip this version" enable

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)