### PR TITLE
Action Usable trigger: Fix nil comparison error with spellCount

### DIFF
--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -3702,7 +3702,7 @@ WeakAuras.event_prototypes = {
       local charges, maxCharges, spellCount = WeakAuras.GetSpellCharges(trigger.realSpellName);
       if maxCharges and maxCharges > 1 then
         return charges
-      elseif spellCount > 0 then
+      elseif spellCount and spellCount > 0 then
         return spellCount
       end
     end,


### PR DESCRIPTION
# Description
Fixes 
```
52x WeakAuras\Prototypes.lua:3705: attempt to compare number with nil
[C]: in function `xpcall'
WeakAuras\GenericTrigger.lua:371: in function <WeakAuras\GenericTrigger.lua:367>
WeakAuras\GenericTrigger.lua:489: in function `ActivateEvent'
WeakAuras\GenericTrigger.lua:547: in function <WeakAuras\GenericTrigger.lua:519>
WeakAuras\GenericTrigger.lua:672: in function `ScanEventsInternal'
WeakAuras\GenericTrigger.lua:632: in function `ScanEvents'
WeakAuras\GenericTrigger.lua:721: in function <WeakAuras\GenericTrigger.lua:712
```

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)