### PR TITLE
Use a simple Show/Hide for the ItemRefTooltip

### DIFF
--- a/WeakAuras/Transmission.lua
+++ b/WeakAuras/Transmission.lua
@@ -333,7 +333,7 @@ local function importPendingData()
   local indexMap = pendingData.indexMap
 
   -- cleanup the mess
-  ItemRefTooltip:Hide()-- this also wipes pendingData as a side effect (not sure if still true)
+  ItemRefTooltip:Hide()-- this also wipes pendingData via the hook on L521
   buttonAnchor:Hide()
   thumbnailAnchor.currentThumbnail:Hide()
   thumbnailAnchor.currentThumbnail = nil

--- a/WeakAuras/Transmission.lua
+++ b/WeakAuras/Transmission.lua
@@ -333,7 +333,7 @@ local function importPendingData()
   local indexMap = pendingData.indexMap
 
   -- cleanup the mess
-  HideUIPanel(ItemRefTooltip) -- this also wipes pendingData as a side effect
+  ItemRefTooltip:Hide()-- this also wipes pendingData as a side effect (not sure if still true)
   buttonAnchor:Hide()
   thumbnailAnchor.currentThumbnail:Hide()
   thumbnailAnchor.currentThumbnail = nil
@@ -835,7 +835,7 @@ local function SetCheckButtonStates(radioButtonAnchor, activeCategories)
 end
 
 function ShowTooltip(lines, linesFromTop, activeCategories)
-  ShowUIPanel(ItemRefTooltip);
+  ItemRefTooltip:Show();
   if not ItemRefTooltip:IsVisible() then
     ItemRefTooltip:SetOwner(UIParent, "ANCHOR_PRESERVE");
   end


### PR DESCRIPTION
A recent 8.2 change forbids use of Show/HideUIPanel in combat

# Description

This is to address https://github.com/tomrus88/BlizzardInterfaceCode/commit/86da24305529deb6512ada1bdb894b606394f1ef#diff-1cd1eb166f5fb0f41a5a29500af2be34R3185

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Did a simple import from chat

# Checklist:
<!-- These can be checked off after the pull request is submitted, in case you want discussion before they’re completely ready -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

<!-- Is there any additional work that needs to be done? If so, add it to the above list -->

- [ ] Check if the comment on Hide() is still true
