### PR TITLE
add debuffClassIcon state to BuffTrigger2 fix #946

### DIFF
--- a/WeakAuras/BuffTrigger2.lua
+++ b/WeakAuras/BuffTrigger2.lua
@@ -186,12 +186,14 @@ local function UpdateMatchData(time, matchDataChanged, resetMatchDataByTrigger, 
   if not matchData[unit][filter] then
     matchData[unit][filter] = {}
   end
+  local debuffClassIcon = WeakAuras.EJIcons[debuffClass]
   if not matchData[unit][filter][index] then
     matchData[unit][filter][index] = {
       name = name,
       icon = icon,
       stacks = stacks,
       debuffClass = debuffClass,
+      debuffClassIcon = debuffClassIcon,
       duration = duration,
       expirationTime = expirationTime,
       unitCaster = unitCaster,
@@ -230,6 +232,11 @@ local function UpdateMatchData(time, matchDataChanged, resetMatchDataByTrigger, 
 
   if data.debuffClass ~= debuffClass then
     data.debuffClass = debuffClass
+    changed = true
+  end
+
+  if data.debuffClassIcon ~= debuffClassIcon then
+    data.debuffClassIcon = debuffClassIcon
     changed = true
   end
 
@@ -376,6 +383,7 @@ local function FindBestMatchDataForUnit(time, id, triggernum, triggerInfo, unit)
 end
 
 local function UpdateStateWithMatch(time, bestMatch, triggerStates, cloneId, matchCount, unitCount, maxUnitCount, matchCountPerUnit, affected, unaffected)
+  local debuffClassIcon = WeakAuras.EJIcons[bestMatch.debuffClass]
   if not triggerStates[cloneId] then
     triggerStates[cloneId] = {
       show = true,
@@ -384,6 +392,7 @@ local function UpdateStateWithMatch(time, bestMatch, triggerStates, cloneId, mat
       icon = bestMatch.icon,
       stacks = bestMatch.stacks,
       debuffClass = bestMatch.debuffClass,
+      debuffClassIcon = debuffClassIcon,
       progressType = "timed",
       duration = bestMatch.duration,
       expirationTime = bestMatch.expirationTime,
@@ -451,6 +460,11 @@ local function UpdateStateWithMatch(time, bestMatch, triggerStates, cloneId, mat
 
     if state.debuffClass ~= bestMatch.debuffClass then
       state.debuffClass = bestMatch.debuffClass
+      changed = true
+    end
+
+    if state.debuffClassIcon ~= debuffClassIcon then
+      state.debuffClassIcon = debuffClassIcon
       changed = true
     end
 
@@ -2269,6 +2283,8 @@ function BuffTrigger.GetAdditionalProperties(data, triggernum)
 
   local ret = "\n\n" .. L["Additional Trigger Replacements"] .. "\n"
   ret = ret .. "|cFFFF0000%spellId|r - " .. L["Spell ID"] .. "\n"
+  ret = ret .. "|cFFFF0000%debuffClass|r - " .. L["Debuff Class"] .. "\n"
+  ret = ret .. "|cFFFF0000%debuffClassIcon|r - " .. L["Debuff Class Icon"] .. "\n"
   ret = ret .. "|cFFFF0000%unitCaster|r - " .. L["Caster Unit"] .. "\n"
   ret = ret .. "|cFFFF0000%casterName|r - " .. L["Caster Name"] .. "\n"
   ret = ret .. "|cFFFF0000%unitName|r - " .. L["Unit Name"] .. "\n"
@@ -2749,6 +2765,12 @@ local function AugmentMatchDataMultiWith(matchData, unit, name, icon, stacks, de
 
   if matchData.debuffClass ~= debuffClass then
     matchData.debuffClass = debuffClass
+    changed = true
+  end
+
+  local debuffClassIcon = WeakAuras.EJIcons[debuffClass]
+  if matchData.debuffClassIcon ~= debuffClassIcon then
+    matchData.debuffClassIcon = debuffClassIcon
     changed = true
   end
 

--- a/WeakAuras/Types.lua
+++ b/WeakAuras/Types.lua
@@ -2026,3 +2026,18 @@ WeakAuras.dbm_types = {
   [6] = L["Phase"],
   [7] = L["Important"]
 }
+
+WeakAuras.EJIcons = {
+  tank =      "|TInterface\\EncounterJournal\\UI-EJ-Icons:::::256:64:7:25:7:25|t",
+  dps =       "|TInterface\\EncounterJournal\\UI-EJ-Icons:::::256:64:39:57:7:25|t",
+  healer =    "|TInterface\\EncounterJournal\\UI-EJ-Icons:::::256:64:71:89:7:25|t",
+  mythic =    "|TInterface\\EncounterJournal\\UI-EJ-Icons:::::256:64:103:121:7:25|t",
+  deadly =    "|TInterface\\EncounterJournal\\UI-EJ-Icons:::::256:64:135:153:7:25|t",
+  important = "|TInterface\\EncounterJournal\\UI-EJ-Icons:::::256:64:167:185:7:25|t",
+  interrupt = "|TInterface\\EncounterJournal\\UI-EJ-Icons:::::256:64:199:217:7:25|t",
+  magic =     "|TInterface\\EncounterJournal\\UI-EJ-Icons:::::256:64:231:249:7:25|t",
+  curse =     "|TInterface\\EncounterJournal\\UI-EJ-Icons:::::256:64:7:25:39:57|t",
+  poison =    "|TInterface\\EncounterJournal\\UI-EJ-Icons:::::256:64:39:57:39:57|t",
+  disease =   "|TInterface\\EncounterJournal\\UI-EJ-Icons:::::256:64:71:89:39:57|t",
+  enrage =    "|TInterface\\EncounterJournal\\UI-EJ-Icons:::::256:64:103:121:39:57|t",
+}

--- a/WeakAurasTemplates/TriggerTemplatesData.lua
+++ b/WeakAurasTemplates/TriggerTemplatesData.lua
@@ -628,6 +628,7 @@ templates.class.PALADIN = {
         { spell = 1044, type = "buff", unit = "group"}, -- Blessing of Freedom
         { spell = 209785, type = "buff", unit = "player", talent = 4}, -- Fires of Justice
         { spell = 223819, type = "buff", unit = "player", talent = 19}, -- Divine Purpose
+        { spell = 183436, type = "buff", unit = "player"}, -- Retribution
       },
       icon = 135993
     },


### PR DESCRIPTION
# Description
Add debuffClassIcon state to BuffTrigger2 
Fixes #946

this allow to do this with just typing %debuffClassIcon
![img](https://camo.githubusercontent.com/70f6772ddb5cdc104ed6e2924ca5ad958568af08/68747470733a2f2f6779617a6f2e636f6d2f36643530336363613166336461366462633934633632663465653034643731622e706e67)

## Type of change
- [x] New feature (non-breaking change which adds functionality)