### PR TITLE
Templates update

### DIFF
--- a/WeakAurasTemplates/TriggerTemplates.lua
+++ b/WeakAurasTemplates/TriggerTemplates.lua
@@ -1322,7 +1322,7 @@ function WeakAuras.CreateTemplateView(frame)
     group:SetFullWidth(true);
     local subTypes = subTypesFor(item, newView.data.regionType);
     local subTypesButtons = {}
-    local firstButton = true;
+    local lastButton
     for k, subType in pairs(subTypes) do
       local button = AceGUI:Create("WeakAurasNewButton");
       subTypesButtons[k] = button;
@@ -1365,10 +1365,13 @@ function WeakAuras.CreateTemplateView(frame)
           WeakAuras.NewAura(newView.data, newView.data.regionType, newView.targetId);
         end
       end);
-      if newView.batchStep and firstButton then
+      if newView.batchStep then
         button.frame:LockHighlight();
         newView.choosenItemBatchSubType[item] = subType;
-        firstButton = false;
+        if lastButton then
+          lastButton.frame:UnlockHighlight();
+        end
+        lastButton = button
       end
       group:AddChild(button);
     end

--- a/WeakAurasTemplates/TriggerTemplatesData.lua
+++ b/WeakAurasTemplates/TriggerTemplatesData.lua
@@ -1101,14 +1101,20 @@ templates.class.ROGUE = {
       title = L["Abilities"],
       args = {
         { spell = 408, type = "ability", requiresTarget = true, usable = true, debuff = true}, -- Kidney Shot
-        { spell = 703, type = "ability", requiresTarget = true}, -- Garrote
+        { spell = 703, type = "ability", requiresTarget = true, debuff = true}, -- Garrote
         { spell = 1725, type = "ability"}, -- Distract
+        { spell = 1752, type = "ability", requiresTarget = true}, -- Sinister Strike / Mutilate
         { spell = 1766, type = "ability", requiresTarget = true}, -- Kick
         { spell = 1784, type = "ability", buff = true}, -- Stealth
+        { spell = 1833, type = "ability", usable = true, requiresTarget = true, debuff = true}, -- Cheap Shot
         { spell = 1856, type = "ability", buff = true}, -- Vanish
+        { spell = 1943, type = "ability", requiresTarget = true, usable = true, debuff = true}, -- Rupture
         { spell = 1966, type = "ability", buff = true}, -- Feint
         { spell = 2094, type = "ability", requiresTarget = true}, -- Blind
         { spell = 2983, type = "ability", buff = true}, -- Sprint
+        { spell = 51723, type = "ability"}, -- Fan of Knives
+        { spell = 57934, type = "ability", requiresTarget = true}, -- Tricks of the Trade
+        { spell = 6770, type = "ability", usable = true, requiresTarget = true, debuff = true}, -- Sap
         { spell = 5277, type = "ability", buff = true}, -- Evasion
         { spell = 31224, type = "ability", buff = true}, -- Cloak of Shadows
         { spell = 36554, type = "ability", requiresTarget = true}, -- Shadowstep
@@ -1117,6 +1123,7 @@ templates.class.ROGUE = {
         { spell = 115191, type = "ability", buff = true}, -- Stealth
         { spell = 137619, type = "ability", requiresTarget = true, debuff = true, talent = 9}, -- Marked for Death
         { spell = 185311, type = "ability", buff = true}, -- Crimson Vial
+        { spell = 196819, type = "ability", requiresTarget = true, usable = true, debuff = true}, -- Envenom
         { spell = 200806, type = "ability", requiresTarget = true, usable = true, talent = 18}, -- Exsanguinate
         { spell = 245388, type = "ability", requiresTarget = true, talent = 17}, -- Toxic Blade
         { spell = 57934, type = "ability", requiresTarget = true, debuff = true}, -- Tricks of the Trade
@@ -1198,21 +1205,27 @@ templates.class.ROGUE = {
       title = L["Abilities"],
       args = {
         { spell = 1725, type = "ability"}, -- Distract
+        { spell = 1752, type = "ability", requiresTarget = true}, -- Sinister Strike
         { spell = 1766, type = "ability", requiresTarget = true}, -- Kick
         { spell = 1776, type = "ability", requiresTarget = true, debuff = true}, -- Gouge
         { spell = 1784, type = "ability", buff = true}, -- Stealth
         { spell = 1856, type = "ability", buff = true}, -- Vanish
         { spell = 1966, type = "ability", buff = true}, -- Feint
         { spell = 2094, type = "ability", requiresTarget = true, debuff = true}, -- Blind
+        { spell = 2098, type = "ability", requiresTarget = true, usable = true}, -- Dispatch
         { spell = 2983, type = "ability", buff = true }, -- Sprint
+        { spell = 8676, type = "ability", requiresTarget = true, usable = true}, -- Shroud of Concealment
         { spell = 13750, type = "ability", buff = true}, -- Adrenaline Rush
         { spell = 13877, type = "ability", buff = true, charges = true}, -- Blade Flurry
         { spell = 31224, type = "ability", buff = true}, -- Cloak of Shadows
         { spell = 51690, type = "ability", requiresTarget = true, talent = 21}, -- Killing Spree
+        { spell = 57934, type = "ability", requiresTarget = true}, -- Tricks of the Trade
         { spell = 79096, type = "ability"}, -- Restless Blades
         { spell = 114018, type = "ability", usable = true, buff = true}, -- Shroud of Concealment
         { spell = 137619, type = "ability", requiresTarget = true, debuff = true, talent = 9}, -- Marked for Death
         { spell = 185311, type = "ability", buff = true}, -- Crimson Vial
+        { spell = 185763, type = "ability", requiresTarget = true}, -- Pistol Shot
+        { spell = 193316, type = "ability", requiresTarget = true, usable = true}, -- Roll the Bones
         { spell = 195457, type = "ability", requiresTarget = true}, -- Grappling Hook
         { spell = 196937, type = "ability", requiresTarget = true, debuff = true, talent = 3}, -- Ghostly Strike
         { spell = 199754, type = "ability", buff = true}, -- Riposte
@@ -1295,23 +1308,33 @@ templates.class.ROGUE = {
     [3] = {
       title = L["Abilities"],
       args = {
+        { spell = 53, type = "ability", requiresTarget = true}, -- Backstab
         { spell = 408, type = "ability", requiresTarget = true, usable = true, debuff = true}, -- Kidney Shot
         { spell = 1725, type = "ability"}, -- Distract
+        { spell = 1752, type = "ability", requiresTarget = true}, -- Sinister Strike
         { spell = 1766, type = "ability", requiresTarget = true}, -- Kick
         { spell = 1784, type = "ability", buff = true}, -- Stealth
+        { spell = 1833, type = "ability", usable = true, requiresTarget = true, debuff = true}, -- Cheap Shot
         { spell = 1856, type = "ability", buff = true}, -- Vanish
         { spell = 1966, type = "ability", buff = true}, -- Feint
         { spell = 2094, type = "ability", requiresTarget = true, debuff = true}, -- Blind
         { spell = 2983, type = "ability", buff = true}, -- Sprint
         { spell = 5277, type = "ability", buff = true}, -- Evasion
+        { spell = 57934, type = "ability", requiresTarget = true}, -- Tricks of the Trade
+        { spell = 6770, type = "ability", requiresTarget = true, usable = true, debuff = true}, -- Sap
         { spell = 31224, type = "ability", buff = true}, -- Cloak of Shadows
         { spell = 36554, type = "ability", charges = true, requiresTarget = true}, -- Shadowstep
+        { spell = 114014, type = "ability", requiresTarget = true}, -- Shuriken Toss
         { spell = 114018, type = "ability", usable = true, buff = true}, -- Shroud of Concealment
         { spell = 115191, type = "ability", buff = true}, -- Stealth
         { spell = 121471, type = "ability", buff = true}, -- Shadow Blades
         { spell = 137619, type = "ability", requiresTarget = true, debuff = true, talent = 9}, -- Marked for Death
         { spell = 185311, type = "ability", buff = true}, -- Crimson Vial
         { spell = 185313, type = "ability", charges = true, buff = true}, -- Shadow Dance
+        { spell = 185438, type = "ability", requiresTarget = true, usable = true}, -- Kidney Shot
+        { spell = 195452, type = "ability", usable = true, requiresTarget = true, debuff = true}, -- Nightblade
+        { spell = 196819, type = "ability", usable = true, requiresTarget = true}, -- Eviscerate
+        { spell = 197835, type = "ability"}, -- Shuriken Storm
         { spell = 212283, type = "ability", buff = true}, -- Symbols of Death
         { spell = 277925, type = "ability", buff = true, talent = 21}, -- Shuriken Tornado
         { spell = 280719, type = "ability", requiresTarget = true, usable = true, debuff = true, talent = 20}, -- Secret Technique

--- a/WeakAurasTemplates/TriggerTemplatesData.lua
+++ b/WeakAurasTemplates/TriggerTemplatesData.lua
@@ -2276,9 +2276,13 @@ templates.class.WARLOCK = {
     [3] = {
       title = L["Abilities"],
       args = {
+        { spell = 172, type = "ability", requiresTarget = true, debuff = true}, -- Corruption
         { spell = 698, type = "ability"}, -- Ritual of Summoning
+        { spell = 710, type = "ability", requiresTarget = true, debuff = true}, -- Banish
+        { spell = 980, type = "ability", requiresTarget = true, debuff = true}, -- Agony
         { spell = 3110, type = "ability", requiresTarget = true}, -- Firebolt
         { spell = 3716, type = "ability", requiresTarget = true}, -- Consuming Shadows
+        { spell = 5782, type = "ability", requiresTarget = true, debuff = true}, -- Fear
         { spell = 6358, type = "ability", requiresTarget = true}, -- Seduction
         { spell = 6360, type = "ability", requiresTarget = true}, -- Whiplash
         { spell = 6789, type = "ability", requiresTarget = true, talent = 15 }, -- Mortal Coil
@@ -2289,12 +2293,15 @@ templates.class.WARLOCK = {
         { spell = 19505, type = "ability", requiresTarget = true}, -- Devour Magic
         { spell = 19647, type = "ability", requiresTarget = true}, -- Spell Lock
         { spell = 20707, type = "ability"}, -- Soulstone
+        { spell = 27243, type = "ability", requiresTarget = true}, -- Seed of Corruption
         { spell = 29893, type = "ability"}, -- Create Soulwell
+        { spell = 30108, type = "ability", requiresTarget = true}, -- Unstable Affliction
         { spell = 30283, type = "ability"}, -- Shadowfury
         { spell = 48018, type = "ability", talent = 15 }, -- Demonic Circle
         { spell = 48020, type = "ability", talent = 15 }, -- Demonic Circle: Teleport
         { spell = 48181, type = "ability", requiresTarget = true, debuff = true, talent = 17 }, -- Haunt
         { spell = 54049, type = "ability", requiresTarget = true}, -- Shadow Bite
+        { spell = 63106, type = "ability", requiresTarget = true, debuff = true, talent = 6}, -- Siphon Life
         { spell = 89792, type = "ability" }, -- Flee
         { spell = 89808, type = "ability"}, -- Singe Magic
         { spell = 104773, type = "ability", buff = true}, -- Unending Resolve
@@ -2307,6 +2314,7 @@ templates.class.WARLOCK = {
         { spell = 205179, type = "ability", requiresTarget = true, debuff = true, talent = 11 }, -- Phantom Singularity
         { spell = 205180, type = "ability", totem = true}, -- Summon Darkglare
         { spell = 232670, type = "ability", requiresTarget = true, overlayGlow = true}, -- Shadow Bolt
+        { spell = 234153, type = "ability", requiresTarget = true}, -- Drain Life
         { spell = 264106, type = "ability", requiresTarget = true, talent = 3 }, -- Deathbolt
         { spell = 264993, type = "ability"}, -- Shadow Shield
         { spell = 278350, type = "ability", requiresTarget = true, talent = 12 }, -- Vile Taint
@@ -2386,8 +2394,11 @@ templates.class.WARLOCK = {
     [3] = {
       title = L["Abilities"],
       args = {
+        { spell = 686, type = "ability", requiresTarget = true}, -- Shadow Bolt
         { spell = 698, type = "ability"}, -- Ritual of Summoning
+        { spell = 710, type = "ability", requiresTarget = true, debuff = true}, -- Banish
         { spell = 3716, type = "ability", requiresTarget = true}, -- Consuming Shadows
+        { spell = 5782, type = "ability", requiresTarget = true, debuff = true}, -- Fear
         { spell = 6360, type = "ability", requiresTarget = true}, -- Whiplash
         { spell = 6789, type = "ability", requiresTarget = true, talent = 14 }, -- Mortal Coil
         { spell = 7814, type = "ability", requiresTarget = true}, -- Lash of Pain
@@ -2410,6 +2421,7 @@ templates.class.WARLOCK = {
         { spell = 89808, type = "ability"}, -- Singe Magic
         { spell = 104316, type = "ability", requiresTarget = true, overlayGlow = true}, -- Call Dreadstalkers
         { spell = 104773, type = "ability", buff = true}, -- Unending Resolve
+        { spell = 105174, type = "ability", requiresTarget = true}, -- Hand of Gul'dan
         { spell = 108416, type = "ability", buff = true, talent = 9 }, -- Dark Pact
         { spell = 111771, type = "ability"}, -- Demonic Gateway
         { spell = 111898, type = "ability", requiresTarget = true, talent = 18 }, -- Grimoire: Felguard
@@ -2420,6 +2432,7 @@ templates.class.WARLOCK = {
         { spell = 264178, type = "ability", requiresTarget = true, overlayGlow = true}, -- Demonbolt
         { spell = 264993, type = "ability"}, -- Shadow Shield
         { spell = 265187, type = "ability"}, -- Summon Demonic Tyrant
+        { spell = 265412, type = "ability", requiresTarget = true, debuff = true, talent = 6}, -- Doom
         { spell = 267171, type = "ability", requiresTarget = true, talent = 2 }, -- Demonic Strength
         { spell = 267211, type = "ability", talent = 3 }, -- Bilescourge Bombers
         { spell = 267217, type = "ability", buff = true, talent = 21 }, -- Nether Portal
@@ -2503,10 +2516,14 @@ templates.class.WARLOCK = {
     [3] = {
       title = L["Abilities"],
       args = {
+        { spell = 348, type = "ability", requiresTarget = true, debuff = true}, -- Immolate
         { spell = 698, type = "ability"}, -- Ritual of Summoning
+        { spell = 710, type = "ability", requiresTarget = true, debuff = true}, -- Banish
         { spell = 1122, type = "ability", duration = 30}, -- Summon Infernal
         { spell = 3110, type = "ability", requiresTarget = true}, -- Firebolt
         { spell = 3716, type = "ability", requiresTarget = true}, -- Consuming Shadows
+        { spell = 5740, type = "ability"}, -- Rain of Fire
+        { spell = 5782, type = "ability", requiresTarget = true, debuff = true}, -- Fear
         { spell = 6353, type = "ability", talent = 3 }, -- Soul Fire
         { spell = 6360, type = "ability", requiresTarget = true}, -- Whiplash
         { spell = 6789, type = "ability", requiresTarget = true, talent = 14 }, -- Mortal Coil
@@ -2518,6 +2535,7 @@ templates.class.WARLOCK = {
         { spell = 17962, type = "ability", requiresTarget = true, charges = true}, -- Conflagrate
         { spell = 19647, type = "ability", requiresTarget = true}, -- Spell Lock
         { spell = 20707, type = "ability"}, -- Soulstone
+        { spell = 29722, type = "ability", requiresTarget = true}, -- Incinerate
         { spell = 29893, type = "ability"}, -- Create Soulwell
         { spell = 30283, type = "ability"}, -- Shadowfury
         { spell = 48018, type = "ability", talent = 15 }, -- Demonic Circle
@@ -2533,7 +2551,9 @@ templates.class.WARLOCK = {
         { spell = 112042, type = "ability"}, -- Threatening Presence
         { spell = 113858, type = "ability", buff = true, talent = 21 }, -- Dark Soul: Instability
         { spell = 152108, type = "ability", talent = 12 }, -- Cataclysm
+        { spell = 116858, type = "ability", requiresTarget = true}, -- Chaos Bolt
         { spell = 196447, type = "ability", usable = true, talent = 20 }, -- Channel Demonfire
+        { spell = 234153, type = "ability", requiresTarget = true}, -- Drain Life
         { spell = 264993, type = "ability"}, -- Shadow Shield
         { spell = 6358, type = "ability", requiresTarget = true}, -- Seduction
       },


### PR DESCRIPTION
# Description
- When creating multiple auras at once, pre-select the last template option for each aura instead of the first : https://i.imgur.com/eue62Gn.jpg

- Added a few spells for all specs of warlock and rogue


Fixes https://www.wowace.com/projects/weakauras-2/issues/1348


PS: maybe don't merge it yet, Infus expressed concerned about adding resource builder/spender spell without cooldown in templates, also this doesn't add these spells for all classes, so it can be considered has a work in progress for the new spells part of this PR