### PR TITLE
wrap PlaySound and friends in pcall

### DIFF
--- a/WeakAuras/RegionTypes/RegionPrototype.lua
+++ b/WeakAuras/RegionTypes/RegionPrototype.lua
@@ -156,17 +156,23 @@ local function SoundPlayHelper(self)
 
   if (options.sound == " custom") then
     if (options.sound_path) then
-      local _, handle = PlaySoundFile(options.sound_path, options.sound_channel or "Master");
-      self.soundHandle = handle;
+      local ok, _, handle = pcall(PlaySoundFile, options.sound_path, options.sound_channel or "Master");
+      if ok then
+        self.soundHandle = handle;
+      end
     end
   elseif (options.sound == " KitID") then
     if (options.sound_kit_id) then
-      local _, handle = PlaySound(options.sound_kit_id, options.sound_channel or "Master");
-      self.soundHandle = handle;
+      local ok, _, handle = pcall(PlaySound,options.sound_kit_id, options.sound_channel or "Master");
+      if ok then
+        self.soundHandle = handle;
+      end
     end
   else
-    local _, handle = PlaySoundFile(options.sound, options.sound_channel or "Master");
-    self.soundHandle = handle;
+    local ok, _, handle = pcall(PlaySoundFile, options.sound, options.sound_channel or "Master");
+    if ok then
+      self.soundHandle = handle;
+    end
   end
   WeakAuras.StopProfileSystem("sound");
 end

--- a/WeakAurasOptions/ActionOptions.lua
+++ b/WeakAurasOptions/ActionOptions.lua
@@ -45,9 +45,9 @@ function WeakAuras.AddActionOption(id, data)
         data.actions[field][value] = v;
       end
       if(value == "sound" or value == "sound_path") then
-        PlaySoundFile(v, "Master");
+        pcall(PlaySoundFile, v, "Master");
       elseif(value == "sound_kit_id") then
-        PlaySound(v, "Master");
+        pcall(PlaySound, v, "Master");
       end
       WeakAuras.Add(data);
     end,

--- a/WeakAurasOptions/ConditionOptions.lua
+++ b/WeakAurasOptions/ConditionOptions.lua
@@ -204,9 +204,9 @@ local function wrapWithPlaySound(func, kit)
   return function(info, v)
     func(info, v);
     if (tonumber(v)) then
-      PlaySound(tonumber(v), "Master");
+      pcall(PlaySound, tonumber(v), "Master");
     else
-      PlaySoundFile(v, "Master");
+      pcall(PlaySoundFile, v, "Master");
     end
   end
 end


### PR DESCRIPTION
# Description

We can't know if a given sound path is actually valid and PlaySound complains now if the sound path isn't valid. So just trap all the errors that would be generated.
Fixes #1421

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

didn't
