### PR TITLE
Custom Anchor - Dynamic Group "Group by Frame" - Border Settings - Groups thumbnails

### DIFF
--- a/.pkgmeta
+++ b/.pkgmeta
@@ -18,6 +18,7 @@ externals:
  WeakAuras/Libs/LibRangeCheck-2.0: https://repos.wowace.com/wow/librangecheck-2-0/trunk/LibRangeCheck-2.0
  WeakAuras/Libs/LibCustomGlow-1.0: https://repos.curseforge.com/wow/libcustomglow
  WeakAuras/Libs/LibDBIcon-1.0: https://repos.wowace.com/wow/libdbicon-1-0/trunk/LibDBIcon-1.0
+ WeakAuras/Libs/LibGetFrame-1.0: https://github.com/mrbuds/LibGetFrame
 
 enable-nolib-creation: no
 

--- a/WeakAuras/AuraEnvironment.lua
+++ b/WeakAuras/AuraEnvironment.lua
@@ -59,6 +59,9 @@ local LCG = LibStub("LibCustomGlow-1.0")
 WeakAuras.ShowOverlayGlow = LCG.ButtonGlow_Start
 WeakAuras.HideOverlayGlow = LCG.ButtonGlow_Stop
 
+local LGF = LibStub("LibGetFrame-1.0")
+WeakAuras.GetUnitFrame = LGF.GetUnitFrame
+
 local function forbidden()
   prettyPrint(L["A WeakAura just tried to use a forbidden function but has been blocked from doing so. Please check your auras!"])
 end

--- a/WeakAuras/RegionTypes/Group.lua
+++ b/WeakAuras/RegionTypes/Group.lua
@@ -2,21 +2,21 @@ local SharedMedia = LibStub("LibSharedMedia-3.0");
 
 -- Default settings
 local default = {
-  controlledChildren     = {},
-  anchorPoint         = "CENTER",
-  anchorFrameType     = "SCREEN",
-  xOffset             = 0,
-  yOffset             = 0,
-  frameStrata         = 1,
-  border                = false,
-  borderColor         = {1.0, 1.0, 1.0, 0.5},
-  backdropColor        = {1.0, 1.0, 1.0, 0.5},
-  borderEdge            = "None",
-  borderOffset         = 5,
-  borderInset            = 11,
-  borderSize            = 16,
-  borderBackdrop        = "Blizzard Tooltip",
-  scale                 = 1,
+  controlledChildren = {},
+  anchorPoint = "CENTER",
+  anchorFrameType = "SCREEN",
+  xOffset = 0,
+  yOffset = 0,
+  frameStrata = 1,
+  border = false,
+  borderColor = { 0, 0, 0, 1 },
+  backdropColor = { 1, 1, 1, 0.5 },
+  borderEdge = "1 Pixel",
+  borderOffset = 4,
+  borderInset = 1,
+  borderSize = 2,
+  borderBackdrop = "Blizzard Tooltip",
+  scale = 1,
 };
 
 -- Called when first creating a new region/display
@@ -85,6 +85,7 @@ local function modify(parent, region, data)
 
   -- Get overall bounding box
   local leftest, rightest, lowest, highest = 0, 0, 0, 0;
+  local minLevel
   for index, childId in ipairs(data.controlledChildren) do
     local childData = WeakAuras.GetData(childId);
     local childRegion = WeakAuras.GetRegion(childId)
@@ -94,6 +95,10 @@ local function modify(parent, region, data)
       rightest = math.max(rightest, trx);
       lowest = math.min(lowest, bly);
       highest = math.max(highest, try);
+      local frameLevel = childRegion and childRegion:GetFrameLevel()
+      if frameLevel then
+        minLevel = minLevel and math.min(minLevel, frameLevel) or frameLevel
+      end
     end
   end
   region.blx = leftest;
@@ -142,7 +147,9 @@ local function modify(parent, region, data)
         border:ClearAllPoints();
         border:SetPoint("bottomleft", region, "bottomleft", leftest-data.borderOffset, lowest-data.borderOffset);
         border:SetPoint("topright",   region, "topright",   rightest+data.borderOffset, highest+data.borderOffset);
-
+        if minLevel then
+          border:SetFrameLevel(minLevel - 1)
+        end
         border:Show();
       else
         border:Hide();

--- a/WeakAuras/RegionTypes/RegionPrototype.lua
+++ b/WeakAuras/RegionTypes/RegionPrototype.lua
@@ -412,6 +412,13 @@ function WeakAuras.regionPrototype.modify(parent, region, data)
 
   region:SetOffset(data.xOffset or 0, data.yOffset or 0);
   region:SetOffsetAnim(0, 0);
+
+  if data.anchorFrameType == "CUSTOM" and data.customAnchor then
+    region.customAnchorFunc = WeakAuras.LoadFunction("return " .. data.customAnchor, data.id, "custom anchor")
+  else
+    region.customAnchorFunc = nil
+  end
+
   if not parent or parent.regionType ~= "dynamicgroup" then
     WeakAuras.AnchorFrame(data, region, parent);
   end
@@ -689,7 +696,7 @@ function WeakAuras.regionPrototype.AddExpandFunction(data, region, cloneId, pare
       end
       region.toShow = true;
 
-      if (data.anchorFrameType == "SELECTFRAME") then
+      if (data.anchorFrameType == "SELECTFRAME" or data.anchorFrameType == "CUSTOM") then
         WeakAuras.AnchorFrame(data, region, parent);
       end
 

--- a/WeakAuras/Transmission.lua
+++ b/WeakAuras/Transmission.lua
@@ -1642,11 +1642,15 @@ function WeakAuras.ShowDisplayTooltip(data, children, matchInfo, icon, icons, im
   if not IsAddOnLoaded('WeakAurasOptions') then
     LoadAddOn('WeakAurasOptions')
   end
-
-  local ok,thumbnail = pcall(regionOptions[regionType].createThumbnail, thumbnailAnchor, regionTypes[regionType].create);
+  if thumbnailAnchor.currentThumbnail then
+    thumbnailAnchor.currentThumbnail:Hide()
+    thumbnailAnchor.currentThumbnail = nil
+  end
+  local ok,thumbnail = pcall(regionOptions[regionType].createThumbnail, thumbnailAnchor);
   if not ok then
     error("Error creating thumbnail", 2)
   end
+  pcall(regionOptions[regionType].modifyThumbnail, thumbnailAnchor, thumbnail, data)
   thumbnailAnchor.currentThumbnail = thumbnail
   thumbnail:SetAllPoints(thumbnailAnchor);
   if (thumbnail.SetIcon) then
@@ -1658,6 +1662,8 @@ function WeakAuras.ShowDisplayTooltip(data, children, matchInfo, icon, icons, im
     end
     if (i) then
       thumbnail:SetIcon(i);
+    else
+      thumbnail:SetIcon();
     end
   end
   WeakAuras.GetData = RegularGetData or WeakAuras.GetData

--- a/WeakAuras/Types.lua
+++ b/WeakAuras/Types.lua
@@ -321,7 +321,18 @@ WeakAuras.anchor_frame_types = {
   SCREEN = L["Screen/Parent Group"],
   PRD = L["Personal Resource Display"],
   MOUSE = L["Mouse Cursor"],
-  SELECTFRAME = L["Select Frame"]
+  SELECTFRAME = L["Select Frame"],
+  CUSTOM = WeakAuras.newFeatureString..L["Custom"]
+}
+
+WeakAuras.anchor_frame_types_dynamicgroup = {
+  SCREEN = L["Screen/Parent Group"],
+  PRD = L["Personal Resource Display"],
+  MOUSE = L["Mouse Cursor"],
+  SELECTFRAME = L["Select Frame"],
+  NAMEPLATE = WeakAuras.newFeatureString..L["Nameplates"],
+  UNITFRAME = WeakAuras.newFeatureString..L["Unit Frames"],
+  CUSTOM = WeakAuras.newFeatureString..L["Custom"]
 }
 
 WeakAuras.spark_rotation_types = {

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -1,4 +1,4 @@
-local internalVersion = 20;
+local internalVersion = 21;
 
 -- WoW APIs
 local GetTalentInfo, IsAddOnLoaded, InCombatLockdown = GetTalentInfo, IsAddOnLoaded, InCombatLockdown
@@ -3347,6 +3347,17 @@ function WeakAuras.Modernize(data)
         end
       end
 
+    end
+  end
+
+  if data.internalVersion < 21 then
+    if data.regionType == "dynamicgroup" then
+      data.border = data.background and data.background ~= "None"
+      data.borderEdge = data.border
+      data.borderBackdrop = data.background ~= "None" and data.background
+      data.borderInset = data.backgroundInset
+      data.background = nil
+      data.backgroundInset = nil
     end
   end
 

--- a/WeakAuras/WeakAuras.toc
+++ b/WeakAuras/WeakAuras.toc
@@ -20,7 +20,7 @@
 ## DefaultState: Enabled
 ## LoadOnDemand: 0
 ## SavedVariables: WeakAurasSaved
-## OptionalDeps: Ace3, LibCompress, LibSharedMedia-3.0, AceGUI-3.0-SharedMediaWidgets, Masque, GTFO, LibButtonGlow-1.0, LibSpellRange-1.0, LibRangeCheck-2.0, LibDBIcon-1.0, LibClassicDurations, LibClassicCast-1.0
+## OptionalDeps: Ace3, LibCompress, LibSharedMedia-3.0, AceGUI-3.0-SharedMediaWidgets, Masque, GTFO, LibButtonGlow-1.0, LibSpellRange-1.0, LibRangeCheck-2.0, LibDBIcon-1.0, LibClassicDurations, LibClassicCast-1.0, LibGetFrame-1.0
 
 embeds.xml
 Init.lua

--- a/WeakAuras/embeds.xml
+++ b/WeakAuras/embeds.xml
@@ -24,4 +24,5 @@
   <Include file="Libs\LibClassicDurations\LibClassicDurations.xml"/>
   <Include file="Libs\LibClassicCast\lib.xml"/>
   @end-non-retail@-->
+  <Script file="Libs\LibGetFrame-1.0\LibGetFrame-1.0.lua"/>
 </Ui>

--- a/WeakAurasOptions/OptionsFrames/IconPicker.lua
+++ b/WeakAurasOptions/OptionsFrames/IconPicker.lua
@@ -105,7 +105,7 @@ local function ConstructIconPicker(frame)
   iconLabel:SetPoint("RIGHT", input, "LEFT", -50, 0);
 
   function group.Pick(self, texturePath)
-    if(self.data.controlledChildren) then
+    if(not self.groupIcon and self.data.controlledChildren) then
       for index, childId in pairs(self.data.controlledChildren) do
         local childData = WeakAuras.GetData(childId);
         if(childData) then
@@ -129,10 +129,11 @@ local function ConstructIconPicker(frame)
     end
   end
 
-  function group.Open(self, data, field)
+  function group.Open(self, data, field, groupIcon)
     self.data = data;
     self.field = field;
-    if(data.controlledChildren) then
+    self.groupIcon = groupIcon
+    if(not groupIcon and data.controlledChildren) then
       self.givenPath = {};
       for index, childId in pairs(data.controlledChildren) do
         local childData = WeakAuras.GetData(childId);
@@ -160,7 +161,7 @@ local function ConstructIconPicker(frame)
   end
 
   function group.CancelClose()
-    if(group.data.controlledChildren) then
+    if(not group.groupIcon and group.data.controlledChildren) then
       for index, childId in pairs(group.data.controlledChildren) do
         local childData = WeakAuras.GetData(childId);
         if(childData) then

--- a/WeakAurasOptions/RegionOptions/AuraBar.lua
+++ b/WeakAurasOptions/RegionOptions/AuraBar.lua
@@ -85,15 +85,15 @@ local function createOptions(id, data)
       hidden = function() return not WeakAuras.CanHaveTooltip(data) end,
       order = 38
     },
-    symbol_header = {
+    icon_header = {
       type = "header",
-      name = L["Symbol Settings"],
+      name = L["Icon Settings"],
       order = 38.01
     },
     icon = {
       type = "toggle",
       width = WeakAuras.normalWidth,
-      name = L["Icon"],
+      name = L["Show Icon"],
       order = 38.1,
     },
     auto = {
@@ -135,7 +135,7 @@ local function createOptions(id, data)
     icon_side = {
       type = "select",
       width = WeakAuras.normalWidth,
-      name = L["Icon"],
+      name = L["Icon Position"],
       values = WeakAuras.icon_side_types,
       hidden = function() return data.orientation:find("VERTICAL") or not data.icon end,
       order = 38.6,
@@ -143,7 +143,7 @@ local function createOptions(id, data)
     icon_side2 = {
       type = "select",
       width = WeakAuras.normalWidth,
-      name = L["Icon"],
+      name = L["Icon Position"],
       values = WeakAuras.rotated_icon_side_types,
       hidden = function() return data.orientation:find("HORIZONTAL") or not data.icon end,
       order = 38.7,
@@ -167,7 +167,7 @@ local function createOptions(id, data)
     icon_color = {
       type = "color",
       width = WeakAuras.normalWidth,
-      name = L["Icon Color"],
+      name = L["Color"],
       hasAlpha = true,
       order = 38.9,
       hidden = function() return not data.icon end,
@@ -220,7 +220,7 @@ local function createOptions(id, data)
     spark = {
       type = "toggle",
       width = WeakAuras.normalWidth,
-      name = L["Spark"],
+      name = L["Show Spark"],
       order = 43
     },
     sparkTexture = {
@@ -357,6 +357,11 @@ local function createOptions(id, data)
       order = 45.3,
       disabled = function() return not data.spark end,
       hidden = function() return not data.spark end,
+    },
+    endHeader = {
+      type = "header",
+      order = 100,
+      name = "",
     },
   };
 

--- a/WeakAurasOptions/RegionOptions/AuraBar.lua
+++ b/WeakAurasOptions/RegionOptions/AuraBar.lua
@@ -408,9 +408,12 @@ local function createOptions(id, data)
 
   end
 
+  for k, v in pairs(WeakAuras.BorderOptions(id, data, true, nil, 70)) do
+    options[k] = v
+  end
+
   return {
     aurabar = options,
-    border = WeakAuras.BorderOptions(id, data, nil, true);
     position = WeakAuras.PositionOptions(id, data),
   };
 end

--- a/WeakAurasOptions/RegionOptions/DynamicGroup.lua
+++ b/WeakAurasOptions/RegionOptions/DynamicGroup.lua
@@ -385,7 +385,12 @@ local function createOptions(id, data)
         WeakAuras.SetThumbnail(data);
         WeakAuras.ResetMoverSizer();
       end
-    }
+    },
+    endHeader = {
+      type = "header",
+      order = 100,
+      name = "",
+    },
   };
 
   WeakAuras.AddCodeOption(options, data, L["Custom Grow"], "custom_grow", 2, function() return data.grow ~= "CUSTOM" end, {"customGrow"}, nil, nil, nil, nil, nil, true)
@@ -396,7 +401,7 @@ local function createOptions(id, data)
   local disableSelfPoint = function() return data.grow ~= "CUSTOM" and data.grow ~= "GRID" and not data.useAnchorPerUnit end
   return {
     dynamicgroup = options,
-    position = WeakAuras.PositionOptions(id, data, nil, true, disableSelfPoint),
+    position = WeakAuras.PositionOptions(id, data, nil, true, disableSelfPoint, true),
     border = WeakAuras.BorderOptions(id, data, nil, nil, borderHideFunc),
   };
 end

--- a/WeakAurasOptions/RegionOptions/DynamicGroup.lua
+++ b/WeakAurasOptions/RegionOptions/DynamicGroup.lua
@@ -359,63 +359,16 @@ local function createOptions(id, data)
         WeakAuras.ResetMoverSizer();
       end
     },
-    -- border/background options
-    -- TODO: use Weakauras.BorderOptions for these instead
-    borderSpace = {
-      type = "header",
-      name = "",
-      order = 29
-    },
-    border = {
-      type = "select",
-      width = WeakAuras.normalWidth,
-      dialogControl = "LSM30_Border",
-      name = L["Border"],
-      order = 30,
-      values = AceGUIWidgetLSMlists.border
-    },
-    background = {
-      type = "select",
-      width = WeakAuras.normalWidth,
-      dialogControl = "LSM30_Background",
-      name = L["Background"],
-      order = 31,
-      values = function()
-        local list = {};
-        for i,v in pairs(AceGUIWidgetLSMlists.background) do
-          list[i] = v;
-        end
-        list["None"] = L["None"];
-
-        return list;
-      end
-    },
-    borderOffset = {
-      type = "range",
-      width = WeakAuras.normalWidth,
-      name = L["Border Offset"],
-      order = 32,
-      softMin = 0,
-      softMax = 32,
-      bigStep = 1
-    },
-    backgroundInset = {
-      type = "range",
-      width = WeakAuras.normalWidth,
-      name = L["Background Inset"],
-      order = 33,
-      softMin = 0,
-      softMax = 32,
-      bigStep = 1
-    },
   };
 
   WeakAuras.AddCodeOption(options, data, L["Custom Grow"], "custom_grow", 2, function() return data.grow ~= "CUSTOM" end, {"customGrow"}, nil, nil, nil, nil, nil, true)
   WeakAuras.AddCodeOption(options, data, L["Custom Sort"], "custom_sort", 21, function() return data.sort ~= "custom" end, {"customSort"}, nil, nil, nil, nil, nil, true)
 
+  local borderHideFunc = function() return data.anchorFrameType == "NAMEPLATE" or data.anchorFrameType == "UNITFRAME" end
   return {
     dynamicgroup = options,
     position = WeakAuras.PositionOptions(id, data, nil, true, true),
+    border = WeakAuras.BorderOptions(id, data, nil, nil, borderHideFunc),
   };
 end
 

--- a/WeakAurasOptions/RegionOptions/DynamicGroup.lua
+++ b/WeakAurasOptions/RegionOptions/DynamicGroup.lua
@@ -399,10 +399,14 @@ local function createOptions(id, data)
 
   local borderHideFunc = function() return data.useAnchorPerUnit or data.grow == "CUSTOM" end
   local disableSelfPoint = function() return data.grow ~= "CUSTOM" and data.grow ~= "GRID" and not data.useAnchorPerUnit end
+
+  for k, v in pairs(WeakAuras.BorderOptions(id, data, nil, borderHideFunc, 70)) do
+    options[k] = v
+  end
+
   return {
     dynamicgroup = options,
     position = WeakAuras.PositionOptions(id, data, nil, true, disableSelfPoint, true),
-    border = WeakAuras.BorderOptions(id, data, nil, nil, borderHideFunc),
   };
 end
 

--- a/WeakAurasOptions/RegionOptions/Group.lua
+++ b/WeakAurasOptions/RegionOptions/Group.lua
@@ -532,12 +532,17 @@ local function createOptions(id, data)
         WeakAuras.ResetMoverSizer();
       end
     },
+    endHeader = {
+      type = "header",
+      order = 100,
+      name = "",
+    },
   };
 
   return {
     group = options,
     border = WeakAuras.BorderOptions(id, data);
-    position = WeakAuras.PositionOptions(id, data, nil, true, true),
+    position = WeakAuras.PositionOptions(id, data, nil, true, true, true),
   };
 end
 

--- a/WeakAurasOptions/RegionOptions/Group.lua
+++ b/WeakAurasOptions/RegionOptions/Group.lua
@@ -539,9 +539,12 @@ local function createOptions(id, data)
     },
   };
 
+  for k, v in pairs(WeakAuras.BorderOptions(id, data, nil, nil, 70)) do
+    options[k] = v
+  end
+
   return {
     group = options,
-    border = WeakAuras.BorderOptions(id, data);
     position = WeakAuras.PositionOptions(id, data, nil, true, true, true),
   };
 end

--- a/WeakAurasOptions/RegionOptions/Group.lua
+++ b/WeakAurasOptions/RegionOptions/Group.lua
@@ -656,4 +656,4 @@ local function createIcon()
 end
 
 -- Register new region type options with WeakAuras
-WeakAuras.RegisterRegionOptions("group", createOptions, createIcon, L["Group"], createThumbnail, modifyThumbnail, L["Controls the positioning and configuration of multiple displays at the same time"]);
+WeakAuras.RegisterRegionOptions("group", createOptions, createIcon, L["Group"], createIcon, function() return end, L["Controls the positioning and configuration of multiple displays at the same time"]);

--- a/WeakAurasOptions/RegionOptions/Icon.lua
+++ b/WeakAurasOptions/RegionOptions/Icon.lua
@@ -44,68 +44,21 @@ local function createOptions(id, data)
       order = 4,
       func = function() WeakAuras.OpenIconPicker(data, "displayIcon"); end
     },
-    desaturate = {
-      type = "toggle",
+    alpha = {
+      type = "range",
       width = WeakAuras.normalWidth,
-      name = L["Desaturate"],
+      name = L["Alpha"],
       order = 5,
-    },
-    cooldownHeader = {
-      type = "header",
-      order = 6,
-      name = L["Cooldown Settings"],
-    },
-    cooldown = {
-      type = "toggle",
-      width = WeakAuras.normalWidth,
-      name = L["Cooldown"],
-      order = 6.1,
-      disabled = function() return not WeakAuras.CanHaveDuration(data); end,
-      get = function() return WeakAuras.CanHaveDuration(data) and data.cooldown; end
-    },
-    inverse = {
-      type = "toggle",
-      width = WeakAuras.normalWidth,
-      name = L["Inverse"],
-      order = 6.2,
-      disabled = function() return not (WeakAuras.CanHaveDuration(data) and data.cooldown); end,
-      get = function() return data.inverse and WeakAuras.CanHaveDuration(data) and data.cooldown; end,
-      hidden = function() return not data.cooldown end
-    },
-    cooldownSwipe = {
-      type = "toggle",
-      width = WeakAuras.normalWidth,
-      name = L["Cooldown Swipe"],
-      order = 6.3,
-      disabled = function() return not WeakAuras.CanHaveDuration(data) end,
-      hidden = function() return not data.cooldown end,
-    },
-    cooldownEdge = {
-      type = "toggle",
-      width = WeakAuras.normalWidth,
-      name = L["Cooldown Edge"],
-      order = 6.4,
-      disabled = function() return not WeakAuras.CanHaveDuration(data) end,
-      hidden = function() return not data.cooldown end,
-    },
-    cooldownTextDisabled = {
-      type = "toggle",
-      width = WeakAuras.normalWidth,
-      name = L["Hide Cooldown Text"],
-      order = 6.5,
-      disabled = function() return not WeakAuras.CanHaveDuration(data); end,
-      hidden = function() return not data.cooldown end,
-    },
-    otherHeader = {
-      type = "header",
-      order = 48,
-      name = "",
+      min = 0,
+      max = 1,
+      bigStep = 0.01,
+      isPercent = true
     },
     zoom = {
       type = "range",
       width = WeakAuras.normalWidth,
       name = L["Zoom"],
-      order = 49,
+      order = 6,
       min = 0,
       max = 1,
       bigStep = 0.01,
@@ -115,7 +68,7 @@ local function createOptions(id, data)
       type = "range",
       width = WeakAuras.normalWidth,
       name = L["Icon Inset"],
-      order = 49.1,
+      order = 7,
       min = 0,
       max = 1,
       bigStep = 0.01,
@@ -128,28 +81,75 @@ local function createOptions(id, data)
       type = "toggle",
       width = WeakAuras.normalWidth,
       name = L["Keep Aspect Ratio"],
-      order = 49.1
+      order = 8
+    },
+    desaturate = {
+      type = "toggle",
+      width = WeakAuras.normalWidth,
+      name = L["Desaturate"],
+      order = 9,
     },
     useTooltip = {
       type = "toggle",
       width = WeakAuras.normalWidth,
       name = L["Tooltip on Mouseover"],
       hidden = function() return not WeakAuras.CanHaveTooltip(data) end,
-      order = 49.5
+      order = 10
     },
-    alpha = {
-      type = "range",
+    cooldownHeader = {
+      type = "header",
+      order = 11,
+      name = L["Cooldown Settings"],
+    },
+    cooldown = {
+      type = "toggle",
       width = WeakAuras.normalWidth,
-      name = L["Icon Alpha"],
-      order = 49.6,
-      min = 0,
-      max = 1,
-      bigStep = 0.01,
-      isPercent = true
+      name = L["Show Cooldown"],
+      order = 11.1,
+      disabled = function() return not WeakAuras.CanHaveDuration(data); end,
+      get = function() return WeakAuras.CanHaveDuration(data) and data.cooldown; end
+    },
+    inverse = {
+      type = "toggle",
+      width = WeakAuras.normalWidth,
+      name = L["Inverse"],
+      order = 11.2,
+      disabled = function() return not (WeakAuras.CanHaveDuration(data) and data.cooldown); end,
+      get = function() return data.inverse and WeakAuras.CanHaveDuration(data) and data.cooldown; end,
+      hidden = function() return not data.cooldown end
+    },
+    cooldownSwipe = {
+      type = "toggle",
+      width = WeakAuras.normalWidth,
+      name = L["Cooldown Swipe"],
+      order = 11.3,
+      disabled = function() return not WeakAuras.CanHaveDuration(data) end,
+      hidden = function() return not data.cooldown end,
+    },
+    cooldownEdge = {
+      type = "toggle",
+      width = WeakAuras.normalWidth,
+      name = L["Cooldown Edge"],
+      order = 11.4,
+      disabled = function() return not WeakAuras.CanHaveDuration(data) end,
+      hidden = function() return not data.cooldown end,
+    },
+    cooldownTextDisabled = {
+      type = "toggle",
+      width = WeakAuras.normalWidth,
+      name = L["Hide Cooldown Text"],
+      order = 11.5,
+      disabled = function() return not WeakAuras.CanHaveDuration(data); end,
+      hidden = function() return not data.cooldown end,
+    },
+    endHeader = {
+      type = "header",
+      order = 100,
+      name = "",
     },
   };
 
-  for k, v in pairs(WeakAuras.GlowOptions(id, data, 10)) do
+  for k, v in pairs(WeakAuras.GlowOptions(id, data, 12)) do
     options[k] = v
   end
 

--- a/WeakAurasOptions/RegionOptions/Icon.lua
+++ b/WeakAurasOptions/RegionOptions/Icon.lua
@@ -2,6 +2,11 @@ local Masque = LibStub("Masque", true)
 local L = WeakAuras.L
 
 local function createOptions(id, data)
+  local hiddenIconExtra = function()
+    return WeakAuras.IsCollapsed("icon", "icon", "iconextra", true);
+  end
+  local indentWidth = 0.15
+
   local options = {
     __title = L["Icon Settings"],
     __order = 1,
@@ -44,57 +49,113 @@ local function createOptions(id, data)
       order = 4,
       func = function() WeakAuras.OpenIconPicker(data, "displayIcon"); end
     },
-    alpha = {
-      type = "range",
-      width = WeakAuras.normalWidth,
-      name = L["Alpha"],
-      order = 5,
-      min = 0,
-      max = 1,
-      bigStep = 0.01,
-      isPercent = true
-    },
-    zoom = {
-      type = "range",
-      width = WeakAuras.normalWidth,
-      name = L["Zoom"],
-      order = 6,
-      min = 0,
-      max = 1,
-      bigStep = 0.01,
-      isPercent = true
-    },
-    iconInset = {
-      type = "range",
-      width = WeakAuras.normalWidth,
-      name = L["Icon Inset"],
-      order = 7,
-      min = 0,
-      max = 1,
-      bigStep = 0.01,
-      isPercent = true,
-      hidden = function()
-        return not Masque;
-      end
-    },
-    keepAspectRatio = {
-      type = "toggle",
-      width = WeakAuras.normalWidth,
-      name = L["Keep Aspect Ratio"],
-      order = 8
-    },
     desaturate = {
       type = "toggle",
       width = WeakAuras.normalWidth,
       name = L["Desaturate"],
-      order = 9,
+      order = 5,
     },
     useTooltip = {
       type = "toggle",
       width = WeakAuras.normalWidth,
       name = L["Tooltip on Mouseover"],
       hidden = function() return not WeakAuras.CanHaveTooltip(data) end,
-      order = 10
+      order = 6
+    },
+    iconExtraDescription = {
+      type = "description",
+      name = function()
+        local line = L["|cFFffcc00Extra:|r"]
+        if data.alpha ~= 1 then
+          line = L["%s Alpha: %.01f"]:format(line, data.alpha)
+        end
+        if data.zoom ~= 0 then
+          line = L["%s Zoom: %.01f"]:format(line, data.zoom)
+        end
+        if data.keepAspectRatio then
+          line = L["%s Keep Aspect Ratio"]:format(line)
+        end
+        return line
+      end,
+      width = WeakAuras.doubleWidth - 0.15,
+      order = 7,
+      fontSize = "medium"
+    },
+    iconExtraExpand = {
+      type = "execute",
+      name = function()
+        local collapsed = WeakAuras.IsCollapsed("icon", "icon", "iconextra", true)
+        return collapsed and L["Show Extra Options"] or L["Hide Extra Options"]
+      end,
+      order = 7.01,
+      width = 0.15,
+      image = function()
+        local collapsed = WeakAuras.IsCollapsed("icon", "icon", "iconextra", true);
+        return collapsed and "Interface\\AddOns\\WeakAuras\\Media\\Textures\\edit" or "Interface\\AddOns\\WeakAuras\\Media\\Textures\\editdown"
+      end,
+      imageWidth = 24,
+      imageHeight = 24,
+      func = function()
+        local collapsed = WeakAuras.IsCollapsed("icon", "icon", "iconextra", true);
+        WeakAuras.SetCollapsed("icon", "icon", "iconextra", not collapsed);
+      end,
+      control = "WeakAurasIcon"
+    },
+    iconExtra_space1 = {
+      type = "description",
+      name = "",
+      width = indentWidth,
+      order = 7.02,
+      hidden = hiddenIconExtra,
+    },
+    alpha = {
+      type = "range",
+      width = WeakAuras.normalWidth - indentWidth,
+      name = L["Alpha"],
+      order = 7.03,
+      min = 0,
+      max = 1,
+      bigStep = 0.01,
+      isPercent = true,
+      hidden = hiddenIconExtra,
+    },
+    zoom = {
+      type = "range",
+      width = WeakAuras.normalWidth,
+      name = L["Zoom"],
+      order = 7.04,
+      min = 0,
+      max = 1,
+      bigStep = 0.01,
+      isPercent = true,
+      hidden = hiddenIconExtra,
+    },
+    iconExtra_space2 = {
+      type = "description",
+      name = "",
+      width = indentWidth,
+      order = 7.05,
+      hidden = hiddenIconExtra,
+    },
+    iconInset = {
+      type = "range",
+      width = WeakAuras.normalWidth - indentWidth,
+      name = L["Icon Inset"],
+      order = 7.06,
+      min = 0,
+      max = 1,
+      bigStep = 0.01,
+      isPercent = true,
+      hidden = function()
+        return not Masque or hiddenIconExtra();
+      end
+    },
+    keepAspectRatio = {
+      type = "toggle",
+      width = WeakAuras.normalWidth,
+      name = L["Keep Aspect Ratio"],
+      order = 7.07,
+      hidden = hiddenIconExtra,
     },
     cooldownHeader = {
       type = "header",

--- a/WeakAurasOptions/RegionOptions/Model.lua
+++ b/WeakAurasOptions/RegionOptions/Model.lua
@@ -185,6 +185,11 @@ local function createOptions(id, data)
       order = 26,
       hidden = function() return not data.api end
     },
+    endHeader = {
+      type = "header",
+      order = 100,
+      name = "",
+    },
   };
 
   if WeakAuras.BuildInfo > 80100 then
@@ -213,7 +218,7 @@ local function createOptions(id, data)
   return {
     model = options,
     border = WeakAuras.BorderOptions(id, data);
-    position = WeakAuras.PositionOptions(id, data),
+    position = WeakAuras.PositionOptions(id, data, nil, nil, nil, true),
   };
 end
 

--- a/WeakAurasOptions/RegionOptions/Model.lua
+++ b/WeakAurasOptions/RegionOptions/Model.lua
@@ -215,9 +215,12 @@ local function createOptions(id, data)
     }
   end
 
+  for k, v in pairs(WeakAuras.BorderOptions(id, data, nil, nil, 70)) do
+    options[k] = v
+  end
+
   return {
     model = options,
-    border = WeakAuras.BorderOptions(id, data);
     position = WeakAuras.PositionOptions(id, data, nil, nil, nil, true),
   };
 end

--- a/WeakAurasOptions/RegionOptions/ProgressTexture.lua
+++ b/WeakAurasOptions/RegionOptions/ProgressTexture.lua
@@ -272,6 +272,11 @@ local function createOptions(id, data)
       name = "",
       order = 56
     },
+    endHeader = {
+      type = "header",
+      order = 100,
+      name = "",
+    },
   };
   options = WeakAuras.regionPrototype.AddAdjustedDurationOptions(options, data, 57);
 

--- a/WeakAurasOptions/RegionOptions/Text.lua
+++ b/WeakAurasOptions/RegionOptions/Text.lua
@@ -128,13 +128,18 @@ local function createOptions(id, data)
       order = 48,
       values = WeakAuras.font_flags
     },
+    endHeader = {
+      type = "header",
+      order = 100,
+      name = "",
+    },
   };
 
   WeakAuras.AddCodeOption(options, data, L["Custom Function"], "customText", 37, function() return not WeakAuras.ContainsCustomPlaceHolder(data.displayText) end, {"customText"}, false);
 
   return {
     text = options;
-    position = WeakAuras.PositionOptions(id, data, nil, true);
+    position = WeakAuras.PositionOptions(id, data, nil, true, nil, true);
   };
 end
 

--- a/WeakAurasOptions/RegionOptions/Texture.lua
+++ b/WeakAurasOptions/RegionOptions/Texture.lua
@@ -89,6 +89,11 @@ local function createOptions(id, data)
       order = 35,
       hidden = function() return data.rotate end
     },
+    endHeader = {
+      type = "header",
+      order = 100,
+      name = "",
+    },
   };
 
   return {

--- a/WeakAurasOptions/WeakAurasOptions.lua
+++ b/WeakAurasOptions/WeakAurasOptions.lua
@@ -3614,7 +3614,7 @@ function WeakAuras.ReloadGroupRegionOptions(data)
   options.args.region.args = regionOption;
 end
 
-function WeakAuras.PositionOptions(id, data, _, hideWidthHeight, disableSelfPoint)
+function WeakAuras.PositionOptions(id, data, _, hideWidthHeight, disableSelfPoint, noEndHeader)
   local metaOrder = 100
   local function IsParentDynamicGroup()
     return data.parent and db.displays[data.parent] and db.displays[data.parent].regionType == "dynamicgroup";
@@ -3810,6 +3810,13 @@ function WeakAuras.PositionOptions(id, data, _, hideWidthHeight, disableSelfPoin
       end
     },
   };
+  if not noEndHeader then
+    positionOptions["endHeader"] = {
+      type = "header",
+      order = 100,
+      name = ""
+    }
+  end
   WeakAuras.AddCodeOption(positionOptions, data, L["Custom Anchor"], "custom_anchor", 72.1, function() return not(data.anchorFrameType == "CUSTOM" and not IsParentDynamicGroup()) end, {"customAnchor"}, nil, nil, nil, nil, nil, true)
   return positionOptions;
 end
@@ -3830,7 +3837,7 @@ function WeakAuras.GlowOptions(id, data, order)
     glow = {
       type = "toggle",
       width = WeakAuras.normalWidth,
-      name = L["Show Glow Effect"],
+      name = L["Show Glow"],
       order = order + 0.02,
     },
     glowType = {
@@ -4052,7 +4059,7 @@ function WeakAuras.BorderOptions(id, data, _, showBackDropOptions, hiddenFunc)
     border = {
       type = "toggle",
       width = WeakAuras.doubleWidth,
-      name = L["Enable"],
+      name = L["Show Border"],
       order = 46.05,
       hidden = hiddenFunc,
     },
@@ -4142,6 +4149,11 @@ function WeakAuras.BorderOptions(id, data, _, showBackDropOptions, hiddenFunc)
       order = 46.8,
       disabled = function() return not data.border end,
       hidden = hiddenFunc,
+    },
+    endHeader = {
+      type = "header",
+      order = 46.9,
+      name = "",
     },
   }
 

--- a/WeakAurasOptions/WeakAurasOptions.lua
+++ b/WeakAurasOptions/WeakAurasOptions.lua
@@ -4656,8 +4656,8 @@ function WeakAuras.OpenTexturePicker(data, field, textures, stopMotion)
   frame.texturePicker:Open(data, field, textures, stopMotion);
 end
 
-function WeakAuras.OpenIconPicker(data, field)
-  frame.iconPicker:Open(data, field);
+function WeakAuras.OpenIconPicker(data, field, groupIcon)
+  frame.iconPicker:Open(data, field, groupIcon);
 end
 
 function WeakAuras.OpenModelPicker(data, field)

--- a/WeakAurasOptions/WeakAurasOptions.lua
+++ b/WeakAurasOptions/WeakAurasOptions.lua
@@ -2410,6 +2410,7 @@ local function addCollapsibleHeader(options, key, input, order, isGroupTab)
     name = "",
     order = order,
     width = "full",
+    hidden = hiddenFunc,
   }
   options[key .. "collapseButton"] = {
     type = "execute",
@@ -4042,16 +4043,18 @@ function WeakAuras.GlowOptions(id, data, order)
 end
 
 -- TODO: update this function to not have an unused parameter
-function WeakAuras.BorderOptions(id, data, _, showBackDropOptions)
+function WeakAuras.BorderOptions(id, data, _, showBackDropOptions, hiddenFunc)
   local metaOrder = 99
   local borderOptions = {
     __title = L["Border Settings"],
     __order = metaOrder,
+    __hidden = hiddenFunc,
     border = {
       type = "toggle",
       width = WeakAuras.doubleWidth,
       name = L["Enable"],
-      order = 46.05
+      order = 46.05,
+      hidden = hiddenFunc,
     },
     borderEdge = {
       type = "select",
@@ -4061,6 +4064,7 @@ function WeakAuras.BorderOptions(id, data, _, showBackDropOptions)
       order = 46.1,
       values = AceGUIWidgetLSMlists.border,
       disabled = function() return not data.border end,
+      hidden = hiddenFunc,
     },
     borderBackdrop = {
       type = "select",
@@ -4070,6 +4074,7 @@ function WeakAuras.BorderOptions(id, data, _, showBackDropOptions)
       order = 46.2,
       values = AceGUIWidgetLSMlists.background,
       disabled = function() return not data.border end,
+      hidden = hiddenFunc,
     },
     borderOffset = {
       type = "range",
@@ -4080,6 +4085,7 @@ function WeakAuras.BorderOptions(id, data, _, showBackDropOptions)
       softMax = 32,
       bigStep = 1,
       disabled = function() return not data.border end,
+      hidden = hiddenFunc,
     },
     borderSize = {
       type = "range",
@@ -4090,6 +4096,7 @@ function WeakAuras.BorderOptions(id, data, _, showBackDropOptions)
       softMax = 64,
       bigStep = 1,
       disabled = function() return not data.border end,
+      hidden = hiddenFunc,
     },
     borderInset = {
       type = "range",
@@ -4100,6 +4107,7 @@ function WeakAuras.BorderOptions(id, data, _, showBackDropOptions)
       softMax = 32,
       bigStep = 1,
       disabled = function() return not data.border end,
+      hidden = hiddenFunc,
     },
     borderColor = {
       type = "color",
@@ -4108,6 +4116,7 @@ function WeakAuras.BorderOptions(id, data, _, showBackDropOptions)
       hasAlpha = true,
       order = 46.6,
       disabled = function() return not data.border end,
+      hidden = hiddenFunc,
     },
     borderInFront  = {
       type = "toggle",
@@ -4115,7 +4124,7 @@ function WeakAuras.BorderOptions(id, data, _, showBackDropOptions)
       name = L["Border in Front"],
       order = 46.7,
       disabled = function() return not data.border end,
-      hidden = function() return not showBackDropOptions end,
+      hidden = function() return hiddenFunc and hiddenFunc() or not showBackDropOptions end,
     },
     backdropInFront  = {
       type = "toggle",
@@ -4123,7 +4132,7 @@ function WeakAuras.BorderOptions(id, data, _, showBackDropOptions)
       name = L["Backdrop in Front"],
       order = 46.75,
       disabled = function() return not data.border end,
-      hidden = function() return not showBackDropOptions end,
+      hidden = function() return hiddenFunc and hiddenFunc() or not showBackDropOptions end,
     },
     backdropColor = {
       type = "color",
@@ -4132,6 +4141,7 @@ function WeakAuras.BorderOptions(id, data, _, showBackDropOptions)
       hasAlpha = true,
       order = 46.8,
       disabled = function() return not data.border end,
+      hidden = hiddenFunc,
     },
   }
 

--- a/WeakAurasOptions/WeakAurasOptions.lua
+++ b/WeakAurasOptions/WeakAurasOptions.lua
@@ -3698,16 +3698,16 @@ function WeakAuras.PositionOptions(id, data, _, hideWidthHeight, disableSelfPoin
           return L["To Screen's"]
         elseif (data.anchorFrameType == "PRD") then
           return L["To Personal Ressource Display's"];
-        elseif (data.anchorFrameType == "SELECTFRAME") then
+        elseif (data.anchorFrameType == "SELECTFRAME" or data.anchorFrameType == "CUSTOM") then
           return L["To Frame's"];
         end
       end,
       order = 75,
       hidden = function()
         if (data.parent) then
-          if (IsParentDynamicGroup()) then
-            return true;
-          end
+          --if (IsParentDynamicGroup()) then
+          --  return true;
+          --end
           return data.anchorFrameType == "SCREEN" or data.anchorFrameType == "MOUSE";
         else
           return data.anchorFrameType == "MOUSE";
@@ -3810,7 +3810,7 @@ function WeakAuras.PositionOptions(id, data, _, hideWidthHeight, disableSelfPoin
       end
     },
   };
-
+  WeakAuras.AddCodeOption(positionOptions, data, L["Custom Anchor"], "custom_anchor", 72.1, function() return not(data.anchorFrameType == "CUSTOM" and not IsParentDynamicGroup()) end, {"customAnchor"}, nil, nil, nil, nil, nil, true)
   return positionOptions;
 end
 

--- a/WeakAurasOptions/WeakAurasOptions.lua
+++ b/WeakAurasOptions/WeakAurasOptions.lua
@@ -3638,11 +3638,57 @@ function WeakAuras.PositionOptions(id, data, _, hideWidthHeight, disableSelfPoin
       type = "range",
       width = WeakAuras.normalWidth,
       name = L["Height"],
-      order = 65,
+      order = 61,
       min = 1,
       softMax = screenHeight,
       bigStep = 1,
       hidden = hideWidthHeight,
+    },
+    xOffset = {
+      type = "range",
+      width = WeakAuras.normalWidth,
+      name = L["X Offset"],
+      order = 62,
+      softMin = (-1 * screenWidth),
+      softMax = screenWidth,
+      bigStep = 10,
+      get = function() return data.xOffset end,
+      set = function(info, v)
+        data.xOffset = v;
+        WeakAuras.Add(data);
+        WeakAuras.SetThumbnail(data);
+        WeakAuras.ResetMoverSizer();
+        if(data.parent) then
+          local parentData = WeakAuras.GetData(data.parent);
+          if(parentData) then
+            WeakAuras.Add(parentData);
+            WeakAuras.SetThumbnail(parentData);
+          end
+        end
+      end
+    },
+    yOffset = {
+      type = "range",
+      width = WeakAuras.normalWidth,
+      name = L["Y Offset"],
+      order = 63,
+      softMin = (-1 * screenHeight),
+      softMax = screenHeight,
+      bigStep = 10,
+      get = function() return data.yOffset end,
+      set = function(info, v)
+        data.yOffset = v;
+        WeakAuras.Add(data);
+        WeakAuras.SetThumbnail(data);
+        WeakAuras.ResetMoverSizer();
+        if(data.parent) then
+          local parentData = WeakAuras.GetData(data.parent);
+          if(parentData) then
+            WeakAuras.Add(parentData);
+            WeakAuras.SetThumbnail(parentData);
+          end
+        end
+      end
     },
     selfPoint = {
       type = "select",
@@ -3719,7 +3765,7 @@ function WeakAuras.PositionOptions(id, data, _, hideWidthHeight, disableSelfPoin
       type = "select",
       width = WeakAuras.normalWidth,
       name = function() return L["to group's"] end,
-      order = 75,
+      order = 76,
       hidden = function()
         if (data.anchorFrameType ~= "SCREEN") then
           return true;
@@ -3761,52 +3807,6 @@ function WeakAuras.PositionOptions(id, data, _, hideWidthHeight, disableSelfPoin
       image = function() return "", 0, 0 end,
       hidden = function()
         return not (data.anchorFrameType ~= "SCREEN" or IsParentDynamicGroup());
-      end
-    },
-    xOffset = {
-      type = "range",
-      width = WeakAuras.normalWidth,
-      name = L["X Offset"],
-      order = 80,
-      softMin = (-1 * screenWidth),
-      softMax = screenWidth,
-      bigStep = 10,
-      get = function() return data.xOffset end,
-      set = function(info, v)
-        data.xOffset = v;
-        WeakAuras.Add(data);
-        WeakAuras.SetThumbnail(data);
-        WeakAuras.ResetMoverSizer();
-        if(data.parent) then
-          local parentData = WeakAuras.GetData(data.parent);
-          if(parentData) then
-            WeakAuras.Add(parentData);
-            WeakAuras.SetThumbnail(parentData);
-          end
-        end
-      end
-    },
-    yOffset = {
-      type = "range",
-      width = WeakAuras.normalWidth,
-      name = L["Y Offset"],
-      order = 85,
-      softMin = (-1 * screenHeight),
-      softMax = screenHeight,
-      bigStep = 10,
-      get = function() return data.yOffset end,
-      set = function(info, v)
-        data.yOffset = v;
-        WeakAuras.Add(data);
-        WeakAuras.SetThumbnail(data);
-        WeakAuras.ResetMoverSizer();
-        if(data.parent) then
-          local parentData = WeakAuras.GetData(data.parent);
-          if(parentData) then
-            WeakAuras.Add(parentData);
-            WeakAuras.SetThumbnail(parentData);
-          end
-        end
       end
     },
   };
@@ -4050,17 +4050,19 @@ function WeakAuras.GlowOptions(id, data, order)
 end
 
 -- TODO: update this function to not have an unused parameter
-function WeakAuras.BorderOptions(id, data, _, showBackDropOptions, hiddenFunc)
-  local metaOrder = 99
+function WeakAuras.BorderOptions(id, data, showBackDropOptions, hiddenFunc, order)
   local borderOptions = {
-    __title = L["Border Settings"],
-    __order = metaOrder,
-    __hidden = hiddenFunc,
+    borderHeader = {
+      type = "header",
+      order = order,
+      name = L["Border Settings"],
+      hidden = hiddenFunc,
+    },
     border = {
       type = "toggle",
       width = WeakAuras.doubleWidth,
       name = L["Show Border"],
-      order = 46.05,
+      order = order + 0.1,
       hidden = hiddenFunc,
     },
     borderEdge = {
@@ -4068,92 +4070,85 @@ function WeakAuras.BorderOptions(id, data, _, showBackDropOptions, hiddenFunc)
       width = WeakAuras.normalWidth,
       dialogControl = "LSM30_Border",
       name = L["Border Style"],
-      order = 46.1,
+      order = order + 0.2,
       values = AceGUIWidgetLSMlists.border,
-      disabled = function() return not data.border end,
-      hidden = hiddenFunc,
+      hidden = function() return hiddenFunc and hiddenFunc() or not data.border end,
     },
     borderBackdrop = {
       type = "select",
       width = WeakAuras.normalWidth,
       dialogControl = "LSM30_Background",
       name = L["Backdrop Style"],
-      order = 46.2,
+      order = order + 0.3,
       values = AceGUIWidgetLSMlists.background,
-      disabled = function() return not data.border end,
-      hidden = hiddenFunc,
+      hidden = function() return hiddenFunc and hiddenFunc() or not data.border end,
     },
     borderOffset = {
       type = "range",
       width = WeakAuras.normalWidth,
       name = L["Border Offset"],
-      order = 46.3,
+      order = order + 0.3,
       softMin = 0,
       softMax = 32,
       bigStep = 1,
-      disabled = function() return not data.border end,
-      hidden = hiddenFunc,
+      hidden = function() return hiddenFunc and hiddenFunc() or not data.border end,
     },
     borderSize = {
       type = "range",
       width = WeakAuras.normalWidth,
       name = L["Border Size"],
-      order = 46.4,
+      order = order + 0.4,
       softMin = 1,
       softMax = 64,
       bigStep = 1,
-      disabled = function() return not data.border end,
-      hidden = hiddenFunc,
+      hidden = function() return hiddenFunc and hiddenFunc() or not data.border end,
     },
     borderInset = {
       type = "range",
       width = WeakAuras.normalWidth,
       name = L["Border Inset"],
-      order = 46.5,
+      order = order + 0.5,
       softMin = 1,
       softMax = 32,
       bigStep = 1,
-      disabled = function() return not data.border end,
-      hidden = hiddenFunc,
+      hidden = function() return hiddenFunc and hiddenFunc() or not data.border end,
+    },
+    border_spacer = {
+      type = "description",
+      name = "",
+      width = WeakAuras.normalWidth,
+      hidden = function() return hiddenFunc and hiddenFunc() or not data.border end,
+      order = order + 0.6
     },
     borderColor = {
       type = "color",
       width = WeakAuras.normalWidth,
       name = L["Border Color"],
       hasAlpha = true,
-      order = 46.6,
-      disabled = function() return not data.border end,
-      hidden = hiddenFunc,
+      order = order + 0.7,
+      hidden = function() return hiddenFunc and hiddenFunc() or not data.border end,
     },
     borderInFront  = {
       type = "toggle",
       width = WeakAuras.normalWidth,
       name = L["Border in Front"],
-      order = 46.7,
-      disabled = function() return not data.border end,
-      hidden = function() return hiddenFunc and hiddenFunc() or not showBackDropOptions end,
-    },
-    backdropInFront  = {
-      type = "toggle",
-      width = WeakAuras.normalWidth,
-      name = L["Backdrop in Front"],
-      order = 46.75,
-      disabled = function() return not data.border end,
-      hidden = function() return hiddenFunc and hiddenFunc() or not showBackDropOptions end,
+      order = order + 0.8,
+      hidden = function() return hiddenFunc and hiddenFunc() or not data.border or not showBackDropOptions end,
     },
     backdropColor = {
       type = "color",
       width = WeakAuras.normalWidth,
       name = L["Backdrop Color"],
       hasAlpha = true,
-      order = 46.8,
-      disabled = function() return not data.border end,
-      hidden = hiddenFunc,
+      order = order + 0.9,
+      hidden = function() return hiddenFunc and hiddenFunc() or not data.border end,
     },
-    endHeader = {
-      type = "header",
-      order = 46.9,
-      name = "",
+    backdropInFront  = {
+      type = "toggle",
+      width = WeakAuras.normalWidth,
+      name = L["Backdrop in Front"],
+      order = order + 1,
+      hidden = function() return hiddenFunc and hiddenFunc() or not data.border or not showBackDropOptions end,
     },
   }
 


### PR DESCRIPTION
# Description
- Killed group & dynamicgroup thumbnail, use the animated icons instead, with ability to set your own
![img](https://i.imgur.com/1WsEQXz.gif)
![img](https://i.imgur.com/ldgbIwq.png)
- Renamed and reorganized a few options in Group and Display tab
https://i.imgur.com/hJIWwj3.png
https://i.imgur.com/sfXrmLt.png
- Use same border settings for both groups and dynamic groups and changed default settings for something closer to pixel perfect style
- New dependency LibGetFrame, publicly accessible with WeakAuras.GetUnitFrame documentation at <https://github.com/mrbuds/LibGetFrame/blob/master/README.md>
- All regions can use a custom anchor function, custom function needs to return a frame
```Lua
function()
  return SUFUnitplayer
end
```
![img](https://i.imgur.com/PDaSIgY.png)
- Dynamic group's growers have a new option "Group by Frame", it can be "unit frame", "nameplates" or a custom function. Enabling this option disable border options.
![img](https://i.imgur.com/Ls0mW5G.png)
Custom anchor per unit example :
```Lua
function(frames, activeRegions)
    for _, regionData in ipairs(activeRegions) do
        local unit = regionData.region.state and regionData.region.state.destUnit
        if unit then
            local frame = C_NamePlate.GetNamePlateForUnit(unit)
            if frame then
                frames[frame] = frames[frame] or {}
                tinsert(frames[frame], regionData)
            end
        end
    end
end
```
- Custom grower interface is incompatible with previously written custom grow, but easy to adapt
It now needs to return an array keyed by anchor frame, or "" if anchor is dynamic group region, followed by an array keyed by regionData `[anchor][regionData] = { x , y }`

Custom grower example:
```Lua
function(newPositions, activeRegions)
    local frames = {}
    for _, regionData in ipairs(activeRegions) do
        local unit = regionData.region.state and regionData.region.state.unit
        if unit then
            local frame = C_NamePlate.GetNamePlateForUnit(unit)
            if frame then
                frames[frame] = frames[frame] or {}
                tinsert(frames[frame], regionData)
            end
        end
    end
    for frame, regionsData in pairs(frames) do
        local totalWidth = #regionsData - 1
        for _, regionData in ipairs(regionsData) do
            totalWidth = totalWidth + (regionData.data.width or regionData.region.width)
        end
        local x, y = - totalWidth/2, - (#regionsData - 1)/2
        newPositions[frame] = {}
        for i, regionData in ipairs(regionsData) do
            x = x + (regionData.data.width or regionData.region.width) / 2
            newPositions[frame][regionData] = { x, y }
            x = x + (regionData.data.width or regionData.region.width) / 2
        end
    end
end
```

Any suggestion, advice or critic welcome

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update
- [x] This break compatibility with previous custom code

# How Has This Been Tested?
No custom code: show buffs as grid in unitframes
```
!nBvZYTTnq4NMEOhAhrh70Cv)qLOoYuQeuTjxGeijejQHaujaLT8b9S3DbinPuLDDMEPZ4HgC5I93V9BfnGMqjgkzc)aLSJsYX)arfv6hPKphpBcLKQRY5vJyzpKxP3tjJKINFMvLFAtIwlTcq0tl2U1WT0ObuYXENzQSsD1sTqzPKKflNhonP1GJ1sDf4ROau1OBCp)G75TOq4g1g(qVf4vRuclDeyYmRqRmU42YQSWbqtb(v3PTWrtP7m8MTsuuWRmE)K8Ia8yopTE72KJ75uYxcNVC6Q5W3DVYQRy3aoypxkNLB8w2uNYpWvwcClXtuY6XdjjRjjdJbJvJbazVKDem(lQUSI7uLSmCoyCNmWzCM0wsjk2oUPnsRvDHM1lktlR3Pi7zzCm6HK0YRum5VdjeudGAwawIf7yyjPFfPjnuAf8mhsguH1EHgEMwb5e4GDmH69R9lv23N(WnysrHIsghgLeg7IoxcIidOcfZlA6KGQsnZb8Gw(6mjZyOPU6FgkCxnaZAlu(VEPuJ4z(LcbXPnO2(GTahylWb2cCGTb)8DUW1vk5ONz1wa2TyVTlcnzmPVp4XVOA(tH5fqMhCAZsXtCjLu5smpWk)i0LfzW8u9(w9jyScXq74rd4MSkAwY04H3hcMGLlQnGsdGAfml2bcKIDGUr3HZOICVtINGGffuFv2PWacKQK4HtMTIGx26Hhyv37)2b0BBfmt5EhSUvNDOfD9PboVlaobM1YYkpTbr5N2y1(tBRaamGlW)bdwmlJg9rFC9hICaHJEWNJtrD8blzCCyyeIuKBVKzasITIcF9UgD88e(VwfV)h)t5kWuvzZ5Qc0WF4JdCyL5UQrQ7M5I(DlFbdhI1WiHhSIONxyckKafx67K7QfcNbmE56hvKhfqUmQtGddawtabck)TiEmL6hhlHaY408mgN3IJ5c6JxHK5CsRooMlOOUg73vOHC8Th4jEH3RZHI6pfmWZ5Ef6iSQ(1ZQI))LEkNByw87Uohg5VnnrqZwGoIRMwl)j7Atjl)8uVXJ1P43B0YF8hmnVM9V7pNEB1yJFAL45tB(TAwooRbRFp33VJfQ90(B9JuN4U5XHRsw0ZZEqYIvjZNff2i)SPJzrrHXRhTijzX9XZ(8xsANE(hobnNN(l4MgUjEIRMeTaTT)AF9YRDqyePsCGZ14k5IIsKW6UUfh)33vGaGPv8)QMRYoIlfU5URsiI65ljP1wRwTauagQA(qPi7byY24Ot7vtBzq6VCWrw4U2CbYge9PM3Ay5c8KCDiZ0ZPi)((Tqp65KXI2zu2bxDD3ZA9o)eCTvJ8uyuqEzhiso7wQDAdYJy6ycX25eHHb9RC3pytUV07f0c9reVd0VBjq2H73DS42vb)Y3WSd7h(L0V2QLh489draHngh(V2(H2OTnZg1Ut3vQoaU)2BWiG(3
```

custom "anchor per unit": attach icon to nameplate (note: this would be better to achieved without dynamic group using custom anchor from aura region)
```
!nF12UnUnt4NMcKfOnWk7bS30lSDS31TELDnvAtBrLfLeTmrKj9ssLtfvp7)ZmuYw2ojB(rVPWjouJgoh)MdjoiokMzJzxkUnMTjMLJ)aKkm67IzFE2Ij)XSWO(tJzPAtUWmGNDtUrVnMnOu(4JCtEDsKwx6KaP7NTALv4Id7fZEOZ5cJmp6HTIy2IlBf0qDP2aAkmazj8c673sF)oKOlMbMaBlptGpY4zoPwzjZ1Xno4aWYkPsAx7pdh9uHZoJSOqySEfeTJaEmxKwTAL3E(8OPZhFf4Do6rELHFbOGTIYYj5wVCTvPIBfkhdUL8(y2YH9zrlzr9xacRcvkBBj)bq4mfFJO5w0vafi4LU17fYCJGecB(OPtr(Qu7nnN34Z0LvBu7DDdpxwzHyupiwYvYnCmu0nsWYbdhjU07hwrMwb2FJBP0kbk4nCP61Z9Uy7RJF4g8szHkMnCuy0OfK1rogcba)FHOOjdcSwQ5eoRYkwMvYT24ukUNHe3ub4P2uP)Tht1kFuCmrGCAd8Sl6kGqxbe6kGqx9o)9uOxcO9R)57)sGzY1t6TPn4kiBjJx2G8QCR1MzBD7TEpeoEq7Pr5fqGiOozU8ErjKXix1dXYFaqfYmOGQABl)m06bRcuygi75cZveoA4vSOzFHIktLBakOHOnyO1Mju5svb9Y(hCTbyPIZdkWynKDGqVYngQzGOaBr)lNCfJOVsw01dARrFhKqi9HNC6SBHshsAFShb6Waf354zRRtYfwhQ26eNUobr8a6hIzSvg4muOXD84Wp4R6)nzoG(rP690Xip(4cB4IrJcr0u5Q5AjwS0cC8g3efzBygWKnvOkqj92pGoyL1P3CyqGTQsrTioJSd73xNGTmUv0a7Et9pvN4)SsBQtwcm4ttxcgCDIub)ULln2Zo6Ej5693T9tPgWh1jvuG4h7kQZ9hphsbobyeQ8N9TNVlwEI8LRAfUBTqD67pYoiFMmKHldHJZXuY5Fs429WynfNodf6BEE5H6TryVSI3fmPO9Fs)5Vil4ikyW(V)NVTGCsiFBCNDW1pij9cMnuBC6lpGi9a81UAUdHCyhnzNkCRV77f4yfNWO4L)ABnXf0WPSDJwkkHrLPhoX7z0HUmxFNIDNekagSNa1(aKGeScK(ln9YUwF3WsOLRL403qgatWaIMMPy74b4GLMrqq)l9(E4qBQDdNgYTUJhHHYGNcnDs)IoNe0Htd7mIdzTQPb0tpF7LND(udIpAI4HgNFidvDg5zHSXWFiONFbGtZuSBeIT9XblUfO)JH5)lpcf6ia5stZqieA9YJYcA2qz)W1geJ4E3s7AoaVUUdUSr7vP47B4YF87SnpM9T1hX3kncHgBKpwN8lv8Cd1gn6qD)k2YRd3)ExlLiVF2q)RIM1rZEuZSRIMojCud9dk6MegoAXYbZIGbQlM8Pph1wuEIsUvALPLIDJrfruajCgky)DU(47GMGFiEWf(e3AHSyTdxsB)Yn)73NbbaJnIVwjuzpGlUCX7FYb0iF(qsALZPvZagGAMMxSwMDd0WW(CRZGm11f7UhF3vzO(tyz)ECz6)VBMtlDno)YVwT5tfb3ZEYfaUZV2agl5LBxZjdhv6uj24l8JXSh16nnB74BIIzTlLwoKkZXCj12BG)ASDlZHA33nPojJA)9kW7hSztWlSldQRU4RUBCjvysJkRHiy7)ZutrE76nb9oDuuRd26md8lFM6JN3cx6D0iP4)3p
```

custom grow example, show buffs on nameplates
```
!nFvBVTTnq4FmddibBnn29L19H9bNe7wx4k7Ak3UIIjlAjABIkt6jsf7KHQF77UJY6fBhNUxWWqsuOosDphV749CmOvGFaZeWUrCBaBvalg)feXtJgiulSld8E2lVmGntNglsVIh9L4u96a2vjY7VNNgNh6R1jwjiA7W5ZncBGhS87QnErQm2)U1Ia24B2POR1j6uahVw4s8AtpFg985OqBalvVHTMhjWxz8iRuRmKXA5PwyaSK5sL0S0ngg6KcJTPYflePgha(LcWHXIzzZN7SN30DWOEtgaZtVYZs5Tbawlss6hBC61KntCRqzzWxj3gWMEDhM)uMFNXGYYqqzRt43bkVCPJsf0szJ6oauojdatWta3jtXxjm7S0mvLPzDII0jzRuvBDPYksv8KpaBiWhaolqOrKmFKwI696UE(DhdwFICHQ6vWnr6fJaGHnwSOWbcFsIMtb5mJyAuc3ycMrB7iu4QmiCUZ(CZUVuJ8EX(cbXZkYoQhCBrb3wuWTffCV8IxGlMRKR4wbICuMXQx9AiGdH0mffQptj2msBKuy)hZdXeGBff7IZZFBEO7NeDepjpCEk6vZd)L8W)4RvZoxNMhof(8u6dVHB55Hsf83AUm1C2EAnmwx9T7HagQj9xPQlCdVaC1wbyIQ4hC2lOp)aDlNVtX2Lc1HZFSDjzexp1dgokbv9Rf2Yx6PtNa67muPN)W6dXTqzNg4shj5F)m9VFJSG9KGo66E(h6hRuzeP2ZA85ncqNWSfGh(TNuyJxOOpHqjaMQuaxgGZooDO3QT8KpkJTlPD(31qvpjpS1HF5JL4vtfpa2LoSMGx)1Fip8SA5BX4JnUPq4pmvKM88hXfU3MFlSjUJG(j1r)PT)rsYzh6no)PTpuB1poxpn6y5mKZt(VHZBlHX2)(UQWNMh2(H1)r2vFUsxf7WsF4x)V3qp8Wb8akGdHwh7skerTeTsjjFWv7g1nEbql2kpCKCRibwmbPJ7m(oGitgTivNTE36ziVGhsHQtXs8MianPAXUQ9io1yWzXaHlkCQJ)1iI0kG3TGowPvcKPyfxQ(2xDzpbFBRhzZCuTTrRmAPoDpE1mj4WsM8bw8A1pT5(vidTc2ckBpG(ai6yJ7Ct)jms(C5chfRZHSRlONd2fMDanIaHUaVxcwHo62Dm6V6Y2xcUFeihxyE4cInKNzbdA4ABf3n2nfDcmW7f7S4EOUDHf21J721JO2hixbDNmBNT0xrMslufOUVEcZF47Ov2XTVfe3bg(5neWM413V34oVRlThJL1mNuESmZaEpCdKqi6r87rLnFTibGBwZEcpQNoc6KmwVrX2iHTYvvcO8qqdsaDu(P6VZSuV56ei4AOv2OXUt1k3EDP9a9Y1S3WQw5k6eefSg5HpEFMhPHpMRfeFNW3PJHmXN06sxhThPXVVieR7GTQzhJj3Ox5)ZNTIfgUfxlf)WmHt3CyRIwURAxTial2ANAwYHSHFTwAub6zZW5lwLB43BkEn6XXJw3Cng(7LkVpp89z84uI1XVj2FdxBP2Q)uDlLex11ENj(dRHSlpz4e)b996wiVXzK(EEDhp9QH(Wz2X9F9B83Dg6aqUvAKZsOZpLQ3vyUvzjU6(qIbq4tEnVHa6uGBPqUyPfpxxDDH)53qata6Lk(9mHk6o8QaTFHtOB)plZA1QHqDr4gvftSug9f4WSXv5cKmqINT9EL7Tg7KA0tuPIJv)C7bvHow1tSumB07)4p)jXnZTp7Ox4AJRkm6H4jRxYjl8ETEfP7D1Uqh7nsdhcjX0P1mRgJnOXZkPHr8klEa3JbRDyokjrdEKcxs9CaYfvCZ9wx2KusQqT5UZ1JFSaigQoWo7Ws))1UtoQQRC9xmZj5waNN3gHk4p)
```

# Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

# Todo:
- Test more, particularly for SetPoint issue on nameplates with moversizer
- Add choice for group/dynamicgroup icon ?

# Concern
I'm not happy with anchorPerUnit option redoing layout for all auras instead of doing it only for auras anchored to the frame where there is a change.