### PR TITLE
Fix Model: Show Model of Unit

### DIFF
--- a/WeakAuras/GenericTrigger.lua
+++ b/WeakAuras/GenericTrigger.lua
@@ -730,6 +730,11 @@ function HandleEvent(frame, event, arg1, arg2, ...)
       WeakAuras.PreShowModels()
     end,
     0.8);  -- Data not available
+
+    timer:ScheduleTimer(function()
+      WeakAuras.PreShowModels()
+    end,
+    4);  -- Data not available
   end
   WeakAuras.StopProfileSystem("generictrigger " .. event);
 end

--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -1180,7 +1180,9 @@ WeakAuras.event_prototypes = {
       return result;
     end,
     internal_events = function(trigger)
-      local result = {}
+      local result = {
+        "WA_DELAYED_PLAYER_ENTERING_WORLD"
+      }
       AddUnitChangeInternalEvents(trigger.unit, result)
       if trigger.unitisunit then
         AddUnitChangeInternalEvents(trigger.unitisunit, result)

--- a/WeakAuras/RegionTypes/Model.lua
+++ b/WeakAuras/RegionTypes/Model.lua
@@ -246,6 +246,10 @@ local function modify(parent, region, data)
       model:ClearTransform();
       model:SetPosition(data.model_z, data.model_x, data.model_y);
     end
+
+    if data.modelIsUnit then
+      model:SetUnit(data.model_path);
+    end
   end
 
   function region:PreHide()


### PR DESCRIPTION
Two bugs there:
* The Unit Characteristics trigger was missing WA_DELAYED_PEW
* Calling SetUnit too "early" doesn't work. Apparently 4s after the
PLAYER_ENTERED_WORLD is about the time where it can be called.