### PR TITLE
Cast Trigger: add meta units "group", "arena", "boss", "nameplate"

### DIFF
--- a/WeakAuras/Types.lua
+++ b/WeakAuras/Types.lua
@@ -152,13 +152,16 @@ WeakAuras.actual_unit_types_with_specific = {
   member = L["Specific Unit"]
 }
 
-WeakAuras.actual_unit_types_with_specific_and_multi = {
+WeakAuras.actual_unit_types_cast = {
   player = L["Player"],
   target = L["Target"],
   focus = L["Focus"],
+  group = L["Group"],
+  boss = L["Boss"],
+  arena = L["Arena"],
+  nameplate = L["Nameplate"],
   pet = L["Pet"],
   member = L["Specific Unit"],
-  multi = L["Multi-target"]
 }
 
 WeakAuras.actual_unit_types = {
@@ -2111,7 +2114,7 @@ if WeakAuras.IsClassic() then
   WeakAuras.unit_types.focus = nil
   WeakAuras.unit_types_bufftrigger_2.focus = nil
   WeakAuras.actual_unit_types_with_specific.focus = nil
-  WeakAuras.actual_unit_types_with_specific_and_multi.focus = nil
+  WeakAuras.actual_unit_types_cast.focus = nil
   WeakAuras.actual_unit_types.focus = nil
   WeakAuras.item_slot_types[0] = AMMOSLOT
   WeakAuras.item_slot_types[16] = MAINHANDSLOT

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -1,4 +1,4 @@
-local internalVersion = 18;
+local internalVersion = 19;
 
 -- WoW APIs
 local GetTalentInfo, IsAddOnLoaded, InCombatLockdown = GetTalentInfo, IsAddOnLoaded, InCombatLockdown
@@ -3004,6 +3004,17 @@ function WeakAuras.Modernize(data)
               trigger.form = { single = value }
             end
           end
+        end
+      end
+    end
+  end
+
+  -- Version 19 were introduced in July 2019 in BFA
+  if data.internalVersion < 19 then
+    if data.triggers then
+      for triggerId, triggerData in ipairs(data.triggers) do
+        if triggerData.trigger.type == "status" and triggerData.trigger.event == "Cast" and triggerData.trigger.unit == "multi" then
+          triggerData.trigger.unit = "nameplate"
         end
       end
     end


### PR DESCRIPTION

They are filter filtered at the event registration level
Removed "multi" and added a migration to convert it to "nameplate", multi could be seen as listening to CLEUE which is confusing
There is a small regression between previous multi & new nameplate: nameplate listen to NAME_PLATE_UNIT_ADDED and NAME_PLATE_UNIT_REMOVED