### PR TITLE
Fix classic load condition + cast trigger hidding on buttons press

### DIFF
--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -4985,7 +4985,6 @@ WeakAuras.event_prototypes = {
       local result = {}
       AddUnitEventForEvents(result, trigger.unit, "UNIT_SPELLCAST_STOP")
       AddUnitEventForEvents(result, trigger.unit, "UNIT_SPELLCAST_INTERRUPTED")
-      AddUnitEventForEvents(result, trigger.unit, "UNIT_SPELLCAST_FAILED")
       AddUnitEventForEvents(result, trigger.unit, "UNIT_SPELLCAST_CHANNEL_STOP")
       if trigger.unit == "nameplate" then
         AddUnitEventForEvents(result, trigger.unit, "NAME_PLATE_UNIT_ADDED")
@@ -5061,7 +5060,6 @@ WeakAuras.event_prototypes = {
             if event == "UNIT_SPELLCAST_STOP"
             or event == "UNIT_SPELLCAST_CHANNEL_STOP"
             or event == "UNIT_SPELLCAST_INTERRUPTED"
-            or event == "UNIT_SPELLCAST_FAILED"
             or event == "NAME_PLATE_UNIT_REMOVED"
             then
               show = false

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -1934,8 +1934,13 @@ local function scanForLoadsImpl(self, event, arg1, ...)
     if (data and not data.controlledChildren) then
       local loadFunc = loadFuncs[id];
       local loadOpt = loadFuncsForOptions[id];
-      shouldBeLoaded = loadFunc and loadFunc("ScanForLoads_Auras", incombat, inencounter, warmodeActive, inpetbattle, vehicle, vehicleUi, group, player, realm, class, spec, race, faction, playerLevel, effectiveLevel, zone, zoneId, zonegroupId, encounter_id, size, difficulty, role, affixes);
-      couldBeLoaded =  loadOpt and loadOpt("ScanForLoads_Auras",   incombat, inencounter, warmodeActive, inpetbattle, vehicle, vehicleUi, group, player, realm, class, spec, race, faction, playerLevel, effectiveLevel, zone, zoneId, zonegroupId, encounter_id, size, difficulty, role, affixes);
+      if WeakAuras.IsClassic() then
+        shouldBeLoaded = loadFunc and loadFunc("ScanForLoads_Auras", incombat, inencounter, group, player, realm, class, spec, race, faction, playerLevel, zone, size);
+        couldBeLoaded =  loadOpt and loadOpt("ScanForLoads_Auras",   incombat, inencounter, group, player, realm, class, spec, race, faction, playerLevel, zone, size);
+      else
+        shouldBeLoaded = loadFunc and loadFunc("ScanForLoads_Auras", incombat, inencounter, warmodeActive, inpetbattle, vehicle, vehicleUi, group, player, realm, class, spec, race, faction, playerLevel, effectiveLevel, zone, zoneId, zonegroupId, encounter_id, size, difficulty, role, affixes);
+        couldBeLoaded =  loadOpt and loadOpt("ScanForLoads_Auras",   incombat, inencounter, warmodeActive, inpetbattle, vehicle, vehicleUi, group, player, realm, class, spec, race, faction, playerLevel, effectiveLevel, zone, zoneId, zonegroupId, encounter_id, size, difficulty, role, affixes);
+      end
 
       if(shouldBeLoaded and not loaded[id]) then
         changed = changed + 1;


### PR DESCRIPTION
# Description
- Load condition function was using incorrect number of args
- Cast trigger was incorrectly using UNIT_SPELLCAST_FAILED as untrigger
Fixes https://www.wowace.com/projects/weakauras-2#c2232