### PR TITLE
resort any region which is changed

### DIFF
--- a/WeakAuras/BuffTrigger.lua
+++ b/WeakAuras/BuffTrigger.lua
@@ -339,7 +339,6 @@ function WeakAuras.SetAuraVisibility(id, triggernum, cloneId, buffShowOn, unitEx
     end
 
     if (state.expirationTime ~= expirationTime) then
-      state.resort = true;
       state.expirationTime = expirationTime;
       state.changed = true;
     end
@@ -987,7 +986,6 @@ do
       end
 
       if (state.expirationTime ~= auradata.expirationTime) then
-        state.resort = state.expirationTime ~= auradata.expirationTime;
         state.expirationTime = auradata.expirationTime;
         state.changed = true;
       end

--- a/WeakAuras/BuffTrigger2.lua
+++ b/WeakAuras/BuffTrigger2.lua
@@ -483,7 +483,6 @@ local function UpdateStateWithMatch(time, bestMatch, triggerStates, cloneId, mat
 
     if state.expirationTime ~= bestMatch.expirationTime then
       state.expirationTime = bestMatch.expirationTime
-      state.resort = true
       changed = true
     end
 
@@ -626,7 +625,6 @@ local function UpdateStateWithNoMatch(time, triggerStates, triggerInfo, cloneId,
 
     if state.expirationTime ~= math.huge then
       state.expirationTime = math.huge
-      state.resort = true
       changed = true
     end
 

--- a/WeakAuras/GenericTrigger.lua
+++ b/WeakAuras/GenericTrigger.lua
@@ -382,7 +382,6 @@ function WeakAuras.ActivateEvent(id, triggernum, data, state, errorHandler)
   if (data.duration) then
     local expirationTime = GetTime() + data.duration;
     if (state.expirationTime ~= expirationTime) then
-      state.resort = state.expirationTime ~= expirationTime;
       state.expirationTime = expirationTime;
       changed = true;
     end
@@ -422,7 +421,6 @@ function WeakAuras.ActivateEvent(id, triggernum, data, state, errorHandler)
         changed = true;
       end
       if (state.expirationTime) then
-        state.resort = state.expirationTime ~= nil;
         state.expirationTime = nil;
         changed = true;
       end
@@ -450,7 +448,6 @@ function WeakAuras.ActivateEvent(id, triggernum, data, state, errorHandler)
         state.duration = arg1;
       end
       if (state.expirationTime ~= arg2) then
-        state.resort = state.expirationTime ~= arg2;
         state.expirationTime = arg2;
         changed = true;
       end
@@ -2590,7 +2587,6 @@ do
     state.name = bar.message
     state.expirationTime = bar.expirationTime + extendTimer
     state.progressType = 'timed'
-    state.resort = true
     state.duration = bar.duration + extendTimer
     state.timerType = bar.timerType
     state.spellId = bar.spellId
@@ -2749,7 +2745,6 @@ do
     state.emphasized = bar.emphasized
     state.count = bar.count
     state.cast = bar.cast
-    state.resort = true
     state.progressType = "timed"
     state.icon = bar.icon
     state.extend = extendTimer
@@ -3449,7 +3444,6 @@ function GenericTrigger.CreateFallbackState(data, triggernum, state)
       state.progressType = "timed";
       state.duration = 0;
       state.expirationTime = math.huge;
-      state.resort = nil;
       state.value = nil;
       state.total = nil;
       return;
@@ -3468,7 +3462,6 @@ function GenericTrigger.CreateFallbackState(data, triggernum, state)
     if (arg3) then
       state.progressType = "static";
       state.duration = nil;
-      state.resort = state.expirationTime ~= nil;
       state.expirationTime = nil;
       state.value = arg1;
       state.total = arg2;
@@ -3476,7 +3469,6 @@ function GenericTrigger.CreateFallbackState(data, triggernum, state)
     else
       state.progressType = "timed";
       state.duration = arg1;
-      state.resort = state.expirationTime ~= arg2;
       state.expirationTime = arg2;
       state.autoHide = nil;
       state.value = nil;
@@ -3487,7 +3479,6 @@ function GenericTrigger.CreateFallbackState(data, triggernum, state)
     state.progressType = "timed";
     state.duration = 0;
     state.expirationTime = math.huge;
-    state.resort = nil;
     state.value = nil;
     state.total = nil;
   end

--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -2376,12 +2376,10 @@ WeakAuras.event_prototypes = {
         ret = ret .. [=[
           if (state.expirationTime ~= expirationTime) then
             state.expirationTime = expirationTime;
-            state.resort = true;
             state.changed = true;
           end
           if (state.duration ~= duration) then
             state.duration = duration;
-            state.resort = true;
             state.changed = true;
           end
           state.progressType = 'timed';
@@ -2392,12 +2390,10 @@ WeakAuras.event_prototypes = {
           if (charges < trackedCharge) then
             if (state.value ~= duration) then
               state.value = duration;
-              state.resort = true;
               state.changed = true;
             end
             if (state.total ~= duration) then
               state.total = duration;
-              state.resort = true;
               state.changed = true;
             end
 
@@ -2407,12 +2403,10 @@ WeakAuras.event_prototypes = {
           elseif (charges > trackedCharge) then
             if (state.expirationTime ~= 0) then
               state.expirationTime = 0;
-              state.resort = true;
               state.changed = true;
             end
             if (state.duration ~= 0) then
               state.duration = 0;
-              state.resort = true;
               state.changed = true;
             end
             state.value = nil;
@@ -2422,12 +2416,10 @@ WeakAuras.event_prototypes = {
             if (state.expirationTime ~= expirationTime) then
               state.expirationTime = expirationTime;
               state.changed = true;
-              state.resort = true;
               state.changed = true;
             end
             if (state.duration ~= duration) then
               state.duration = duration;
-              state.resort = true;
               state.changed = true;
             end
             state.value = nil;
@@ -5127,7 +5119,6 @@ WeakAuras.event_prototypes = {
                 show = true,
                 changed = true,
                 inverse = castType == "cast",
-                resort = true
               }
               local duration = trigger_inverse and 0 or (endTime - startTime)/1000
               local expirationTime = trigger_inverse and math.huge or expirationTime
@@ -5141,7 +5132,6 @@ WeakAuras.event_prototypes = {
               then
                 state.show = false
                 state.changed = true
-                state.resort = true
               end
             end
           else

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -239,8 +239,6 @@ local triggerTypesOptions = WeakAuras.triggerTypesOptions;
 --  progressType: Either "timed", "static"
 --    duration: The duration if the progressType is timed
 --    expirationTime: The expirationTime if the progressType is timed
---    resort: Should be set to true by the trigger system the parent needs
---            to be resorted. The glue code resets this.
 --    autoHide: If the aura should be hidden on expiring
 --    value: The value if the progressType is static
 --    total: The total if the progressType is static
@@ -5212,7 +5210,6 @@ local function startStopTimers(id, cloneId, triggernum, state)
       local record = timers[id][triggernum][cloneId];
       if (state.expirationTime == nil) then
         state.expirationTime = GetTime() + state.duration;
-        state.resort = true;
       end
       if (record.expirationTime ~= state.expirationTime or record.state ~= state) then
         if (record.handle ~= nil) then
@@ -5266,8 +5263,7 @@ local function ApplyStateToRegion(id, cloneId, region, state, parent)
 
   WeakAuras.UpdateMouseoverTooltip(region);
   region:Expand();
-  if state.resort and parent and parent.ActivateChild then
-    state.resort = false;
+  if parent and parent.ActivateChild then
     parent:ActivateChild(id, cloneId)
   end
 end


### PR DESCRIPTION

This fixes a problem where trying to use a custom sort on e.g. a buff trigger that sorts by stacks doesn't properly keep the list sorted.
Reported on discord