### PR TITLE
Add history collection

### DIFF
--- a/WeakAuras/History.lua
+++ b/WeakAuras/History.lua
@@ -1,0 +1,93 @@
+--[[
+This file contains all of the interfaces to the history collection. Indexed by uid of the active display.
+
+History:
+  Table containing historical information about display:
+  source: string indicating where this data came from. Possible values:
+    "user": aura was created by the user via the WeakAuras interface
+    "import": aura was imported via WeakAuras.Import (i.e. pasted string or addon channel transmission)
+    "addon": aura was imported via WeakAuras.RegisterDisplay (i.e. an addon requested the addition)
+  data: snapshot of data as it was at last import, or nil if source == "user", and the user has not chosen to save their changes to history
+  addon: if source == "addon", then this string indicates which addon supplied the last import
+  skippedVersions: record of versions that the user has indicated they don't wish to see update notifications for
+  allowUpdates: if false, then WeakAuras will ignore any addon-sourced update requests
+  lastUpdate: UNIX timestamp of the last time the user completed an import for this display
+--]]
+
+local WeakAuras = WeakAuras
+local history -- history db upvalue
+
+function WeakAuras.LoadHistory(historydb, ageCutoff)
+  history = historydb
+  if ageCutoff then
+    WeakAuras.ClearOldHistory(ageCutoff)
+  end
+end
+
+function WeakAuras.SetHistory(uid, data, source, addon)
+  if uid and data then
+    history[uid] = history[uid] or {}
+    local hist = history[uid]
+    hist.data = data
+    hist.source = source
+    hist.addon = source == "addon" and (addon or "unknown") or nil
+    hist.skippedVersions = hist.skippedVersions or {}
+    hist.lastUpdate = time()
+    if hist.allowUpdates == nil then
+      hist.allowUpdates = true
+    end
+  end
+end
+
+function WeakAuras.GetHistory(uid)
+  return uid and history[uid]
+end
+
+function WeakAuras.RemoveHistory(uid)
+  if uid then
+    history[uid] = nil
+  end
+end
+
+function WeakAuras.AllowUpdates(uid, allowed)
+  local hist = WeakAuras.Gethistory(uid)
+  if hist then
+    hist.allowUpdates = allowed ~= false
+  end
+end
+
+function WeakAuras.IsUpdateAllowed(uid)
+  local hist = WeakAuras.GetHistory(uid)
+  return hist and hist.allowUpdates
+end
+
+function WeakAuras.SkipVersion(uid, version, skip)
+  local hist = WeakAuras.GetHistory(uid)
+  if hist then
+    hist.skippedVersions[version] = skip ~= false
+  end
+end
+
+function WeakAuras.IsVersionSkipped(uid, version)
+  local hist = WeakAuras.GetHistory(uid)
+  if hist then
+    return hist.skippedVersions[version]
+  end
+end
+
+function WeakAuras.RestoreFromHistory(uid)
+  local hist = WeakAuras.GetHistory(uid)
+  if hist and hist.data then
+    WeakAuras.Add(CopyTable(hist.data))
+  end
+end
+
+function WeakAuras.ClearOldHistory(daysBack, includeNonDeleted)
+  local cutoffTime = time() - ((daysBack or 30) * 86400) -- eighty six, four hundred seconds in a day...
+  for uid, hist in pairs(history) do
+    if (includeNonDeleted or not WeakAuras.GetDataByUID(uid))
+    and (hist.lastUpdate < cutoffTime) then
+      history[uid] = nil
+    end
+  end
+end

--- a/WeakAuras/WeakAuras.toc
+++ b/WeakAuras/WeakAuras.toc
@@ -22,23 +22,28 @@
 ## SavedVariables: WeakAurasSaved
 ## OptionalDeps: Ace3, LibCompress, LibSharedMedia-3.0, AceGUI-3.0-SharedMediaWidgets, Masque, GTFO, LibButtonGlow-1.0, LibSpellRange-1.0, LibRangeCheck-2.0, LibDBIcon-1.0, LibClassicDurations, LibClassicCast-1.0, LibGetFrame-1.0
 
-embeds.xml
-Init.lua
-
-locales.xml
-
 # If you add files here, you have to add them to babelfish.lua as well
 
+# external code + initialization
+embeds.xml
+Init.lua
+locales.xml
+
+# core files
 Prototypes.lua
 Types.lua
 Profiling.lua
 WeakAuras.lua
+History.lua
 Transmission.lua
+
+# trigger systems
 BuffTrigger.lua
 BuffTrigger2.lua
 GenericTrigger.lua
 AuraEnvironment.lua
 
+# region support
 RegionTypes\RegionPrototype.lua
 RegionTypes\ProgressTexture.lua
 RegionTypes\Texture.lua

--- a/babelfish.lua
+++ b/babelfish.lua
@@ -27,7 +27,8 @@ local fileList = {
         "WeakAuras/Transmission.lua",
         "WeakAuras/Types.lua",
         "WeakAuras/WeakAuras.lua",
-        "WeakAuras/SubRegionTypes/SubText.lua"
+        "WeakAuras/SubRegionTypes/SubText.lua",
+        "WeakAuras/History.lua"
     },
     WeakAuras_Options = {
         "WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasDisplayButton.lua",


### PR DESCRIPTION
# Description

History is a uid-indexed table containing historical information about displays:
  source: string indicating where this data came from. Possible values:
    "user": aura was created by the user via the WeakAuras interface
    "import": aura was imported via WeakAuras.Import (i.e. pasted string or addon channel transmission)
    "addon": aura was imported via WeakAuras.RegisterDisplay (i.e. an addon requested the addition)
  data: snapshot of data as it was at last import, or nil if source == "user", and the user has not chosen to save their changes to history
  addon: if source == "addon", then this string indicates which addon supplied the last import
  skippedVersions: record of versions that the user has indicated they don't wish to see update notifications for
  allowUpdates: if false, then WeakAuras will ignore any addon-sourced update requests
  lastUpdate: UNIX timestamp of the last time the user completed an import for this display

Additionally, enforce UID uniqueness for all auras in display. In the future this will be naturally enforced, once all systems have been migrated.
But for now, check on every addon load to ensure that the database is sane

## Type of change

- [x] New feature (non-breaking change which adds functionality)

