### PR TITLE
Multiunits

### DIFF
--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -1233,25 +1233,7 @@ local function AddUnitChangeInternalEvents(unit, t)
 end
 
 local function AddUnitEventForEvents(result, unit, event)
-  -- recursion for handling meta units
-  if unit == "boss" or unit == "arena" then
-    for i = 1, 5 do
-      AddUnitEventForEvents(result, unit .. i, event)
-    end
-  elseif unit == "nameplate" then
-    for i = 1, 40 do
-      AddUnitEventForEvents(result, "nameplate" .. i, event)
-    end
-  elseif unit == "group" then
-    AddUnitEventForEvents(result, "player", event)
-    for i = 1, 40 do
-      AddUnitEventForEvents(result, "raid" .. i, event)
-    end
-    for i = 1, 4 do
-      AddUnitEventForEvents(result, "party" .. i, event)
-    end
-  -- normal units
-  elseif not unit or not WeakAuras.baseUnitId[unit] then
+  if not unit or not (WeakAuras.baseUnitId[unit] or WeakAuras.multiUnitId[unit]) then
     if not result.events then
       result.events = {}
     end
@@ -5141,11 +5123,10 @@ WeakAuras.event_prototypes = {
           local localizedSpellName = %q
           local cloneId = ""
 
-          local multi_unit = trigger_unit == "nameplate" or trigger_unit == "group" or trigger_unit == "arena" or trigger_unit == "boss" and true or false
+          local multi_unit = WeakAuras.multiUnitId[trigger_unit] and true or false
           if multi_unit and trigger_clone and sourceUnit and UnitExists(sourceUnit) then
             cloneId = UnitGUID(sourceUnit)
           end
-
           if event == "PLAYER_TARGET_CHANGED"
           or event == "PLAYER_FOCUS_CHANGED"
           or (event == "WA_DELAYED_PLAYER_ENTERING_WORLD" and trigger_inverse)

--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -5101,6 +5101,10 @@ WeakAuras.event_prototypes = {
         LibClassicCast:RegisterCallback("UNIT_SPELLCAST_CHANNEL_START", WeakAuras.ScanEvents)
       end
       AddUnitEventForEvents(result, trigger.unit, "UNIT_TARGET")
+      if trigger.unit == "nameplate" then
+        AddUnitEventForEvents(result, trigger.unit, "NAME_PLATE_UNIT_ADDED")
+        AddUnitEventForEvents(result, trigger.unit, "NAME_PLATE_UNIT_REMOVED")
+      end
       if trigger.use_destUnit and trigger.destUnit and trigger.destUnit ~= "" then
         AddUnitEventForEvents(result, trigger.destUnit, "UNIT_TARGET")
       end

--- a/WeakAuras/Types.lua
+++ b/WeakAuras/Types.lua
@@ -2078,7 +2078,13 @@ WeakAuras.baseUnitId = {
   ["pet"] = true,
   ["focus"] = true,
   ["vehicle"] = true
-  -- ["mouseover"] = true
+}
+
+WeakAuras.multiUnitId = {
+  ["nameplate"] = true,
+  ["boss"] = true,
+  ["arena"] = true,
+  ["group"] = true,
 }
 
 for i = 1, 4 do

--- a/WeakAurasOptions/GenericTrigger.lua
+++ b/WeakAurasOptions/GenericTrigger.lua
@@ -169,7 +169,7 @@ local function GetCustomTriggerOptions(data, optionTriggerChoices, trigger)
               end
             elseif trueEvent:match("^UNIT_") then
               local unit = string.lower(i)
-              if not WeakAuras.baseUnitId[unit] then
+              if not WeakAuras.baseUnitId[unit] and not WeakAuras.multiUnitId[unit] then
                 return "|cFFFF0000"..L["Unit %s is not a valid unit for RegisterUnitEvent"]:format(unit)
               end
             end


### PR DESCRIPTION
# Description

 Allow usage of multi units (nameplate, boss, arena, group) by custom and generic triggers

exemple of event for a TSU: 

`UNIT_SPELLCAST_START:nameplate`


- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update
