### PR TITLE
make profiling data accessible from 3rd party

### DIFF
--- a/WeakAuras/Profiling.lua
+++ b/WeakAuras/Profiling.lua
@@ -6,6 +6,8 @@ local profileData = {}
 profileData.systems = {}
 profileData.auras = {}
 
+WeakAuras.profileData = profileData
+
 WeakAuras.table_to_string = function(tbl, depth)
   if depth and depth >= 3 then
     return "{ ... }"


### PR DESCRIPTION
# Description
This allow 3rd party addons to use WeakAuras profiling data

Example with Details "custom display"
```
1fv4kUnmm4xNEqAy7Vd2pcDJTeyDdCzhh3nruJvUAMJDWw(GXy(PzVj7fB2jnx7AVHi2ksF6tYFcEnSde(oNAKbH22H6y7g7WEKlsobpBh2ynmQmKlfP24z00rX23gBlllJnhRHTmQlY3JPtCWgm8eOxvC87zOsKXPu3s43Rco0xo6S9kn9UuMsmhj2eB6TUetP)QLP6Fk2QmX2ru58RYuCtIjBcx7SP6tykjno6jzAooqMtjxS1Rx8oolQoR5FNfb(ejlLk)Og)H)(5()TLa1z8xr7f60BQKYVI6qsLw9ZRrFPzWHz9C5TEvf)Q4S32nNYtgzSz6i2C2cyISlNPpq8UmKkJ8JQhpqEEAexLO7ST1lu12WqvhBtQEUZnoIdoZ)zH3CYabg4dwhi2QK4F(9678wJ0rGqs(oqaIS2dIAdtUESJEOEZN3kEy37)0xarwtaXZlLy70vItMDQ9bMG9GGr3Jep5zTAwncI5o7hjTwjZz82GRlJMb4V
```
and
```
1f1FRTrmm0VoPW1JU)DW(Jq2ylh00coSrHI4uoRKyQp7dB5cJr9NM(nzFXM8LFsshIZNXVNE6jj4tWsqf7cMbguwFhAZTZ89RqUsUKISVFM3XOXrb5L5UiJUok3(LCBDDDUzFoSNrBv5)GCI9(KJhjDx1(VJu1iJJq)IWxMMcySEi4xBS0xfK64VJm1hZn5M1(GOLWyUwu41CRXLBhqtioPiYnIwEHx7UWSw4utwCisAXjBj3jWdXfT0NNQ1)eTjPHM8NRzFz4W(DT(btDvgVvDMjU5eo505MXJCZzZQrXU0tFN4LfktD6Fy2SLI8OfNiYD2G9dYArQFAh7LXtPYnbItb3)z3i4Gct8wFaulmA8VVF7trVthiqPPyhOeCMdMvjMGvGQ08G64sl3Q2TPaLPZ7a1ChtH1yh988zpSq98YVD)JGIXWgIl5ZEVLndGAxTJdK1A0fKOpf6k1Gb4F)
```

Result:
![img](https://i.imgur.com/YVSnE7S.png)

Maybe it's possible to make a details plugin to add these "custom displays" without the need to import it manually.
### **These 2 examples are not perfect, and i'm not 100% sure i do it the right way.**


## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update