### PR TITLE
Classic fixes

### DIFF
--- a/.pkgmeta-classic
+++ b/.pkgmeta-classic
@@ -19,6 +19,7 @@ externals:
  WeakAuras/Libs/LibDBIcon-1.0: https://repos.wowace.com/wow/libdbicon-1-0/trunk/LibDBIcon-1.0
  WeakAuras/Libs/LibClassicDurations: git://github.com/rgd87/LibClassicDurations.git
  WeakAuras/Libs/LibClassicCast: git://github.com/joev/LibClassicCast.git
+ WeakAuras/Libs/LibGetFrame-1.0: https://github.com/mrbuds/LibGetFrame
 
 enable-nolib-creation: no
 

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -1868,7 +1868,7 @@ local function scanForLoadsImpl(self, event, arg1, ...)
   end
 
   local player, realm, spec, zone = UnitName("player"), GetRealmName(), WeakAuras.IsClassic() and 1 or GetSpecialization(), GetRealZoneText();
-  local specId = GetSpecializationInfo(spec)
+  local specId = not WeakAuras.IsClassic() and GetSpecializationInfo(spec)
   local zoneId = C_Map.GetBestMapForUnit("player")
   local zonegroupId = zoneId and C_Map.GetMapGroupID(zoneId)
   local _, race = UnitRace("player")

--- a/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasDisplayButton.lua
+++ b/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasDisplayButton.lua
@@ -513,7 +513,11 @@ local methods = {
         if(editbox) then
           if (not fullName) then
             local name, realm = UnitFullName("player")
-            fullName = name.."-"..realm
+            if realm then
+              fullName = name.."-"..realm
+            else
+              fullName = name
+            end
           end
           editbox:Insert("[WeakAuras: "..fullName.." - "..data.id.."]");
         elseif not data.controlledChildren then


### PR DESCRIPTION
Fix 2 issues

But on sandbox currently weakauras is not usable due to a bug in ace3

```
1x ...nfig-3.0\AceConfigDialog-3.0\AceConfigDialog-3.0-77.lua:567: CreateFrame(): Couldn't find inherited node "DialogBorderDarkTemplate"
[C]: in function `CreateFrame'
...nfig-3.0\AceConfigDialog-3.0\AceConfigDialog-3.0-77.lua:567: in main chunk

Locals:
(*temporary) = "Frame"
(*temporary) = nil
(*temporary) = <unnamed> {
 0 = <userdata>
}
(*temporary) = "DialogBorderDarkTemplate"
```