### PR TITLE
fix import error with escape from < and >

### DIFF
--- a/babelfish.lua
+++ b/babelfish.lua
@@ -95,6 +95,13 @@ local function parseFile(filename)
     return strings
 end
 
+-- escape < and > for import
+local function getJsonFormattedString(s)
+    s = string.gsub(s, "<", "\\<")
+    s = string.gsub(s, ">", "\\>")
+    return s
+end
+
 -- extract data from specified lua files
 for _, namespace in ipairs(ordered) do
     print(namespace)
@@ -109,7 +116,7 @@ for _, namespace in ipairs(ordered) do
         table.sort(sorted)
         if #sorted > 0 then
             for _, v in ipairs(sorted) do
-                ns_file:write(string.format("L[\"%s\"] = true\n", v))
+                ns_file:write(string.format("L[\"%s\"] = true\n", getJsonFormattedString(v)))
             end
         end
         print("  (" .. #sorted .. ") " .. file)


### PR DESCRIPTION
# Description

The signs `<` and `>` break the json import string (error 500).
Escape them fix the problem.
https://travis-ci.org/WeakAuras/WeakAuras2/builds/568530798#L267

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Tested the babelfish.lua itself
- Import tested with an test string ">><>Test<><<" ( on another project )
- Export with bigwigs packager ( on another project )