### PR TITLE
classic: removed "Spell Activation Overlay" trigger

### DIFF
--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -6061,6 +6061,7 @@ if WeakAuras.IsClassic() then
   WeakAuras.event_prototypes["Alternate Power"] = nil
   WeakAuras.event_prototypes["Equipment Set"] = nil
   WeakAuras.event_prototypes["Range Check"] = nil
+  WeakAuras.event_prototypes["Spell Activation Overlay"] = nil
 end
 
 WeakAuras.dynamic_texts = {


### PR DESCRIPTION
events SPELL_ACTIVATION_OVERLAY_GLOW_SHOW* doesnt exists on classic