### PR TITLE
Cooldown Spell trigger: guard against nil error when copying aura from retail to classic

### DIFF
--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -2610,7 +2610,7 @@ WeakAuras.event_prototypes = {
         test = "true",
         conditionType = "bool",
         conditionTest = function(state, needle)
-          return state and state.show and (UnitExists('target') and WeakAuras.IsSpellInRange(state.spellname, 'target') == needle)
+          return state and state.show and (UnitExists('target') and state.spellname and WeakAuras.IsSpellInRange(state.spellname, 'target') == needle)
         end,
         conditionEvents = {
           "PLAYER_TARGET_CHANGED",


### PR DESCRIPTION
fix error when importing a cooldown spell trigger for a spell that doesn't exists
![img](https://cdn.discordapp.com/attachments/218087027042811905/609432160650395666/Screenshot_1.png)