### PR TITLE
enhance parent-child validation

### DIFF
--- a/WeakAuras/Transmission.lua
+++ b/WeakAuras/Transmission.lua
@@ -287,9 +287,9 @@ local function install(data, oldData, patch, mode, isParent)
     -- always import as a new thing
     if data then
       imported = CopyTable(data)
-      installedUID = data.uid
       data.id = WeakAuras.FindUnusedId(data.id)
       WeakAuras.Add(data)
+      installedUID = data.uid
     else
       -- nothing to add
       return
@@ -301,9 +301,9 @@ local function install(data, oldData, patch, mode, isParent)
       return
     end
     imported = CopyTable(data)
-    installedUID = data.uid
     data.id = WeakAuras.FindUnusedId(data.id)
     WeakAuras.Add(data)
+    installedUID = data.uid
   elseif not data then
     -- this is an old thing
     if checkButtons.oldchildren:GetChecked() then

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -3464,10 +3464,11 @@ function WeakAuras.SyncParentChildRelationships(silent)
     if data.parent then
       if data.controlledChildren then
         if not silent then
-          prettyPrint("detected corruption in saved variables: "..id.." has both child and parent.")
+          prettyPrint("detected corruption in saved variables: "..id.." is a group that thinks it's a parent.")
         end
         -- A display cannot have both children and a parent
         data.parent = nil
+        parents[id] = data
       elseif not db.displays[data.parent] then
         if not(silent) then
           prettyPrint("detected corruption in saved variables: "..id.." has a nonexistent parent.")


### PR DESCRIPTION
# Description

Once upon a time, there was an addon called SpeedrunSplits.
It was a good addon, used by many, in oldschool WoW.
Then, Blizzard decided to make oldschool WoW new again, and a lot of people were very happy.
The author of SpeedrunSplits decided to make his addon available for Clasasic WoW, and again, a lot of people were very happy.
But then, it was  covered that SpeedrunSplits broke the WeakAuras database accidentally, and a lot of people were very sad.
So, we the developers of WeakAuras will make the database more robust against what broke,
And hopefully people will be happy again.

...More seriously, the bug here was that SpeedrunSplits was replacing the tContains function with another
which had incompatible behavior, thus confusing SyncParentChildRelationships into thinking that groups
were corrupted. This issue has been fixed in SpeedrunSplits beta 2.4 and later, but the damage to the database remains.
So, improve SyncParentChildRelationships to detect the damage and repair it.
Also incidentally remove the vulnerability in the first place.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

basic smoke testing