### PR TITLE
allow string custom option to give a multiline edit box

### DIFF
--- a/WeakAuras/Types.lua
+++ b/WeakAuras/Types.lua
@@ -1947,6 +1947,7 @@ WeakAuras.author_option_fields = {
     default = "",
     useLength = false,
     length = 10,
+    multiline = false,
   },
   toggle = {
     default = false,

--- a/WeakAurasOptions/AuthorOptions.lua
+++ b/WeakAurasOptions/AuthorOptions.lua
@@ -530,6 +530,15 @@ typeControlAdders = {
         return not option.useLength
       end
     }
+    args["prefix" .. "multiline"] = {
+      type = "toggle",
+      width = WeakAuras.doubleWidth,
+      name = name(option, "multiline", L["Large Input"]),
+      desc = desc(option, "multiline", L["If checked, then the user will see a multi line edit box. This is useful for inputting large amounts of text."]),
+      order = order(),
+      get = get(option, "multiline"),
+      set = set(data, option, "multiline"),
+    }
   end,
   number = function(options, args, data, order, prefix, i)
     local option = options[i]
@@ -1887,6 +1896,7 @@ local function addUserModeOption(options, args, data, order, prefix, i)
       userOption.type = "input"
       userOption.get = getUserNumAsString(option)
       userOption.set = setUserNum(data, option, true)
+      userOption.multiline = option.multiline
     elseif optionType == "range" then
       userOption.softMax = option.softMax
       userOption.softMin = option.softMin


### PR DESCRIPTION
# Description

Fixes #1566

## Type of change

- [x] New feature (non-breaking change which adds functionality)
