### PR TITLE
default to height of 1

### DIFF
--- a/WeakAurasOptions/AuthorOptions.lua
+++ b/WeakAurasOptions/AuthorOptions.lua
@@ -1960,7 +1960,7 @@ local function addUserModeOption(options, args, data, order, prefix, i)
       if not option.variableWidth then
         userOption.width = "full"
       end
-      if option.useHeight and option.height > 1 then
+      if option.useHeight and (option.height or 1) > 1 then
         userOption.name = string.rep("\n", option.height - 1)
       else
         userOption.name = " "


### PR DESCRIPTION
Sometimes options might be merged with differing heights.
So resolve this by using 1 as the default height
