### PR TITLE
fix migration

### DIFF
--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -3217,7 +3217,7 @@ function WeakAuras.Modernize(data)
 
       local text1 = {
         ["type"] = "subtext",
-        text_visible = data.text1Enabled or true,
+        text_visible = data.text1Enabled ~= false,
         text_color = data.text1Color,
         text_text = data.text1,
         text_font = data.text1Font,


### PR DESCRIPTION
Presumably this was done to eliminate nils here. But `false or true` evaluates to true, so anybody who disabled text1 on icons will wake up to a nasty surprise.