### PR TITLE
don't load environment of children for custom anchor function

### DIFF
--- a/WeakAuras/AuraEnvironment.lua
+++ b/WeakAuras/AuraEnvironment.lua
@@ -137,6 +137,10 @@ function WeakAuras.ClearAuraEnvironment(id)
   environment_initialized[id] = false;
 end
 
+-- environment_initialized can have the values:
+-- * false/nil => not initialized
+-- * 1 => initialized without children
+-- * 2 => initialized with children
 function WeakAuras.ActivateAuraEnvironment(id, cloneId, state, states, skipChildren)
   local data = WeakAuras.GetData(id)
   local region = WeakAuras.GetRegion(id, cloneId)
@@ -145,7 +149,7 @@ function WeakAuras.ActivateAuraEnvironment(id, cloneId, state, states, skipChild
     tremove(aura_env_stack)
     current_aura_env = aura_env_stack[#aura_env_stack] or nil
   else
-    if environment_initialized[id] then
+    if environment_initialized[id] == 2 or (environment_initialized[id] == 1 and skipChildren) then
       -- Point the current environment to the correct table
       current_aura_env = aura_environments[id]
       current_aura_env.id = id
@@ -157,7 +161,8 @@ function WeakAuras.ActivateAuraEnvironment(id, cloneId, state, states, skipChild
       tinsert(aura_env_stack, current_aura_env)
     else
       -- Either this aura environment has not yet been initialized, or it was reset via an edit in WeakaurasOptions
-      environment_initialized[id] = true
+      -- or it wasn't yet initialized to the full extent needed
+      environment_initialized[id] = skipChildren and 1 or 2
       aura_environments[id] = {}
       current_aura_env = aura_environments[id]
       current_aura_env.id = id

--- a/WeakAuras/AuraEnvironment.lua
+++ b/WeakAuras/AuraEnvironment.lua
@@ -137,10 +137,6 @@ function WeakAuras.ClearAuraEnvironment(id)
   environment_initialized[id] = false;
 end
 
--- environment_initialized can have the values:
--- * false/nil => not initialized
--- * 1 => initialized without children
--- * 2 => initialized with children
 function WeakAuras.ActivateAuraEnvironment(id, cloneId, state, states, skipChildren)
   local data = WeakAuras.GetData(id)
   local region = WeakAuras.GetRegion(id, cloneId)
@@ -149,7 +145,7 @@ function WeakAuras.ActivateAuraEnvironment(id, cloneId, state, states, skipChild
     tremove(aura_env_stack)
     current_aura_env = aura_env_stack[#aura_env_stack] or nil
   else
-    if environment_initialized[id] == 2 or (environment_initialized[id] == 1 and skipChildren) then
+    if environment_initialized[id] then
       -- Point the current environment to the correct table
       current_aura_env = aura_environments[id]
       current_aura_env.id = id
@@ -161,8 +157,7 @@ function WeakAuras.ActivateAuraEnvironment(id, cloneId, state, states, skipChild
       tinsert(aura_env_stack, current_aura_env)
     else
       -- Either this aura environment has not yet been initialized, or it was reset via an edit in WeakaurasOptions
-      -- or it wasn't yet initialized to the full extent needed
-      environment_initialized[id] = skipChildren and 1 or 2
+      environment_initialized[id] = true
       aura_environments[id] = {}
       current_aura_env = aura_environments[id]
       current_aura_env.id = id

--- a/WeakAuras/AuraEnvironment.lua
+++ b/WeakAuras/AuraEnvironment.lua
@@ -137,7 +137,7 @@ function WeakAuras.ClearAuraEnvironment(id)
   environment_initialized[id] = false;
 end
 
-function WeakAuras.ActivateAuraEnvironment(id, cloneId, state, states)
+function WeakAuras.ActivateAuraEnvironment(id, cloneId, state, states, skipChildren)
   local data = WeakAuras.GetData(id)
   local region = WeakAuras.GetRegion(id, cloneId)
   if not data then
@@ -168,7 +168,7 @@ function WeakAuras.ActivateAuraEnvironment(id, cloneId, state, states)
       -- push new environment onto the stack
       tinsert(aura_env_stack, current_aura_env)
 
-      if data.controlledChildren then
+      if data.controlledChildren and not skipChildren then
         current_aura_env.child_envs = {}
         for dataIndex, childID in ipairs(data.controlledChildren) do
           local childData = WeakAuras.GetData(childID)

--- a/WeakAuras/AuraEnvironment.lua
+++ b/WeakAuras/AuraEnvironment.lua
@@ -137,7 +137,7 @@ function WeakAuras.ClearAuraEnvironment(id)
   environment_initialized[id] = false;
 end
 
-function WeakAuras.ActivateAuraEnvironment(id, cloneId, state, states, skipChildren)
+function WeakAuras.ActivateAuraEnvironment(id, cloneId, state, states)
   local data = WeakAuras.GetData(id)
   local region = WeakAuras.GetRegion(id, cloneId)
   if not data then
@@ -168,7 +168,7 @@ function WeakAuras.ActivateAuraEnvironment(id, cloneId, state, states, skipChild
       -- push new environment onto the stack
       tinsert(aura_env_stack, current_aura_env)
 
-      if data.controlledChildren and not skipChildren then
+      if data.controlledChildren then
         current_aura_env.child_envs = {}
         for dataIndex, childID in ipairs(data.controlledChildren) do
           local childData = WeakAuras.GetData(childID)

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -6432,12 +6432,12 @@ local function GetAnchorFrame(region, anchorFrameType, parent, anchorFrameFrame)
 
   if (anchorFrameType == "CUSTOM" and region.customAnchorFunc) then
     WeakAuras.StartProfileSystem("custom region anchor")
-    WeakAuras.StartProfileAura(id)
-    WeakAuras.ActivateAuraEnvironment(id, region.cloneId, region.state, nil, true)
+    WeakAuras.StartProfileAura(region.id)
+    WeakAuras.ActivateAuraEnvironment(region.id, region.cloneId, region.state)
     local ok, frame = xpcall(region.customAnchorFunc, geterrorhandler())
     WeakAuras.ActivateAuraEnvironment()
     WeakAuras.StopProfileSystem("custom region anchor")
-    WeakAuras.StopProfileAura(id)
+    WeakAuras.StopProfileAura(region.id)
     if ok and frame then
       return frame
     elseif WeakAuras.IsOptionsOpen() then

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -6450,25 +6450,37 @@ local function GetAnchorFrame(region, anchorFrameType, parent, anchorFrameFrame)
   return parent;
 end
 
+local anchorFrameDeferred = {}
+
 function WeakAuras.AnchorFrame(data, region, parent)
-  local anchorParent = GetAnchorFrame(region, data.anchorFrameType, parent, data.anchorFrameFrame);
-  if not anchorParent then return end
-  if (data.anchorFrameParent or data.anchorFrameParent == nil
-      or data.anchorFrameType == "SCREEN" or data.anchorFrameType == "MOUSE" or data.anchorFrameType == "CUSTOM") then
-    local errorhandler = function(text)
-      geterrorhandler()(L["'ERROR: Anchoring %s': \n"]:format(data.id) .. text)
+  if data.anchorFrameType == "CUSTOM"
+  and (data.regionType == "group" or data.regionType == "dynamicgroup")
+  and not WeakAuras.IsLoginFinished()
+  and not anchorFrameDeferred[data.id]
+  then
+    loginQueue[#loginQueue + 1] = {WeakAuras.AnchorFrame, {data, region, parent}}
+    anchorFrameDeferred[data.id] = true
+  else
+    local anchorParent = GetAnchorFrame(region, data.anchorFrameType, parent, data.anchorFrameFrame);
+    if not anchorParent then return end
+    if (data.anchorFrameParent or data.anchorFrameParent == nil
+        or data.anchorFrameType == "SCREEN" or data.anchorFrameType == "MOUSE" or data.anchorFrameType == "CUSTOM") then
+      local errorhandler = function(text)
+        geterrorhandler()(L["'ERROR: Anchoring %s': \n"]:format(data.id) .. text)
+      end
+      xpcall(region.SetParent, errorhandler, region, anchorParent);
+    else
+      region:SetParent(frame);
     end
-    xpcall(region.SetParent, errorhandler, region, anchorParent);
-  else
-    region:SetParent(frame);
-  end
 
-  region:SetAnchor(data.selfPoint, anchorParent, data.anchorPoint);
+    region:SetAnchor(data.selfPoint, anchorParent, data.anchorPoint);
 
-  if(data.frameStrata == 1) then
-    region:SetFrameStrata(region:GetParent():GetFrameStrata());
-  else
-    region:SetFrameStrata(WeakAuras.frame_strata_types[data.frameStrata]);
+    if(data.frameStrata == 1) then
+      region:SetFrameStrata(region:GetParent():GetFrameStrata());
+    else
+      region:SetFrameStrata(WeakAuras.frame_strata_types[data.frameStrata]);
+    end
+    anchorFrameDeferred[data.id] = nil
   end
 end
 

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -6432,12 +6432,12 @@ local function GetAnchorFrame(region, anchorFrameType, parent, anchorFrameFrame)
 
   if (anchorFrameType == "CUSTOM" and region.customAnchorFunc) then
     WeakAuras.StartProfileSystem("custom region anchor")
-    WeakAuras.StartProfileAura(region.id)
-    WeakAuras.ActivateAuraEnvironment(region.id, region.cloneId, region.state)
+    WeakAuras.StartProfileAura(id)
+    WeakAuras.ActivateAuraEnvironment(id, region.cloneId, region.state, nil, true)
     local ok, frame = xpcall(region.customAnchorFunc, geterrorhandler())
     WeakAuras.ActivateAuraEnvironment()
     WeakAuras.StopProfileSystem("custom region anchor")
-    WeakAuras.StopProfileAura(region.id)
+    WeakAuras.StopProfileAura(id)
     if ok and frame then
       return frame
     elseif WeakAuras.IsOptionsOpen() then


### PR DESCRIPTION
fix #1622

Custom anchor function is run on group's Add, before children are added
It activate environment for the group which activate environment for it's children, but that don't work because they are not added yet.

This skip activating environment for group children for this custom function.