### PR TITLE
fix "fallback" regionType

### DIFF
--- a/WeakAuras/RegionTypes/Text.lua
+++ b/WeakAuras/RegionTypes/Text.lua
@@ -257,6 +257,8 @@ local function fallbackmodify(parent, region, data)
   region:SetWidth(text:GetWidth());
   region:SetHeight(text:GetStringHeight());
 
+  region.Update = function() end
+
   WeakAuras.regionPrototype.modifyFinish(parent, region, data);
 end
 

--- a/WeakAuras/Transmission.lua
+++ b/WeakAuras/Transmission.lua
@@ -361,8 +361,10 @@ local function importPendingData()
   -- cleanup the mess
   ItemRefTooltip:Hide()-- this also wipes pendingData via the hook on L521
   buttonAnchor:Hide()
-  thumbnailAnchor.currentThumbnail:Hide()
-  thumbnailAnchor.currentThumbnail = nil
+  if thumbnailAnchor.currentThumbnail then
+    thumbnailAnchor.currentThumbnail:Hide()
+    thumbnailAnchor.currentThumbnail = nil
+  end
   if imports and WeakAuras.LoadOptions() then
     WeakAuras.ShowOptions()
   else
@@ -1671,24 +1673,26 @@ function WeakAuras.ShowDisplayTooltip(data, children, matchInfo, icon, icons, im
     thumbnailAnchor.currentThumbnail:Hide()
     thumbnailAnchor.currentThumbnail = nil
   end
-  local ok,thumbnail = pcall(regionOptions[regionType].createThumbnail, thumbnailAnchor);
-  if not ok then
-    error("Error creating thumbnail", 2)
-  end
-  pcall(regionOptions[regionType].modifyThumbnail, thumbnailAnchor, thumbnail, data)
-  thumbnailAnchor.currentThumbnail = thumbnail
-  thumbnail:SetAllPoints(thumbnailAnchor);
-  if (thumbnail.SetIcon) then
-    local i;
-    if(icon) then
-      i = icon;
-    elseif(WeakAuras.transmitCache and WeakAuras.transmitCache[data.id]) then
-      i = WeakAuras.transmitCache[data.id];
+  if regionOptions[regionType] then
+    local ok,thumbnail = pcall(regionOptions[regionType].createThumbnail, thumbnailAnchor);
+    if not ok then
+      error("Error creating thumbnail", 2)
     end
-    if (i) then
-      thumbnail:SetIcon(i);
-    else
-      thumbnail:SetIcon();
+    pcall(regionOptions[regionType].modifyThumbnail, thumbnailAnchor, thumbnail, data)
+    thumbnailAnchor.currentThumbnail = thumbnail
+    thumbnail:SetAllPoints(thumbnailAnchor);
+    if (thumbnail.SetIcon) then
+      local i;
+      if(icon) then
+        i = icon;
+      elseif(WeakAuras.transmitCache and WeakAuras.transmitCache[data.id]) then
+        i = WeakAuras.transmitCache[data.id];
+      end
+      if (i) then
+        thumbnail:SetIcon(i);
+      else
+        thumbnail:SetIcon();
+      end
     end
   end
   WeakAuras.GetData = RegularGetData or WeakAuras.GetData

--- a/WeakAurasOptions/WeakAurasOptions.lua
+++ b/WeakAurasOptions/WeakAurasOptions.lua
@@ -2667,6 +2667,8 @@ function WeakAuras.AddOption(id, data)
   else
     regionOption = {
       [data.regionType] = {
+        __title = "|cFFFFFF00" .. data.regionType,
+        __order = 1,
         unsupported = {
           type = "description",
           name = L["This region of type \"%s\" is not supported."]:format(data.regionType),
@@ -3388,6 +3390,8 @@ function WeakAuras.ReloadTriggerOptions(data)
     else
       regionOption = {
         [data.regionType] = {
+          __title = "|cFFFFFF00" .. data.regionType,
+          __order = 1,
           unsupported = {
             type = "description",
             name = L["This region of type \"%s\" is not supported."]:format(data.regionType)


### PR DESCRIPTION
Importing a model or a group including one break weakauras

This prevent importing an aura of an unsupported region, but doesn't fix the issue if there is already one imported. I have not found a proper solution for this