### PR TITLE
Fix Weapon Enchantment Trigger

### DIFF
--- a/WeakAuras/GenericTrigger.lua
+++ b/WeakAuras/GenericTrigger.lua
@@ -2922,7 +2922,7 @@ do
 
       local function tenchUpdate()
         WeakAuras.StartProfileSystem("generictrigger");
-        local _, mh_rem, _, _, oh_rem = GetWeaponEnchantInfo();
+        local _, mh_rem, _, _, _, oh_rem = GetWeaponEnchantInfo();
         local time = GetTime();
         local mh_exp_new = mh_rem and (time + (mh_rem / 1000));
         local oh_exp_new = oh_rem and (time + (oh_rem / 1000));


### PR DESCRIPTION
# Description

With classic release Weapon Enchantment is used again, currently the trigger doesn't return stacks information (like number of poison stacks for rogue) and duration on offhand is wrong.

I currently fixed the duration problem for the offhand, and I'm working on adding stacks information on the trigger.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Not been tested yet.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
