### PR TITLE
Add Experimental Repair Tool

### DIFF
--- a/WeakAuras/History.lua
+++ b/WeakAuras/History.lua
@@ -4,10 +4,12 @@ This file contains all of the interfaces to the history collection. Indexed by u
 History:
   Table containing historical information about display:
   source: string indicating where this data came from. Possible values:
-    "user": aura was created by the user via the WeakAuras interface
     "import": aura was imported via WeakAuras.Import (i.e. pasted string or addon channel transmission)
     "addon": aura was imported via WeakAuras.RegisterDisplay (i.e. an addon requested the addition)
+    "auto": history created automatically due to database management
   data: snapshot of data as it was at last import, or nil if source == "user", and the user has not chosen to save their changes to history
+  migration: snapshot of data as it was at last automatic data upgrade. Repair tool will restore this data to active status
+  lastMigrated: UNIX timestamp of the last time this aura was automatically upgraded
   addon: if source == "addon", then this string indicates which addon supplied the last import
   skippedVersions: record of versions that the user has indicated they don't wish to see update notifications for
   allowUpdates: if false, then WeakAuras will ignore any addon-sourced update requests
@@ -18,11 +20,12 @@ if not WeakAuras.IsCorrectVersion() then return end
 local WeakAuras = WeakAuras
 local history -- history db upvalue
 
-function WeakAuras.LoadHistory(historydb, ageCutoff)
+function WeakAuras.LoadHistory(historydb, ageCutoff, migrationExpiry)
   history = historydb
-  if ageCutoff then
+  if ageCutoff ~= false then
     WeakAuras.ClearOldHistory(ageCutoff)
   end
+  WeakAuras.ClearOldMigrations(migrationExpiry)
 end
 
 function WeakAuras.SetHistory(uid, data, source, addon)
@@ -37,6 +40,7 @@ function WeakAuras.SetHistory(uid, data, source, addon)
     if hist.allowUpdates == nil then
       hist.allowUpdates = true
     end
+    return hist
   end
 end
 
@@ -89,6 +93,31 @@ function WeakAuras.ClearOldHistory(daysBack, includeNonDeleted)
     if (includeNonDeleted or not WeakAuras.GetDataByUID(uid))
     and (hist.lastUpdate < cutoffTime) then
       history[uid] = nil
+    end
+  end
+end
+
+function WeakAuras.SetMigrationSnapshot(uid, oldData)
+  local hist = WeakAuras.GetHistory(uid) or WeakAuras.SetHistory(uid, oldData, "auto")
+  if hist and oldData then
+    hist.migration = oldData
+    hist.lastMigrated = time()
+  end
+end
+
+function WeakAuras.GetMigrationSnapshot(uid)
+  local hist = WeakAuras.GetHistory(uid)
+  if hist then
+    return hist.migration
+  end
+end
+
+function WeakAuras.ClearOldMigrations(daysBack)
+  local cutoffTime = time() - ((daysBack or 14) * 86400)
+  for _, hist in pairs(history) do
+    if not hist.lastMigrated or hist.lastMigrated < cutoffTime then
+      hist.migration = nil
+      hist.lastMigrated = nil
     end
   end
 end

--- a/WeakAuras/Locales/enUS.lua
+++ b/WeakAuras/Locales/enUS.lua
@@ -7,3 +7,15 @@ setmetatable(WeakAuras.L, {__index = function(self, key)
   self[key] = (key or "")
   return key
 end})
+
+L["Automatic Repair Confirmation Dialog"] = [[
+WeakAuras has detected that it has been downgraded.
+Your saved auras may no longer work properly.
+
+Would you like to run the |cffff0000EXPERIMENTAL|r repair tool? This will overwrite any changes you have made since the last database upgrade.
+Last upgrade: %s]]
+
+L["Manual Repair Confirmation Dialog"] = [[
+Are you sure you want to run the |cffff0000EXPERIMENTAL|r repair tool?
+This will overwrite any changes you have made since the last database upgrade.
+Last upgrade: %s]]

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -1503,7 +1503,7 @@ Broker_WeakAuras = LDB:NewDataObject("WeakAuras", {
   iconB = 1
 });
 
-local loginFinished, loginMessage = false, L["Options will finish loading after the login process has completed."]
+local loginFinished, loginMessage = false, L["Options will open after the login process has completed."]
 
 function WeakAuras.IsLoginFinished()
   return loginFinished
@@ -1522,6 +1522,8 @@ function WeakAuras.Login(initialTime, takeNewSnapshots)
   local loginThread = coroutine.create(function()
     WeakAuras.Pause();
     local toAdd = {};
+    loginFinished = false
+    loginMessage = L["Options will open after the login process has completed."]
     for id, data in pairs(db.displays) do
       if(id ~= data.id) then
         print("|cFF8800FFWeakAuras|r detected a corrupt entry in WeakAuras saved displays - '"..tostring(id).."' vs '"..tostring(data.id).."'" );
@@ -2630,7 +2632,7 @@ function WeakAuras.ResolveCollisions(onFinished)
     end);
     popup.editBox:SetText(currentId);
     popup.text:SetJustifyH("left");
-    popup.icon:SetTexture("Interface\\Aweddons\\WeakAuras\\Media\\Textures\\icon.blp");
+    popup.icon:SetTexture("Interface\\Addons\\WeakAuras\\Media\\Textures\\icon.blp");
     popup.icon:SetVertexColor(0.833, 0, 1);
 
     UpdateText(popup);

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -2680,7 +2680,6 @@ function WeakAuras.RepairDatabase(loginAfter)
     WeakAuras.SetImporting(true)
     -- set db version to current code version
     db.dbVersion = WeakAuras.InternalVersion()
-    db.lastUpgrade = time()
     -- reinstall snapshots from history
     for id, data in pairs(db.displays) do
       local snapshot = WeakAuras.GetMigrationSnapshot(data.uid)

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -1627,9 +1627,9 @@ loadedFrame:SetScript("OnEvent", function(self, event, addon)
       WeakAuras.dynFrame:AddAction('login', loginThread)
     end
     if not ok then
-    loginMessage = L["WeakAuras has encountered an error during the login process. Please report this issue at https://github.com/WeakAuras/Weakauras2/issues/new."]
-      .. "\nMessage:" .. msg
-      geterrorhandler()(msg .. '\n' .. debugstack(loginThread))
+      loginMessage = L["WeakAuras has encountered an error during the login process. Please report this issue at https://github.com/WeakAuras/Weakauras2/issues/new."]
+        .. "\nMessage:" .. msg
+        geterrorhandler()(msg .. '\n' .. debugstack(loginThread))
     end
   elseif(event == "LOADING_SCREEN_ENABLED") then
     in_loading_screen = true;

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -2644,16 +2644,16 @@ end
 StaticPopupDialogs["WEAKAURAS_CONFIRM_REPAIR"] = {
   text = "",
   button1 = L["Run the repair tool"],
-  button2 = L["Cancel"],
+  button2 = L["Continue Without Repairing"],
   OnAccept = function(self)
      WeakAuras.RepairDatabase()
   end,
   OnShow = function(self)
     if self.data.reason == "user" then
       self.text:SetText(L["Manual Repair Confirmation Dialog"]:format(WeakAuras.LastUpgrade()))
+      self.button2:SetText(L["Cancel"])
     else
       self.text:SetText(L["Automatic Repair Confirmation Dialog"]:format(WeakAuras.LastUpgrade()))
-      self.button2:SetText(L["Continue Without Repairing"])
     end
   end,
   OnCancel = function(self)

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -1513,11 +1513,6 @@ function WeakAuras.LoginMessage()
   return loginMessage
 end
 
-local isDatabaseUpgrade = false
-function WeakAuras.IsDatabaseUpgrade()
-  return isDatabaseUpgrade
-end
-
 function WeakAuras.Login(initialTime, takeNewSnapshots)
   local loginThread = coroutine.create(function()
     WeakAuras.Pause();
@@ -1533,15 +1528,13 @@ function WeakAuras.Login(initialTime, takeNewSnapshots)
     end
     coroutine.yield();
 
-    isDatabaseUpgrade = takeNewSnapshots;
-    WeakAuras.AddMany(toAdd);
+    WeakAuras.AddMany(toAdd, takeNewSnapshots);
     coroutine.yield();
     WeakAuras.AddManyFromAddons(from_files);
     WeakAuras.RegisterDisplay = WeakAuras.AddFromAddon;
     coroutine.yield();
     WeakAuras.ResolveCollisions(function() registeredFromAddons = true; end);
     coroutine.yield();
-    isDatabaseUpgrade = false;
 
     for _, triggerSystem in pairs(triggerSystems) do
       if (triggerSystem.AllAdded) then
@@ -3671,7 +3664,7 @@ function WeakAuras.SyncParentChildRelationships(silent)
   end
 end
 
-function WeakAuras.AddMany(table)
+function WeakAuras.AddMany(table, takeSnapshots)
   local idtable = {};
   for _, data in ipairs(table) do
     idtable[data.id] = data;
@@ -3698,7 +3691,7 @@ function WeakAuras.AddMany(table)
       end
     end
     if not(loaded[id]) then
-      WeakAuras.Add(data);
+      WeakAuras.Add(data, takeSnapshots);
       coroutine.yield();
       loaded[id] = true;
     end
@@ -4142,8 +4135,8 @@ local function pAdd(data)
 
 end
 
-function WeakAuras.Add(data)
-  if WeakAuras.IsDatabaseUpgrade() then
+function WeakAuras.Add(data, takeSnapshot)
+  if takeSnapshot then
     WeakAuras.SetMigrationSnapshot(data.uid, CopyTable(data))
   end
   WeakAuras.PreAdd(data)


### PR DESCRIPTION
# Description

This adds a repair tool. When the database version changes, then a snapshot of each aura is stored into history before running Modernize on that data. If the user then downgrades their WA version past this migration, then WeakAuras detects the change and asks the user to run the repair tool, which will overwrite the database with the migration snapshots.

The user can also manually run the repair tool via /wa repair. This may be handy for fixing bad migrations caught in alpha (though of course, alpha testers should still keep backups 😉).

For now, I would like to mark this feature as experimental, rather than something fully fledged and ready for the most "user" of users to use. I don't believe this will make things worse, but I also don't want to create the expectation that users can just type /wa repair whenever they like and their problems will be magically solved.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Verified that repair tool works as described above. If user declines to repair then login proceeds as before.
