### PR TITLE
Improve Weapon Enchant Trigger

### DIFF
--- a/WeakAuras/GenericTrigger.lua
+++ b/WeakAuras/GenericTrigger.lua
@@ -2947,7 +2947,7 @@ do
       tenchFrame:SetScript("OnEvent", function(self, event, arg1)
         WeakAuras.StartProfileSystem("generictrigger");
         if (event == "UNIT_INVENTORY_CHANGED" and arg1 == "player") then
-          tenchUpdate()
+          timer:ScheduleTimer(tenchUpdate, 0.1);
         end
         WeakAuras.StopProfileSystem("generictrigger");
       end);

--- a/WeakAuras/GenericTrigger.lua
+++ b/WeakAuras/GenericTrigger.lua
@@ -2885,7 +2885,7 @@ do
   local mh = GetInventorySlotInfo("MainHandSlot")
   local oh = GetInventorySlotInfo("SecondaryHandSlot")
 
-  local mh_name, mh_exp, mh_dur;
+  local mh_name, mh_exp, mh_dur, mh_charges, oh_charges;
   local mh_icon = GetInventoryItemTexture("player", mh);
 
   local oh_name, oh_exp, oh_dur;
@@ -2902,6 +2902,7 @@ do
 
       tenchTip = WeakAuras.GetHiddenTooltip();
 
+      -- TODO: Remove the (x min) from the name
       local function getTenchName(id)
         tenchTip:SetInventoryItem("player", id);
         local lines = { tenchTip:GetRegions() };
@@ -2922,7 +2923,8 @@ do
 
       local function tenchUpdate()
         WeakAuras.StartProfileSystem("generictrigger");
-        local _, mh_rem, _, _, _, oh_rem = GetWeaponEnchantInfo();
+        local mh_rem, oh_rem
+        _, mh_rem, mh_charges, _, _, oh_rem, oh_charges = GetWeaponEnchantInfo();
         local time = GetTime();
         local mh_exp_new = mh_rem and (time + (mh_rem / 1000));
         local oh_exp_new = oh_rem and (time + (oh_rem / 1000));
@@ -2930,36 +2932,36 @@ do
           mh_exp = mh_exp_new;
           mh_dur = mh_rem and mh_rem / 1000;
           mh_name = mh_exp and getTenchName(mh) or "None";
-          mh_icon = GetInventoryItemTexture("player", mh)
-          WeakAuras.ScanEvents("MAINHAND_TENCH_UPDATE");
+          mh_icon = GetInventoryItemTexture("player", mh)        
         end
         if(math.abs((oh_exp or 0) - (oh_exp_new or 0)) > 1) then
           oh_exp = oh_exp_new;
           oh_dur = oh_rem and oh_rem / 1000;
           oh_name = oh_exp and getTenchName(oh) or "None";
           oh_icon = GetInventoryItemTexture("player", oh)
-          WeakAuras.ScanEvents("OFFHAND_TENCH_UPDATE");
         end
+        WeakAuras.ScanEvents("TENCH_UPDATE");
         WeakAuras.StopProfileSystem("generictrigger");
       end
 
       tenchFrame:SetScript("OnEvent", function(self, event, arg1)
         WeakAuras.StartProfileSystem("generictrigger");
-        if(arg1 == "player") then
-          timer:ScheduleTimer(tenchUpdate, 0.1);
+        if (event == "UNIT_INVENTORY_CHANGED" and arg1 == "player") then
+          tenchUpdate()
         end
         WeakAuras.StopProfileSystem("generictrigger");
       end);
+
       tenchUpdate();
     end
   end
 
   function WeakAuras.GetMHTenchInfo()
-    return mh_exp, mh_dur, mh_name, mh_icon;
+    return mh_exp, mh_dur, mh_name, mh_icon, mh_charges;
   end
 
   function WeakAuras.GetOHTenchInfo()
-    return oh_exp, oh_dur, oh_name, oh_icon;
+    return oh_exp, oh_dur, oh_name, oh_icon, oh_charges;
   end
 end
 

--- a/WeakAuras/GenericTrigger.lua
+++ b/WeakAuras/GenericTrigger.lua
@@ -2923,7 +2923,7 @@ do
 
       local function tenchUpdate()
         WeakAuras.StartProfileSystem("generictrigger");
-        local mh_rem, oh_rem
+        local _, mh_rem, oh_rem
         _, mh_rem, mh_charges, _, _, oh_rem, oh_charges = GetWeaponEnchantInfo();
         local time = GetTime();
         local mh_exp_new = mh_rem and (time + (mh_rem / 1000));
@@ -2932,7 +2932,7 @@ do
           mh_exp = mh_exp_new;
           mh_dur = mh_rem and mh_rem / 1000;
           mh_name = mh_exp and getTenchName(mh) or "None";
-          mh_icon = GetInventoryItemTexture("player", mh)        
+          mh_icon = GetInventoryItemTexture("player", mh)
         end
         if(math.abs((oh_exp or 0) - (oh_exp_new or 0)) > 1) then
           oh_exp = oh_exp_new;

--- a/WeakAuras/GenericTrigger.lua
+++ b/WeakAuras/GenericTrigger.lua
@@ -2918,7 +2918,7 @@ do
           end
         end
 
-        return "Unknown";
+        return "Unknown", "Unknown";
       end
 
       local function tenchUpdate()
@@ -2931,13 +2931,13 @@ do
         if(math.abs((mh_exp or 0) - (mh_exp_new or 0)) > 1) then
           mh_exp = mh_exp_new;
           mh_dur = mh_rem and mh_rem / 1000;
-          mh_name, mh_shortenedName = mh_exp and getTenchName(mh) or "None";
+          mh_name, mh_shortenedName = mh_exp and getTenchName(mh) or "None", "None";
           mh_icon = GetInventoryItemTexture("player", mh)
         end
         if(math.abs((oh_exp or 0) - (oh_exp_new or 0)) > 1) then
           oh_exp = oh_exp_new;
           oh_dur = oh_rem and oh_rem / 1000;
-          oh_name, oh_shortenedName = oh_exp and getTenchName(oh) or "None";
+          oh_name, oh_shortenedName = oh_exp and getTenchName(oh) or "None", "None";
           oh_icon = GetInventoryItemTexture("player", oh)
         end
         WeakAuras.ScanEvents("TENCH_UPDATE");

--- a/WeakAuras/GenericTrigger.lua
+++ b/WeakAuras/GenericTrigger.lua
@@ -2885,10 +2885,10 @@ do
   local mh = GetInventorySlotInfo("MainHandSlot")
   local oh = GetInventorySlotInfo("SecondaryHandSlot")
 
-  local mh_name, mh_exp, mh_dur, mh_charges, oh_charges;
+  local mh_name, mh_shortenedName, mh_exp, mh_dur, mh_charges, mh_EnchantID;
   local mh_icon = GetInventoryItemTexture("player", mh);
 
-  local oh_name, oh_exp, oh_dur;
+  local oh_name, oh_shortenedName, oh_exp, oh_dur, oh_charges, oh_EnchantID;
   local oh_icon = GetInventoryItemTexture("player", oh);
 
   local tenchFrame = nil
@@ -2902,7 +2902,6 @@ do
 
       tenchTip = WeakAuras.GetHiddenTooltip();
 
-      -- TODO: Remove the (x min) from the name
       local function getTenchName(id)
         tenchTip:SetInventoryItem("player", id);
         local lines = { tenchTip:GetRegions() };
@@ -2912,7 +2911,8 @@ do
             if(text) then
               local _, _, name = text:find("^(.+) %(%d+ [^%)]+%)$");
               if(name) then
-                return name;
+                local _, _, shortenedName = name:find("^(.+) [VI%d]+$")
+                return name, shortenedName or name;
               end
             end
           end
@@ -2924,20 +2924,20 @@ do
       local function tenchUpdate()
         WeakAuras.StartProfileSystem("generictrigger");
         local _, mh_rem, oh_rem
-        _, mh_rem, mh_charges, _, _, oh_rem, oh_charges = GetWeaponEnchantInfo();
+        _, mh_rem, mh_charges, mh_EnchantID, _, oh_rem, oh_charges, oh_EnchantID = GetWeaponEnchantInfo();
         local time = GetTime();
         local mh_exp_new = mh_rem and (time + (mh_rem / 1000));
         local oh_exp_new = oh_rem and (time + (oh_rem / 1000));
         if(math.abs((mh_exp or 0) - (mh_exp_new or 0)) > 1) then
           mh_exp = mh_exp_new;
           mh_dur = mh_rem and mh_rem / 1000;
-          mh_name = mh_exp and getTenchName(mh) or "None";
+          mh_name, mh_shortenedName = mh_exp and getTenchName(mh) or "None";
           mh_icon = GetInventoryItemTexture("player", mh)
         end
         if(math.abs((oh_exp or 0) - (oh_exp_new or 0)) > 1) then
           oh_exp = oh_exp_new;
           oh_dur = oh_rem and oh_rem / 1000;
-          oh_name = oh_exp and getTenchName(oh) or "None";
+          oh_name, oh_shortenedName = oh_exp and getTenchName(oh) or "None";
           oh_icon = GetInventoryItemTexture("player", oh)
         end
         WeakAuras.ScanEvents("TENCH_UPDATE");
@@ -2957,11 +2957,11 @@ do
   end
 
   function WeakAuras.GetMHTenchInfo()
-    return mh_exp, mh_dur, mh_name, mh_icon, mh_charges;
+    return mh_exp, mh_dur, mh_name, mh_shortenedName, mh_icon, mh_charges, mh_EnchantID;
   end
 
   function WeakAuras.GetOHTenchInfo()
-    return oh_exp, oh_dur, oh_name, oh_icon, oh_charges;
+    return oh_exp, oh_dur, oh_name, oh_shortenedName, oh_icon, oh_charges, oh_EnchantID;
   end
 end
 

--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -4501,18 +4501,17 @@ WeakAuras.event_prototypes = {
         local triggerStack = %s
         local triggerRemaining = %s
         local triggerShowOn = %q
-        local expirationTime, duration, name
-        local stack
+        local _, expirationTime, duration, name, stack, enchantID
 
         if triggerWeaponType == "main" then
-          expirationTime, duration, name, _, stack = WeakAuras.GetMHTenchInfo()
+          expirationTime, duration, name, shortenedName, _, stack, enchantID = WeakAuras.GetMHTenchInfo()
         else
-          expirationTime, duration, name, _, stack = WeakAuras.GetOHTenchInfo()
+          expirationTime, duration, name, shortenedName, _, stack, enchantID = WeakAuras.GetOHTenchInfo()
         end
 
         local remaining = expirationTime and expirationTime - GetTime()
 
-        local nameCheck = triggerName == "" or triggerName == name
+        local nameCheck = triggerName == "" or name and triggerName == name or shortenedName and triggerName == shortenedName or enchantID and triggerName == enchantID
         local stackCheck = not triggerStack or stack and stack %s triggerStack
         local remainingCheck = not triggerRemaining or remaining and remaining %s triggerRemaining
         local found = expirationTime and nameCheck and stackCheck and remainingCheck
@@ -4597,18 +4596,18 @@ WeakAuras.event_prototypes = {
     iconFunc = function(trigger)
       local _, icon;
       if(trigger.weapon == "main") then
-        _, _, _, icon = WeakAuras.GetMHTenchInfo();
+        _, _, _, _, icon = WeakAuras.GetMHTenchInfo();
       elseif(trigger.weapon == "off") then
-        _, _, _, icon = WeakAuras.GetOHTenchInfo();
+        _, _, _, _, icon = WeakAuras.GetOHTenchInfo();
       end
       return icon;
     end,
     stacksFunc = function(trigger)
       local _, charges;
       if(trigger.weapon == "main") then
-        _, _, _, _, charges = WeakAuras.GetMHTenchInfo();
+        _, _, _, _, _, charges = WeakAuras.GetMHTenchInfo();
       elseif(trigger.weapon == "off") then
-        _, _, _, _, charges = WeakAuras.GetOHTenchInfo();
+        _, _, _, _, _, charges = WeakAuras.GetOHTenchInfo();
       end
       return charges;
     end,

--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -4538,7 +4538,7 @@ WeakAuras.event_prototypes = {
       {
         name = "enchant",
         display = L["Weapon Enchant"],
-        desc = L["Enchant name or Enchant ID"],
+        desc = L["Enchant Name or ID"],
         type = "string",
         test = "true"
       },

--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -4513,7 +4513,7 @@ WeakAuras.event_prototypes = {
         local remaining = expirationTime and expirationTime - GetTime()
 
         local nameCheck = triggerName == "" or triggerName == name
-        local stackCheck = not triggerStack or stack and stack and stack %s triggerStack
+        local stackCheck = not triggerStack or stack and stack %s triggerStack
         local remainingCheck = not triggerRemaining or remaining and remaining %s triggerRemaining
         local found = expirationTime and nameCheck and stackCheck and remainingCheck
       ]];
@@ -4522,7 +4522,7 @@ WeakAuras.event_prototypes = {
       trigger.use_enchant and trigger.enchant or "",
       trigger.use_stack and tonumber(trigger.stack or 0) or "nil",
       trigger.use_remaining and tonumber(trigger.remaining or 0) or "nil",
-      trigger.showOn or "ShowOnActive",
+      trigger.showOn or "showOnActive",
       trigger.stack_operator or "<",
       trigger.remaining_operator or "<")
     end,
@@ -4547,6 +4547,7 @@ WeakAuras.event_prototypes = {
         display = L["Stack Count"],
         type = "number",
         test = "true",
+        enable = WeakAuras.IsClassic(),
         hidden = not WeakAuras.IsClassic()
       },
       {
@@ -4560,12 +4561,16 @@ WeakAuras.event_prototypes = {
         display = L["Show On"],
         type = "select",
         values = "weapon_enchant_types",
-        test = "(triggerShowOn == \"showOnActive\" and found) " ..
-        "or (triggerShowOn == \"showOnMissing\" and not found) "  ..
-        "or (triggerShowOn == \"showAlways\")",
+        test = 'true',
         default = "showOnActive",
         required = true
       },
+      {
+        hidden = true,
+        test = "(triggerShowOn == 'showOnActive' and found) " ..
+        "or (triggerShowOn == 'showOnMissing' and not found) "  ..
+        "or (triggerShowOn == 'showAlways')"
+      }
     },
     durationFunc = function(trigger)
       local expirationTime, duration;

--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -4598,8 +4598,8 @@ WeakAuras.event_prototypes = {
       end
       return icon;
     end,
-    stacksFunc = function(trigger)      
-      local charges;
+    stacksFunc = function(trigger)
+      local _, charges;
       if(trigger.weapon == "main") then
         _, _, _, _, charges = WeakAuras.GetMHTenchInfo();
       elseif(trigger.weapon == "off") then

--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -4511,7 +4511,7 @@ WeakAuras.event_prototypes = {
 
         local remaining = expirationTime and expirationTime - GetTime()
 
-        local nameCheck = triggerName == "" or name and triggerName == name or shortenedName and triggerName == shortenedName or enchantID and triggerName == enchantID
+        local nameCheck = triggerName == "" or name and triggerName == name or shortenedName and triggerName == shortenedName or tonumber(triggerName) and enchantID and tonumber(triggerName) == enchantID
         local stackCheck = not triggerStack or stack and stack %s triggerStack
         local remainingCheck = not triggerRemaining or remaining and remaining %s triggerRemaining
         local found = expirationTime and nameCheck and stackCheck and remainingCheck
@@ -4538,6 +4538,7 @@ WeakAuras.event_prototypes = {
       {
         name = "enchant",
         display = L["Weapon Enchant"],
+        desc = L["Enchant name or Enchant ID"],
         type = "string",
         test = "true"
       },

--- a/WeakAuras/Types.lua
+++ b/WeakAuras/Types.lua
@@ -2129,6 +2129,12 @@ WeakAuras.dbm_types = {
   [7] = L["Important"]
 }
 
+WeakAuras.weapon_enchant_types = {
+  showOnActive = L["Enchant Found"],
+  showOnMissing = L["Enchant Missing"],
+  showAlways = L["Always"],
+}
+
 WeakAuras.EJIcons = {
   tank =      "|TInterface\\EncounterJournal\\UI-EJ-Icons:::::256:64:7:25:7:25|t",
   dps =       "|TInterface\\EncounterJournal\\UI-EJ-Icons:::::256:64:39:57:7:25|t",

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -3470,7 +3470,6 @@ function WeakAuras.Modernize(data)
       for triggerId, triggerData in ipairs(data.triggers) do
         local trigger = triggerData.trigger
         if trigger and trigger.type == "status" and trigger.event == "Weapon Enchant" then
-          print("Found a Weapon Enchant")
           if trigger.use_inverse then
             trigger.showOn = "showOnMissing"
           else

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -1,5 +1,4 @@
--- TODO: Bump the internal version
-local internalVersion = 23;
+local internalVersion = 24;
 
 -- WoW APIs
 local GetTalentInfo, IsAddOnLoaded, InCombatLockdown = GetTalentInfo, IsAddOnLoaded, InCombatLockdown
@@ -3466,7 +3465,26 @@ function WeakAuras.Modernize(data)
     end
   end
 
-  -- TODO: Migrate tench inverse to tench showOn
+  if data.internalVersion < 24 then
+    if data.triggers then
+      for triggerId, triggerData in ipairs(data.triggers) do
+        local trigger = triggerData.trigger
+        if trigger and trigger.type == "status" and trigger.event == "Weapon Enchant" then
+          print("Found a Weapon Enchant")
+          if trigger.use_inverse then
+            trigger.showOn = "showOnMissing"
+          else
+            trigger.showOn = "showOnActive"
+          end
+          trigger.use_inverse = nil
+          if not trigger.use_weapon then
+            trigger.use_weapon = "true"
+            trigger.weapon = "main"
+          end
+        end
+      end
+    end
+  end
 
   for _, triggerSystem in pairs(triggerSystems) do
     triggerSystem.Modernize(data);

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -1,3 +1,4 @@
+-- TODO: Bump the internal version
 local internalVersion = 23;
 
 -- WoW APIs
@@ -3464,6 +3465,8 @@ function WeakAuras.Modernize(data)
       end
     end
   end
+
+  -- TODO: Migrate tench inverse to tench showOn
 
   for _, triggerSystem in pairs(triggerSystems) do
     triggerSystem.Modernize(data);


### PR DESCRIPTION
# Description

With classic release, shaman and rogue use enchant on their weapon, this pull request aim to add stacks information for weapon enchantment (like rogue poison charges) and improve the weapon enchant trigger interface.

![image](https://user-images.githubusercontent.com/12969608/64067576-03261c00-cc2b-11e9-88a1-adcf2d9d1d64.png)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Since I don't have the level to use poisons on my rogue I asked some players to test it for me.

# Additional context

It seem like `Crippling Poison` doesn't return stacks with `GetWeaponEnchantInfo()`.
