### PR TITLE
don't package modelpaths for WeakAuras classic

### DIFF
--- a/.pkgmeta-classic
+++ b/.pkgmeta-classic
@@ -36,8 +36,8 @@ ignore:
  - WeakAuras/RegionTypes/Model.lua
  - WeakAurasOptions/RegionOptions/Model.lua
  - WeakAuras/WeakAurasTemplates
+ - WeakAuras/WeakAurasModelPaths
 
 move-folders:
  WeakAuras/WeakAuras: WeakAuras
  WeakAuras/WeakAurasOptions: WeakAurasOptions
- WeakAuras/WeakAurasModelPaths: WeakAurasModelPaths


### PR DESCRIPTION
since we don't support models currently in classic WA
