### PR TITLE
disable Health trigger overlays in Classic

### DIFF
--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -1539,7 +1539,7 @@ WeakAuras.event_prototypes = {
           end
         end,
         enable = function(trigger)
-          return trigger.use_showAbsorb;
+          return not WeakAuras.IsClassic() and trigger.use_showAbsorb;
         end
       },
       {
@@ -1551,7 +1551,7 @@ WeakAuras.event_prototypes = {
           end
         end,
         enable = function(trigger)
-          return trigger.use_showIncomingHeal;
+          return not WeakAuras.IsClassic() and trigger.use_showIncomingHeal;
         end
       }
     },


### PR DESCRIPTION
# Description
Option is disabled but if you import an aura with it enable it make nil error

reported on discord
```
"Message: Interface\AddOns\WeakAuras\Prototypes.lua:1549: attempt to call global 'UnitGetIncomingHeals' (a nil value)
Time: Mon Sep 16 08:54:48 2019
Count: 997
Stack: Interface\AddOns\WeakAuras\Prototypes.lua:1549: attempt to call global 'UnitGetIncomingHeals' (a nil value)"
```