### PR TITLE
cast trigger: don't hide cast bar on UNIT_SPELLCAST_FAILED

### DIFF
--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -5157,12 +5157,10 @@ WeakAuras.event_prototypes = {
       AddUnitEventForEvents(result, trigger.unit, "UNIT_SPELLCAST_INTERRUPTIBLE")
       AddUnitEventForEvents(result, trigger.unit, "UNIT_SPELLCAST_NOT_INTERRUPTIBLE")
       AddUnitEventForEvents(result, trigger.unit, "UNIT_SPELLCAST_INTERRUPTED")
-      AddUnitEventForEvents(result, trigger.unit, "UNIT_SPELLCAST_FAILED")
       if WeakAuras.IsClassic() and trigger.unit ~= "player" then
         LibClassicCasterino:RegisterCallback("UNIT_SPELLCAST_START", WeakAuras.ScanUnitEvents)
         LibClassicCasterino:RegisterCallback("UNIT_SPELLCAST_DELAYED", WeakAuras.ScanUnitEvents) -- only for player
         LibClassicCasterino:RegisterCallback("UNIT_SPELLCAST_STOP", WeakAuras.ScanUnitEvents)
-        LibClassicCasterino:RegisterCallback("UNIT_SPELLCAST_FAILED", WeakAuras.ScanUnitEvents)
         LibClassicCasterino:RegisterCallback("UNIT_SPELLCAST_CHANNEL_START", WeakAuras.ScanUnitEvents)
         LibClassicCasterino:RegisterCallback("UNIT_SPELLCAST_CHANNEL_UPDATE", WeakAuras.ScanUnitEvents) -- only for player
         LibClassicCasterino:RegisterCallback("UNIT_SPELLCAST_CHANNEL_STOP", WeakAuras.ScanUnitEvents)
@@ -5222,7 +5220,6 @@ WeakAuras.event_prototypes = {
             local show, expirationTime, castType, spell, icon, startTime, endTime, interruptible, spellId, remaining
 
             if event == "UNIT_SPELLCAST_STOP"
-            or event == "UNIT_SPELLCAST_FAILED"
             or event == "UNIT_SPELLCAST_CHANNEL_STOP"
             or event == "UNIT_SPELLCAST_INTERRUPTED"
             or event == "NAME_PLATE_UNIT_REMOVED"


### PR DESCRIPTION
fixes #1766

LibClassicCasterino send the callback UNIT_SPELLCAST_FAILED when unit dies or when it detect an enemy player is moving, so i re-added this event for hiding the castbar, but this is an issue on retail because it trigger when you spam your spells.

Depending on @rgd87 answer on https://github.com/rgd87/LibClassicCasterino/issues/20 i wish to delay next weakauras release to after this is changed on LibClassicCasterino