### PR TITLE
Allow authors (and users) to customize array option's entry names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ WeakAuras_Templates.lua
 WeakAuras/Libs/*
 !WeakAuras/Libs/LibDeflate
 format.bat
+**/desktop.ini

--- a/WeakAuras/Types.lua
+++ b/WeakAuras/Types.lua
@@ -1985,8 +1985,23 @@ WeakAuras.author_option_fields = {
     collapse = false,
     limitType = "none",
     size = 10,
+    nameSource = 0,
+    entryNames = nil, -- handled as a special case in code
     subOptions = {},
   }
+}
+
+WeakAuras.array_entry_name_types = {
+  [-1] = L["Fixed Names"],
+  [0] = L["Entry Order"],
+  -- the rest is auto-populated with indices which are valid entry name sources
+}
+
+WeakAuras.name_source_option_types = {
+  -- option types which can be used to generate entry names on arrays
+  input = true,
+  number = true,
+  range = true,
 }
 
 WeakAuras.group_limit_types = {

--- a/WeakAuras/Types.lua
+++ b/WeakAuras/Types.lua
@@ -1986,6 +1986,7 @@ WeakAuras.author_option_fields = {
     limitType = "none",
     size = 10,
     nameSource = 0,
+    hideReorder = true,
     entryNames = nil, -- handled as a special case in code
     subOptions = {},
   }

--- a/WeakAurasOptions/AuthorOptions.lua
+++ b/WeakAurasOptions/AuthorOptions.lua
@@ -1196,6 +1196,20 @@ typeControlAdders = {
         end,
         disabled = function() return option.limitType == "none" end,
       }
+      args[prefix .. "hideReorder"] = {
+        type = "toggle",
+        name = name(option, "hideReorder", L["Disallow Entry Reordering"]),
+        desc = desc(option, "hideReorder"),
+        order = order(),
+        width = WeakAuras.normalWidth,
+        get = function()
+          return option.hideReorder or option.nameSource == -1
+        end,
+        set = set(data, option, "hideReorder"),
+        disabled = function()
+          return option.nameSource == -1
+        end,
+      }
       local nameSources = CopyTable(WeakAuras.array_entry_name_types)
       local validNameSourceTypes = WeakAuras.name_source_option_types
       if option.limitType ~= "fixed" then
@@ -1355,7 +1369,6 @@ local function down(data, options, index)
     WeakAuras.ReloadTriggerOptions(data)
   end
 end
-
 
 local function duplicate(data, options, index)
   local option = options[index]
@@ -1924,7 +1937,7 @@ local function addUserModeOption(options, args, data, order, prefix, i)
         if option.limitType == "fixed" then
           buttonWidth = buttonWidth - 0.30
         end
-        if option.nameSource == -1 then
+        if option.hideReorder or option.nameSource == -1 then
           buttonWidth = buttonWidth - 0.30
         end
         args[prefix .. "entryChoice"] = {
@@ -2022,7 +2035,7 @@ local function addUserModeOption(options, args, data, order, prefix, i)
             control = "WeakAurasIcon"
           }
         end
-        if option.nameSource ~= -1 then
+        if option.nameSource ~= -1 and not option.hideReorder then
           args[prefix .. "moveEntryUp"] = {
             type = "execute",
             name = L["Move Entry Up"],


### PR DESCRIPTION
# Description

This is only approximately 80% complete, and needs some heavy testing of edge cases.

This enhancement adds a new dropdown to `Author Mode` of array type options, "Name Source". This dropdown controls how the page selector in `User Mode` displays each entry in the array.

Possible Values:

- Fixed Names
	- Only available on arrays with a fixed size. In this mode, the author is expected to specify the name of each entry manually.
- Entry Order
	- This provides the default behavior, where each entry is names "Entry N".
- Any key of a suitable sub option.
	- There may be 0 or more of these. Any Range, Number, or String type option is a suitable name source. In this mode, the chosen option's user value will be used to name the entry.