### PR TITLE
Add WeakAurasArchive

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -46,6 +46,7 @@ globals = {
 	"WeakAurasOptionsSaved",
 	"WeakAurasSaved",
 	"WeakAurasTimers",
+	"WeakAurasArchive",
 
 	-- Third Party Addons/Libs
 	"BigWigs",

--- a/.pkgmeta
+++ b/.pkgmeta
@@ -19,6 +19,7 @@ externals:
   WeakAuras/Libs/LibCustomGlow-1.0: https://github.com/Stanzilla/LibCustomGlow
   WeakAuras/Libs/LibDBIcon-1.0: https://repos.wowace.com/wow/libdbicon-1-0/trunk/LibDBIcon-1.0
   WeakAuras/Libs/LibGetFrame-1.0: https://github.com/mrbuds/LibGetFrame
+  WeakAuras/Libs/Archivist: https://github.com/emptyrivers/Archivist
 
 enable-nolib-creation: no
 
@@ -38,3 +39,4 @@ move-folders:
   WeakAuras/WeakAurasOptions: WeakAurasOptions
   WeakAuras/WeakAurasModelPaths: WeakAurasModelPaths
   WeakAuras/WeakAurasTemplates: WeakAurasTemplates
+  WeakAuras/WeakAurasArchive: WeakAurasArchive

--- a/.pkgmeta-classic
+++ b/.pkgmeta-classic
@@ -23,6 +23,7 @@ externals:
   WeakAuras/Libs/!LibTotemInfo: https://github.com/SwimmingTiger/LibTotemInfo
   WeakAuras/Libs/LibRangeCheck-2.0: https://repos.wowace.com/wow/librangecheck-2-0/trunk/LibRangeCheck-2.0
   WeakAuras/Libs/LibClassicSpellActionCount-1.0: https://github.com/Ennea/LibClassicSpellActionCount-1.0
+  WeakAuras/Libs/Archivist: https://github.com/emptyrivers/Archivist
 
 enable-nolib-creation: no
 
@@ -44,3 +45,4 @@ ignore:
 move-folders:
   WeakAuras/WeakAuras: WeakAuras
   WeakAuras/WeakAurasOptions: WeakAurasOptions
+  WeakAuras/WeakAurasArchive: WeakAurasArchive

--- a/WeakAuras/ArchiveTypes/Repository.lua
+++ b/WeakAuras/ArchiveTypes/Repository.lua
@@ -1,0 +1,122 @@
+--[[
+Repository store type. This is a meta-archive of sorts.
+  Store contains 0 or more substores, each of which is essentially
+  a list of ReadOnly stores, along with a small amount of meta-data
+  about the sub-stores. Store type is tailored for quick retrieval of
+  meta-data and only decompressing the data we need right now. In our use case,
+  the sub stores are all historical aura snapshots. It would be an
+  error to mutate this data, so we use ReadOnly stores (which don't
+  return anything on Commit/Close) to minimize performance impact of reading data.
+--]]
+
+local Archivist = select(2, ...).Archivist
+
+local subStoreMethods = {
+  Validate = function(self)
+    if type(self.id) ~= "string" or not Archivist:Check("ReadOnly", self.id) then
+      self.id = nil
+      return false
+    else
+      return true
+    end
+  end,
+  Set = function(self, data)
+    if type(self.id) == "string" then
+      Archivist:Delete("ReadOnly", self.id, true)
+    end
+    local store, storeID = Archivist:Create("ReadOnly", nil, data)
+    self.id = storeID
+    self.timestamp = time()
+  end,
+  Load = function(self) -- convenience method
+    return Archivist:Load("ReadOnly", self.id)
+  end,
+  Close = function(self) -- convenience method
+    return Archivist:Close("ReadOnly", self.id)
+  end,
+  Delete = function(self)
+    Archivist:Delete("ReadOnly", self.id)
+    self.id = nil
+  end,
+}
+
+local storeMethods = {
+  Validate = function(self)
+    for id, subStore in pairs(self.stores) do
+      if not subStore:Validate() then
+        -- either it's too old, or doesn't exist. Either way we don't need to keep this record
+        self.stores[id] = nil
+      end
+    end
+  end,
+  Get = function(self, id, load)
+    local subStore = self.stores[id]
+    local data
+    if subStore and load then
+      data = subStore:Load()
+    end
+    return subStore, data
+  end,
+  Set = function(self, id, data)
+    if not self.stores[id] and data ~= nil then
+      self.stores[id] = {}
+      for name, method in pairs(subStoreMethods) do
+        self.stores[id][name] = method
+      end
+    end
+    self.stores[id]:Set(data)
+    return self.stores[id]
+  end,
+  Clean = function(self, cutoff)
+    for id, subStore in pairs(self.stores) do
+      if subStore.timestamp < cutoff then
+        self:Drop(id)
+      end
+    end
+  end,
+  Drop = function(self, id)
+    if self.stores[id] then
+      self.stores[id]:Delete()
+      self.stores[id] = nil
+    end
+  end,
+}
+
+local prototype = {
+  id = "Repository",
+  version = 1,
+  Init = nil, -- Repositories are entirely self-contained! No need for Init.
+  Create = function(self, image)
+    local store = type(image) == "table" and image or {}
+    if type(store.stores) ~= "table" then
+      store.stores = {}
+    end
+    for name, method in pairs(storeMethods) do
+      store[name] = method
+    end
+    store:Validate()
+    return store, store
+  end,
+  Update = nil, -- This is the initial version! No need for Update yet.
+  Open = function(self, image)
+    local store = image
+    for name, method in pairs(storeMethods) do
+      store[name] = method
+    end
+    for _, subStore in pairs(store.stores) do
+      for name, method in pairs(subStoreMethods) do
+        subStore[name] = method
+      end
+    end
+    store:Validate()
+    return store
+  end,
+  Commit = function(self, store)
+    return store
+  end,
+  Close = function(self, store)
+    return store
+  end
+}
+
+Archivist:RegisterStoreType(prototype)

--- a/WeakAuras/History.lua
+++ b/WeakAuras/History.lua
@@ -1,123 +1,76 @@
---[[
-This file contains all of the interfaces to the history collection. Indexed by uid of the active display.
 
-History:
-  Table containing historical information about display:
-  source: string indicating where this data came from. Possible values:
-    "import": aura was imported via WeakAuras.Import (i.e. pasted string or addon channel transmission)
-    "addon": aura was imported via WeakAuras.RegisterDisplay (i.e. an addon requested the addition)
-    "auto": history created automatically due to database management
-  data: snapshot of data as it was at last import, or nil if source == "user", and the user has not chosen to save their changes to history
-  migration: snapshot of data as it was at last automatic data upgrade. Repair tool will restore this data to active status
-  lastMigrated: UNIX timestamp of the last time this aura was automatically upgraded
-  addon: if source == "addon", then this string indicates which addon supplied the last import
-  skippedVersions: record of versions that the user has indicated they don't wish to see update notifications for
-  allowUpdates: if false, then WeakAuras will ignore any addon-sourced update requests
-  lastUpdate: UNIX timestamp of the last time the user completed an import for this display
---]]
+
 if not WeakAuras.IsCorrectVersion() then return end
 
 local WeakAuras = WeakAuras
-local history -- history db upvalue
 
-function WeakAuras.LoadHistory(historydb, ageCutoff, migrationExpiry)
-  history = historydb
-  if ageCutoff ~= false then
-    WeakAuras.ClearOldHistory(ageCutoff)
+local histRepo, migrationRepo
+local function loadHistory()
+  if not histRepo then
+    histRepo = WeakAuras.LoadFromArchive("Repository", "history")
   end
-  WeakAuras.ClearOldMigrations(migrationExpiry)
+  return histRepo
+end
+
+local function loadMigrations()
+  if not migrationRepo then
+    migrationRepo = WeakAuras.LoadFromArchive("Repository", "migration")
+  end
+  return migrationRepo
+end
+
+function WeakAuras.CleanArchive(historyCutoff, migrationCutoff)
+  if type(historyCutoff) == "number" then
+    local repo = loadHistory()
+    local cutoffTime = time() - (historyCutoff * 86400)
+    for uid, subStore in pairs(repo.stores) do
+      -- Ideally we would just use Clean and not access the stores list directly,
+      -- but that'd mean having Clean take a predicate which seems like overkill for the moment
+      if not WeakAuras.GetDataByUID(uid) and subStore.timestamp < cutoffTime then
+        repo:Drop(uid)
+      end
+    end
+  end
+
+  if type(migrationCutoff) == "number" then
+    local repo = loadMigrations()
+    repo:Clean(time() - (migrationCutoff * 86400))
+  end
 end
 
 function WeakAuras.SetHistory(uid, data, source, addon)
   if uid and data then
-    history[uid] = history[uid] or {}
-    local hist = history[uid]
-    hist.data = data
-    hist.source = source
-    hist.addon = source == "addon" and (addon or "unknown") or nil
-    hist.skippedVersions = hist.skippedVersions or {}
-    hist.lastUpdate = time()
-    if hist.allowUpdates == nil then
-      hist.allowUpdates = true
-    end
+    local repo = loadHistory()
+    data.source = source
+    data.addon = source == "addon" and addon or nil
+    local hist = repo:Set(uid, data, true)
     return hist
   end
 end
 
-function WeakAuras.GetHistory(uid)
-  return uid and history[uid]
+function WeakAuras.GetHistory(uid, load)
+  return loadHistory():Get(uid, load)
 end
 
 function WeakAuras.RemoveHistory(uid)
-  if uid then
-    history[uid] = nil
-  end
-end
-
-function WeakAuras.AllowUpdates(uid, allowed)
-  local hist = WeakAuras.Gethistory(uid)
-  if hist then
-    hist.allowUpdates = allowed ~= false
-  end
-end
-
-function WeakAuras.IsUpdateAllowed(uid)
-  local hist = WeakAuras.GetHistory(uid)
-  return hist and hist.allowUpdates
-end
-
-function WeakAuras.SkipVersion(uid, version, skip)
-  local hist = WeakAuras.GetHistory(uid)
-  if hist then
-    hist.skippedVersions[version] = skip ~= false
-  end
-end
-
-function WeakAuras.IsVersionSkipped(uid, version)
-  local hist = WeakAuras.GetHistory(uid)
-  if hist then
-    return hist.skippedVersions[version]
-  end
+  return loadHistory():Drop(uid)
 end
 
 function WeakAuras.RestoreFromHistory(uid)
-  local hist = WeakAuras.GetHistory(uid)
-  if hist and hist.data then
-    WeakAuras.Add(CopyTable(hist.data))
-  end
-end
-
-function WeakAuras.ClearOldHistory(daysBack, includeNonDeleted)
-  local cutoffTime = time() - ((daysBack or 30) * 86400) -- eighty six, four hundred seconds in a day...
-  for uid, hist in pairs(history) do
-    if (includeNonDeleted or not WeakAuras.GetDataByUID(uid))
-    and (hist.lastUpdate < cutoffTime) then
-      history[uid] = nil
-    end
+  local _, histData = WeakAuras.GetHistory(uid, true)
+  if histData then
+    WeakAuras.Add(histData)
   end
 end
 
 function WeakAuras.SetMigrationSnapshot(uid, oldData)
-  local hist = WeakAuras.GetHistory(uid) or WeakAuras.SetHistory(uid, oldData, "auto")
-  if hist and oldData then
-    hist.migration = oldData
-    hist.lastMigrated = time()
+  if type(oldData) == "table" then
+    local repo = loadMigrations()
+    repo:Set(uid, oldData)
   end
 end
 
-function WeakAuras.GetMigrationSnapshot(uid)
-  local hist = WeakAuras.GetHistory(uid)
-  if hist then
-    return hist.migration
-  end
+function WeakAuras.GetMigrationSnapshot(uid, load)
+  return loadMigrations():Get(uid, load)
 end
 
-function WeakAuras.ClearOldMigrations(daysBack)
-  local cutoffTime = time() - ((daysBack or 14) * 86400)
-  for _, hist in pairs(history) do
-    if not hist.lastMigrated or hist.lastMigrated < cutoffTime then
-      hist.migration = nil
-      hist.lastMigrated = nil
-    end
-  end
-end

--- a/WeakAuras/WeakAuras.toc
+++ b/WeakAuras/WeakAuras.toc
@@ -26,6 +26,7 @@
 embeds.xml
 Init.lua
 locales.xml
+ArchiveTypes\Repository.lua
 
 # core files
 Prototypes.lua

--- a/WeakAuras/embeds.xml
+++ b/WeakAuras/embeds.xml
@@ -25,4 +25,5 @@
   <Script file="Libs\LibClassicSpellActionCount-1.0\LibClassicSpellActionCount-1.0.lua"/>
   @end-non-retail@-->
   <Script file="Libs\LibGetFrame-1.0\LibGetFrame-1.0.lua"/>
+  <Include file="Libs\Archivist\Archivist.xml"/>
 </Ui>

--- a/WeakAurasArchive/WeakAurasArchive.lua
+++ b/WeakAurasArchive/WeakAurasArchive.lua
@@ -1,0 +1,12 @@
+-- all this is is a frame that ensures that the SV is a table type
+local addonName = ...
+local loader = CreateFrame("FRAME")
+loader:RegisterEvent("ADDON_LOADED")
+loader:SetScript("OnEvent", function(self, _, addon)
+  if addon == addonName then
+    if type(WeakAurasArchive) ~= "table" then
+      WeakAurasArchive = {}
+    end
+    self:UnregisterEvent("ADDON_LOADED")
+  end
+end)

--- a/WeakAurasArchive/WeakAurasArchive.toc
+++ b/WeakAurasArchive/WeakAurasArchive.toc
@@ -1,0 +1,12 @@
+#@retail@
+## Interface: 80300
+#@end-retail@
+#@non-retail@
+# ## Interface: 11303
+#@end-non-retail@
+## Title: WeakAuras Archive
+## LoadOnDemand: 1
+## SavedVariables: WeakAurasArchive
+## Dependencies: WeakAuras
+
+WeakAurasArchive.lua


### PR DESCRIPTION
This adds a new external to WeakAuras, which I have been writing on and off for a little while - see https://github.com/emptyrivers/Archivist.

The basic idea here is that for the data we don’t need instantly on every login (so, history data), we can shunt that data into a LoadOnDemand addon to avoid having to load it every time. Since some users have a large volume of data (I’ve seen upwards of 30 MB in extreme cases), I decided to create a utility to maintain this archived data in a compressed format (hence the Archivist project).

This also creates a convenient location for authors to store saved data, without risking the same kind of SV bloat that history data created.