### PR TITLE
classic: workaround GetSpellCount change in 1.13.03 #1849

### DIFF
--- a/.pkgmeta-classic
+++ b/.pkgmeta-classic
@@ -22,6 +22,7 @@ externals:
   WeakAuras/Libs/LibGetFrame-1.0: https://github.com/mrbuds/LibGetFrame
   WeakAuras/Libs/!LibTotemInfo: https://github.com/SwimmingTiger/LibTotemInfo
   WeakAuras/Libs/LibRangeCheck-2.0: https://repos.wowace.com/wow/librangecheck-2-0/trunk/LibRangeCheck-2.0
+  WeakAuras/Libs/LibClassicSpellActionCount-1.0: https://github.com/Ennea/LibClassicSpellActionCount-1.0
 
 enable-nolib-creation: no
 

--- a/WeakAuras/GenericTrigger.lua
+++ b/WeakAuras/GenericTrigger.lua
@@ -73,6 +73,10 @@ local aceEvents = WeakAurasAceEvents
 local WeakAuras = WeakAuras;
 local L = WeakAuras.L;
 local GenericTrigger = {};
+local LCSA
+if WeakAuras.IsClassic then
+  LCSA = LibStub("LibClassicSpellActionCount-1.0")
+end
 
 local event_prototypes = WeakAuras.event_prototypes;
 
@@ -2119,9 +2123,16 @@ do
       end
     end
 
+    local count
+    if WeakAuras.IsClassic() then
+      count = LCSA:GetSpellReagentCount(id)
+    else
+      count = GetSpellCount(id)
+    end
+
     return charges, maxCharges, startTime, duration, unifiedCooldownBecauseRune,
            startTimeCooldown, durationCooldown, cooldownBecauseRune, startTimeCharges, durationCharges,
-           GetSpellCount(id);
+           count;
   end
 
   function WeakAuras.CheckSpellKnown()

--- a/WeakAuras/embeds.xml
+++ b/WeakAuras/embeds.xml
@@ -22,6 +22,7 @@
   <Include file="Libs\LibClassicDurations\LibClassicDurations.xml"/>
   <Script file="Libs\LibClassicCasterino\LibClassicCasterino.lua"/>
   <Include file="Libs\!LibTotemInfo\embeds.xml"/>
+  <Script file="Libs\LibClassicSpellActionCount-1.0\LibClassicSpellActionCount-1.0.lua"/>
   @end-non-retail@-->
   <Script file="Libs\LibGetFrame-1.0\LibGetFrame-1.0.lua"/>
 </Ui>


### PR DESCRIPTION
# Description
Work around GetSpellCount returning 0 for all spells since last classic update

copy/pasta from https://github.com/tullamods/Dominos/blob/master/Dominos/bars/getActionReagentUses.lua adapted to use localized spell name instead of spell ids

Fixes #1849


ps: it's highly possible a lib doing this will be release