### PR TITLE
reposition children of dynamic group on unitframes on GETFRAME_REFRES…

### DIFF
--- a/WeakAuras/RegionTypes/DynamicGroup.lua
+++ b/WeakAuras/RegionTypes/DynamicGroup.lua
@@ -949,9 +949,11 @@ local function modify(parent, region, data)
   end
 
   if data.useAnchorPerUnit and data.anchorPerUnit == "UNITFRAME" then
-    LGF.RegisterCallback("WeakAuras", "GETFRAME_REFRESH", function()
+    LGF.RegisterCallback("WeakAuras" .. data.uid, "GETFRAME_REFRESH", function()
       region:PositionChildren()
     end)
+  else
+    LGF.UnregisterCallback("WeakAuras" .. data.uid, "GETFRAME_REFRESH")
   end
 
   function region:DoPositionChildrenPerFrame(frame, positions)

--- a/WeakAuras/RegionTypes/DynamicGroup.lua
+++ b/WeakAuras/RegionTypes/DynamicGroup.lua
@@ -2,6 +2,7 @@ if not WeakAuras.IsCorrectVersion() then return end
 
 local WeakAuras = WeakAuras
 local SharedMedia = LibStub("LibSharedMedia-3.0")
+local LGF = LibStub("LibGetFrame-1.0")
 
 local default = {
   controlledChildren = {},
@@ -945,6 +946,12 @@ local function modify(parent, region, data)
     else
       self.needToPosition = true
     end
+  end
+
+  if data.useAnchorPerUnit and data.anchorPerUnit == "UNITFRAME" then
+    LGF.RegisterCallback("WeakAuras", "GETFRAME_REFRESH", function()
+      region:PositionChildren()
+    end)
   end
 
   function region:DoPositionChildrenPerFrame(frame, positions)


### PR DESCRIPTION
…H callback

# Description
LibGetFrame refresh its list of unitframes 1s after a list of events
PLAYER_REGEN_DISABLED
PLAYER_REGEN_ENABLED
PLAYER_ENTERING_WORLD
GROUP_ROSTER_UPDATE

I added possibility on LibGetFrame to register a callback with CallbackHandler-1.0 on these events to reposition children of dynamic groups with options "group by frame" + "unitframe"
https://github.com/mrbuds/LibGetFrame/commit/f0a0d6bb9e22ff01df2884c99147fdd997a34755

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

I'd like to test this a bit more, i'm not confident the way it's implemented in DynamicGroup.lua is right