### PR TITLE
Add Relative Offset Property Change

### DIFF
--- a/WeakAuras/RegionTypes/RegionPrototype.lua
+++ b/WeakAuras/RegionTypes/RegionPrototype.lua
@@ -168,7 +168,7 @@ function WeakAuras.regionPrototype.AddProperties(properties, defaultsForRegion)
     type = "customcode"
   }
   properties["xOffset"] = {
-    display = L["X-Offset"],
+    display = L["Absolute X-Offset"],
     setter = "SetXOffset",
     type = "number",
     softMin = -screenWidth,
@@ -176,7 +176,7 @@ function WeakAuras.regionPrototype.AddProperties(properties, defaultsForRegion)
     bigStep = 1
   }
   properties["yOffset"] = {
-    display = L["Y-Offset"],
+    display = L["Absolute Y-Offset"],
     setter = "SetYOffset",
     type = "number",
     softMin = -screenHeight,

--- a/WeakAuras/RegionTypes/RegionPrototype.lua
+++ b/WeakAuras/RegionTypes/RegionPrototype.lua
@@ -183,6 +183,22 @@ function WeakAuras.regionPrototype.AddProperties(properties, defaultsForRegion)
     softMax = screenHeight,
     bigStep = 1
   }
+  properties["xOffsetRelative"] = {
+    display = WeakAuras.newFeatureString .. L["Relative X-Offset"],
+    setter = "SetXOffsetRelative",
+    type = "number",
+    softMin = -screenWidth,
+    softMax = screenWidth,
+    bigStep = 1
+  }
+  properties["yOffsetRelative"] = {
+    display = WeakAuras.newFeatureString .. L["Relative Y-Offset"],
+    setter = "SetYOffsetRelative",
+    type = "number",
+    softMin = -screenHeight,
+    softMax = screenHeight,
+    bigStep = 1
+  }
 
   if (defaultsForRegion and defaultsForRegion.alpha) then
     properties["alpha"] = {
@@ -289,8 +305,8 @@ local function UpdatePosition(self)
     return;
   end
 
-  local xOffset = self.xOffset + (self.xOffsetAnim or 0);
-  local yOffset = self.yOffset + (self.yOffsetAnim or 0);
+  local xOffset = self.xOffset + (self.xOffsetAnim or 0) + (self.xOffsetRelative or 0)
+  local yOffset = self.yOffset + (self.yOffsetAnim or 0) + (self.yOffsetRelative or 0)
   self:RealClearAllPoints();
 
   xpcall(self.SetPoint, geterrorhandler(), self, self.anchorPoint, self.relativeTo, self.relativePoint, xOffset, yOffset);
@@ -337,6 +353,31 @@ end
 
 local function GetYOffset(self)
   return self.yOffset;
+end
+
+local function SetOffsetRelative(self, xOffsetRelative, yOffsetRelative)
+  if (self.xOffsetRelative == xOffsetRelative and self.yOffsetRelative == yOffsetRelative) then
+    return
+  end
+  self.xOffsetRelative = xOffsetRelative
+  self.yOffsetRelative = yOffsetRelative
+  UpdatePosition(self)
+end
+
+local function SetXOffsetRelative(self, xOffsetRelative)
+  self:SetOffsetRelative(xOffsetRelative, self:GetYOffsetRelative())
+end
+
+local function SetYOffsetRelative(self, yOffsetRelative)
+  self:SetOffsetRelative(self:GetXOffsetRelative(), yOffsetRelative)
+end
+
+local function GetXOffsetRelative(self)
+  return self.xOffsetRelative
+end
+
+local function GetYOffsetRelative(self)
+  return self.yOffsetRelative
 end
 
 local function SetOffsetAnim(self, xOffset, yOffset)
@@ -416,9 +457,14 @@ function WeakAuras.regionPrototype.create(region)
   region.SetOffset = SetOffset;
   region.SetXOffset = SetXOffset;
   region.SetYOffset = SetYOffset;
-  region.SetOffsetAnim = SetOffsetAnim;
   region.GetXOffset = GetXOffset;
   region.GetYOffset = GetYOffset;
+  region.SetOffsetRelative = SetOffsetRelative
+  region.SetXOffsetRelative = SetXOffsetRelative
+  region.SetYOffsetRelative = SetYOffsetRelative
+  region.GetXOffsetRelative = GetXOffsetRelative
+  region.GetYOffsetRelative = GetYOffsetRelative
+  region.SetOffsetAnim = SetOffsetAnim;
   region.ResetPosition = ResetPosition;
   region.RealClearAllPoints = region.ClearAllPoints;
   region.ClearAllPoints = function()

--- a/WeakAuras/RegionTypes/RegionPrototype.lua
+++ b/WeakAuras/RegionTypes/RegionPrototype.lua
@@ -507,6 +507,7 @@ function WeakAuras.regionPrototype.modify(parent, region, data)
   end
 
   region:SetOffset(data.xOffset or 0, data.yOffset or 0);
+  region:SetOffsetRelative(0, 0)
   region:SetOffsetAnim(0, 0);
 
   if data.anchorFrameType == "CUSTOM" and data.customAnchor then

--- a/WeakAuras/RegionTypes/RegionPrototype.lua
+++ b/WeakAuras/RegionTypes/RegionPrototype.lua
@@ -167,24 +167,8 @@ function WeakAuras.regionPrototype.AddProperties(properties, defaultsForRegion)
     action = "RunCode",
     type = "customcode"
   }
-  properties["xOffset"] = {
-    display = L["Absolute X-Offset"],
-    setter = "SetXOffset",
-    type = "number",
-    softMin = -screenWidth,
-    softMax = screenWidth,
-    bigStep = 1
-  }
-  properties["yOffset"] = {
-    display = L["Absolute Y-Offset"],
-    setter = "SetYOffset",
-    type = "number",
-    softMin = -screenHeight,
-    softMax = screenHeight,
-    bigStep = 1
-  }
   properties["xOffsetRelative"] = {
-    display = WeakAuras.newFeatureString .. L["Relative X-Offset"],
+    display = L["Relative X-Offset"],
     setter = "SetXOffsetRelative",
     type = "number",
     softMin = -screenWidth,
@@ -192,7 +176,7 @@ function WeakAuras.regionPrototype.AddProperties(properties, defaultsForRegion)
     bigStep = 1
   }
   properties["yOffsetRelative"] = {
-    display = WeakAuras.newFeatureString .. L["Relative Y-Offset"],
+    display = L["Relative Y-Offset"],
     setter = "SetYOffsetRelative",
     type = "number",
     softMin = -screenHeight,

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -3681,6 +3681,17 @@ function WeakAuras.Modernize(data)
         end
       end
     end
+
+    if data.conditions then
+      for conditionIndex, condition in ipairs(data.conditions) do
+        for changeIndex, change in ipairs(condition.changes) do
+          if change.property == "xOffset" or change.property == "yOffset" then
+            change.value = (change.value or 0) - (data[change.property] or 0)
+            change.property = change.property .. "Relative"
+          end
+        end
+      end
+    end
   end
 
   for _, triggerSystem in pairs(triggerSystems) do

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -1,4 +1,4 @@
-local internalVersion = 25;
+local internalVersion = 26;
 
 -- WoW APIs
 local GetTalentInfo, IsAddOnLoaded, InCombatLockdown = GetTalentInfo, IsAddOnLoaded, InCombatLockdown
@@ -3681,7 +3681,9 @@ function WeakAuras.Modernize(data)
         end
       end
     end
+  end
 
+  if data.internalVersion < 26 then
     if data.conditions then
       for conditionIndex, condition in ipairs(data.conditions) do
         for changeIndex, change in ipairs(condition.changes) do


### PR DESCRIPTION
# Description

Adds a Property Change that allows the user to adjust the position of a Region relative to its current location. Renames current similar Property Changes to "Absolute X/Y Offset" to help clearly indicate the difference between the two.

<!-- If it is a GitHub ticket, then #ticketNum will be sufficient. A WowAce ticket should include a URL. -->
Fixes #1561

Initially I wanted to have the Property Changes be additive (such that one Condition could add 10, and another could add 10, for a change in 20) but I realized this was inconsistent with existing interactions (or lack thereof) between Property Changes.

<!-- Afenar. -->

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Used all of the affected Conditions in an aura. Reloads performed.
- [x] Tested interaction with Animations.

# Checklist:
<!-- These can be checked off after the pull request is submitted, in case you want discussion before they’re completely ready -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

<!-- Is there any additional work that needs to be done? If so, add it to the above list -->
