### PR TITLE
Custom Options Author Names Tweaks

### DIFF
--- a/WeakAurasOptions/AuthorOptions.lua
+++ b/WeakAurasOptions/AuthorOptions.lua
@@ -196,7 +196,7 @@ local function descType(option)
     L["Used in Auras:"]
   }
   for id, optionData in pairs(option.references) do
-    tinsert(desc, ("%s - Option %i"):format(id, optionData.path[#optionData.path]))
+    tinsert(desc, ("%s - Option #%i"):format(id, optionData.path[#optionData.path]))
   end
   return tconcat(desc, "\n")
 end
@@ -1305,7 +1305,7 @@ typeControlAdders = {
           childOption.subOptions[j] = {
             type = "toggle",
             key = "subOption" .. j,
-            name = L["Sub Option %i"]:format(j),
+            name = L["Sub Option #%i"]:format(j),
             default = false,
             width = 1,
             useDesc = false,
@@ -1696,7 +1696,7 @@ function addAuthorModeOption(options, args, data, order, prefix, i, isSubOption)
           -- mostly because it would have a very non-intuitive effect
           -- the names and keys would likely not match anymore, and so
           -- the merged display would basically explode into a bunch of separate options
-          childOption.name = childOption.name or ("Option %i"):format(i)
+          childOption.name = childOption.name or ("Option #%i"):format(i)
           if not childOption.key then
             local newKey = "option" .. i
             local existingKeys = {}
@@ -2468,7 +2468,7 @@ function WeakAuras.GetAuthorOptions(data, args, startorder)
             childData.authorOptions[i] = {
               type = "toggle",
               key = "option" .. i,
-              name = L["Option %i"]:format(i),
+              name = L["Option #%i"]:format(i),
               default = false,
               width = 1,
               useDesc = false,
@@ -2481,7 +2481,7 @@ function WeakAuras.GetAuthorOptions(data, args, startorder)
           data.authorOptions[i] = {
             type = "toggle",
             key = "option" .. i,
-            name = L["Option %i"]:format(i),
+            name = L["Option #%i"]:format(i),
             default = false,
             width = 1,
             useDesc = false,

--- a/WeakAurasOptions/AuthorOptions.lua
+++ b/WeakAurasOptions/AuthorOptions.lua
@@ -1452,7 +1452,7 @@ function addAuthorModeOption(options, args, data, order, prefix, i)
   end
   local optionClass = optionClasses[option.type]
   local optionName = optionClass == "noninteractive" and WeakAuras.author_option_types[option.type]
-                     or option.name or L["Option #%i"]:format(i)
+                     or option.name
 
   args[prefix .. "collapse"] = {
     type = "execute",

--- a/WeakAurasOptions/AuthorOptions.lua
+++ b/WeakAurasOptions/AuthorOptions.lua
@@ -592,7 +592,7 @@ typeControlAdders = {
         return not option.useLength
       end
     }
-    args["prefix" .. "multiline"] = {
+    args[prefix .. "multiline"] = {
       type = "toggle",
       width = WeakAuras.doubleWidth,
       name = name(option, "multiline", L["Large Input"]),

--- a/WeakAurasOptions/AuthorOptions.lua
+++ b/WeakAurasOptions/AuthorOptions.lua
@@ -1280,14 +1280,14 @@ typeControlAdders = {
     end
     args[prefix .. "groupStart"] = {
       type = "header",
-      name = L["Start of %s"]:format(option.name ~= "" and option.name or L["Option #%i"]:format(i)),
+      name = L["Start of %s"]:format(option.name),
       order = order()
     }
     local subPrefix = prefix .. "option"
     for subIndex, subOption in ipairs(option.subOptions) do
       local addControlsForType = typeControlAdders[subOption.type]
       if addControlsForType then
-        addAuthorModeOption(option.subOptions, args, data, order, subPrefix .. subIndex, subIndex, true)
+        addAuthorModeOption(option.subOptions, args, data, order, subPrefix .. subIndex, subIndex)
       end
     end
     args[prefix .. "addSubOption"] = {
@@ -1318,7 +1318,7 @@ typeControlAdders = {
     }
     args[prefix .. "groupEnd"] = {
       type = "header",
-      name = L["End of %s"]:format(option.name ~= "" and option.name or L["Option #%i"]:format(i)),
+      name = L["End of %s"]:format(option.name),
       order = order()
     }
   end
@@ -1420,7 +1420,7 @@ local function ensureNonDuplicateKey(option)
   end
 end
 
-function addAuthorModeOption(options, args, data, order, prefix, i, isSubOption)
+function addAuthorModeOption(options, args, data, order, prefix, i)
   -- add header controls
   local option = options[i]
 
@@ -1452,7 +1452,7 @@ function addAuthorModeOption(options, args, data, order, prefix, i, isSubOption)
   end
   local optionClass = optionClasses[option.type]
   local optionName = optionClass == "noninteractive" and WeakAuras.author_option_types[option.type]
-                     or option.name ~= "" and option.name or (isSubOption and L["Sub Option #%i"] or L["Option #%i"]):format(i)
+                     or option.name or L["Option #%i"]:format(i)
 
   args[prefix .. "collapse"] = {
     type = "execute",

--- a/WeakAurasOptions/AuthorOptions.lua
+++ b/WeakAurasOptions/AuthorOptions.lua
@@ -1451,7 +1451,7 @@ function addAuthorModeOption(options, args, data, order, prefix, i)
     buttonWidth = buttonWidth + 0.15
   end
   local optionClass = optionClasses[option.type]
-  local optionName = option.class == "noninteractive" and WeakAuras.author_option_types[option.type]
+  local optionName = optionClass == "noninteractive" and WeakAuras.author_option_types[option.type]
                      or option.name or L["Option #%i"]:format(i)
 
   args[prefix .. "collapse"] = {

--- a/WeakAurasOptions/AuthorOptions.lua
+++ b/WeakAurasOptions/AuthorOptions.lua
@@ -1280,14 +1280,14 @@ typeControlAdders = {
     end
     args[prefix .. "groupStart"] = {
       type = "header",
-      name = L["Start of %s"]:format(option.name),
+      name = L["Start of %s"]:format(option.name ~= "" and option.name or L["Option #%i"]:format(i)),
       order = order()
     }
     local subPrefix = prefix .. "option"
     for subIndex, subOption in ipairs(option.subOptions) do
       local addControlsForType = typeControlAdders[subOption.type]
       if addControlsForType then
-        addAuthorModeOption(option.subOptions, args, data, order, subPrefix .. subIndex, subIndex)
+        addAuthorModeOption(option.subOptions, args, data, order, subPrefix .. subIndex, subIndex, true)
       end
     end
     args[prefix .. "addSubOption"] = {
@@ -1318,7 +1318,7 @@ typeControlAdders = {
     }
     args[prefix .. "groupEnd"] = {
       type = "header",
-      name = L["End of %s"]:format(option.name),
+      name = L["End of %s"]:format(option.name ~= "" and option.name or L["Option #%i"]:format(i)),
       order = order()
     }
   end
@@ -1420,7 +1420,7 @@ local function ensureNonDuplicateKey(option)
   end
 end
 
-function addAuthorModeOption(options, args, data, order, prefix, i)
+function addAuthorModeOption(options, args, data, order, prefix, i, isSubOption)
   -- add header controls
   local option = options[i]
 
@@ -1452,7 +1452,7 @@ function addAuthorModeOption(options, args, data, order, prefix, i)
   end
   local optionClass = optionClasses[option.type]
   local optionName = optionClass == "noninteractive" and WeakAuras.author_option_types[option.type]
-                     or option.name or L["Option #%i"]:format(i)
+                     or option.name ~= "" and option.name or (isSubOption and L["Sub Option #%i"] or L["Option #%i"]):format(i)
 
   args[prefix .. "collapse"] = {
     type = "execute",

--- a/WeakAurasOptions/AuthorOptions.lua
+++ b/WeakAurasOptions/AuthorOptions.lua
@@ -196,7 +196,7 @@ local function descType(option)
     L["Used in Auras:"]
   }
   for id, optionData in pairs(option.references) do
-    tinsert(desc, ("%s - Option #%i"):format(id, optionData.path[#optionData.path]))
+    tinsert(desc, ("%s - Option %i"):format(id, optionData.path[#optionData.path]))
   end
   return tconcat(desc, "\n")
 end
@@ -1305,7 +1305,7 @@ typeControlAdders = {
           childOption.subOptions[j] = {
             type = "toggle",
             key = "subOption" .. j,
-            name = L["Sub Option #%i"]:format(j),
+            name = L["Sub Option %i"]:format(j),
             default = false,
             width = 1,
             useDesc = false,
@@ -1696,7 +1696,7 @@ function addAuthorModeOption(options, args, data, order, prefix, i)
           -- mostly because it would have a very non-intuitive effect
           -- the names and keys would likely not match anymore, and so
           -- the merged display would basically explode into a bunch of separate options
-          childOption.name = childOption.name or ("Option #%i"):format(i)
+          childOption.name = childOption.name or ("Option %i"):format(i)
           if not childOption.key then
             local newKey = "option" .. i
             local existingKeys = {}
@@ -2468,7 +2468,7 @@ function WeakAuras.GetAuthorOptions(data, args, startorder)
             childData.authorOptions[i] = {
               type = "toggle",
               key = "option" .. i,
-              name = L["Option #%i"]:format(i),
+              name = L["Option %i"]:format(i),
               default = false,
               width = 1,
               useDesc = false,
@@ -2481,7 +2481,7 @@ function WeakAuras.GetAuthorOptions(data, args, startorder)
           data.authorOptions[i] = {
             type = "toggle",
             key = "option" .. i,
-            name = L["Option #%i"]:format(i),
+            name = L["Option %i"]:format(i),
             default = false,
             width = 1,
             useDesc = false,


### PR DESCRIPTION
# Description

Correctly displays intended fallback name when using a noninteractive display type.
Uses fallback name when name field is an empty string, in Author Mode _only_.
Removes inconsistency between default names and fallback names.
<!-- If it is a GitHub ticket, then #ticketNum will be sufficient. A WowAce ticket should include a URL. -->
Fixes #1847

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Used every noninteractive Custom Option type.
- [x] Named Custom Options a blank name. Checked in and out of Author Mode.
- [x] Created new options.

# Checklist:
<!-- These can be checked off after the pull request is submitted, in case you want discussion before they’re completely ready -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

<!-- Is there any additional work that needs to be done? If so, add it to the above list -->
