### PR TITLE
add ComposeSorts and CompareRegionData helpers

### DIFF
--- a/WeakAuras/RegionTypes/DynamicGroup.lua
+++ b/WeakAuras/RegionTypes/DynamicGroup.lua
@@ -115,72 +115,147 @@ function WeakAuras.GetPolarCoordinates(x, y, originX, originY)
   return r, theta;
 end
 
-local function expirationTime(regionData)
-  if (regionData.region and regionData.region.state) then
-    local expires = regionData.region.state.expirationTime
-    if (expires and expires > 0 and expires > GetTime()) then
-      return expires
+function WeakAuras.InvertSort(sortFunc)
+  -- takes a comparator and returns the "inverse"
+  -- i.e. when sortFunc returns true/false, inverseSortFunc returns false/true
+  -- nils are preserved to ensure that inverseSortFunc composes well
+  if type(sortFunc) ~= "function" then
+    error("InvertSort requires a function to invert.")
+  else
+    return function(...)
+      local result = sortFunc(...)
+      if result == nil then return nil end
+      return not result
     end
   end
-  return nil
 end
-WeakAuras.ExpirationTime = expirationTime
 
-local function compareExpirationTimes(regionDataA, regionDataB)
-  local aExpires = expirationTime(regionDataA)
-  local bExpires = expirationTime(regionDataB)
-
-  if (aExpires and bExpires) then
-    if abs(aExpires - bExpires) < 0.001 then
-      return nil
-    end
-    return aExpires < bExpires
-  elseif (aExpires) then
+function WeakAuras.SortNilLast(a, b)
+  -- sorts nil values to the end
+  -- only returns nil if both values are non-nil
+  -- Useful as a high priority sorter in a composition,
+  -- to ensure that children with missing data
+  -- don't ever sit in the middle of a row
+  -- and interrupt the sorting algorithm
+  if a == nil and b == nil then
+    -- guarantee stability in the nil region
     return false
-  elseif (bExpires) then
+  elseif a == nil then
+    return false
+  elseif b == nil then
     return true
   else
     return nil
   end
-
 end
-WeakAuras.CompareExpirationTimes = compareExpirationTimes
+
+local sortNilFirst = WeakAuras.InvertSort(WeakAuras.SortNilLast)
+function WeakAuras.SortNilFirst(a, b)
+  if a == nil and b == nil then
+    -- we want SortNil to always prevent nils from propogating
+    -- as well as to sort nils onto one side
+    -- to maintain stability, we need SortNil(nil, nil) to always be false
+    -- hence this special case
+    return false
+  else
+    return sortNilFirst(a,b)
+  end
+end
+
+function WeakAuras.SortGreaterLast(a, b)
+  -- sorts values in ascending order
+  -- values of disparate types are sorted according to the value of type(value)
+  -- which is a bit weird but at least guarantees a stable sort
+  -- can only sort comparable values (i.e. numbers and strings)
+  -- no support currently for tables with __lt metamethods
+  if a == b then
+    return nil
+  end
+  if type(a) ~= type(b) then
+    return type(a) > type(b)
+  end
+  if type(a) == "number" then
+    if abs(b - a) < 0.001 then
+      return nil
+    else
+      return a < b
+    end
+  elseif type(a) == "string" then
+    return a < b
+  else
+    return nil
+  end
+end
+
+WeakAuras.SortGreaterFirst = WeakAuras.InvertSort(WeakAuras.SortGreaterLast)
+
+function WeakAuras.CompareRegionData(path, compareFunc)
+  -- takes an array-like table, and a function that takes 2 values and returns true/false/nil
+  -- creates function that accesses the value indicated by path, and compares using compareFunc
+  if type(path) ~= "table" then
+    path = {}
+  end
+  if type(compareFunc) ~= "function" then
+    -- if compareFunc not provided, compare by default as "<"
+    compareFunc = WeakAuras.SortGreaterLast
+  end
+  return function(a, b)
+    local aValue, bValue = a, b
+    for _, key in ipairs(path) do
+      if type(aValue) ~= "table" then return nil end
+      if type(bValue) ~= "table" then return nil end
+      aValue, bValue = aValue[key], bValue[key]
+    end
+    return compareFunc(aValue, bValue)
+  end
+end
+
+function WeakAuras.SortAscending(path)
+  return WeakAuras.CompareRegionData(path, WeakAuras.ComposeSorts(WeakAuras.SortNilFirst, WeakAuras.SortGreaterLast))
+end
+
+function WeakAuras.SortDescending(path)
+  return WeakAuras.InvertSort(WeakAuras.SortAscending(path))
+end
+
+function WeakAuras.ComposeSorts(...)
+  -- accepts vararg of sort funcs
+  -- returns new sort func that combines the functions passed in
+  -- order of functions passed in determines their priority in new sort
+  -- returns nil if all functions return nil,
+  -- so that it can be composed or inverted without trouble
+  local sorts = {}
+  for i = 1, select("#", ...) do
+    local sortFunc = select(i, ...)
+    if type(sortFunc) == "function" then
+      tinsert(sorts, sortFunc)
+    end
+  end
+  return function(a, b)
+    for _, sortFunc in ipairs(sorts) do
+      local result = sortFunc(a, b)
+      if result ~= nil then
+        return result
+      end
+    end
+    return nil
+  end
+end
 
 local function noop() end
 
 local sorters = {
   none = function(data)
-    return function(a, b)
-      if a.dataIndex == b.dataIndex then
-        local aIndex = a.region.state and a.region.state.index
-        local bIndex = b.region.state and b.region.state.index
-        if bIndex and aIndex then
-          if type(aIndex) ~= type(bIndex) then
-            -- state.index can be any value from custom code,
-            -- so guard against disparate types which can't be compared
-            return type(aIndex) < type(bIndex)
-          elseif aIndex == bIndex then
-            return nil
-          else
-            return aIndex < bIndex
-          end
-        elseif aIndex then
-          return false
-        elseif bIndex then
-          return true
-        else
-          return nil
-        end
-      else
-        return a.dataIndex < b.dataIndex
-      end
-    end
+    return WeakAuras.ComposeSorts(
+      WeakAuras.CompareRegionData({"dataIndex"}),
+      WeakAuras.CompareRegionData({"region", "state", "index"})
+    )
   end,
   hybrid = function(data)
     local sortHybridTable = data.sortHybridTable or {}
     local hybridSortAscending = data.hybridSortMode == "ascending"
     local hybridFirst = data.hybridPosition == "hybridFirst"
-    return function(a, b)
+    local function compareHybridStatus(a, b)
       if not b then return true end
       if not a then return false end
 
@@ -192,44 +267,29 @@ local sorters = {
       elseif bIsHybrid and not aIsHybrid then
         return not hybridFirst
       else
-        local aLTb = compareExpirationTimes(a, b)
-        if aLTb == nil then
-          if a.dataIndex == b.dataIndex then
-            return nil
-          else
-            return a.dataIndex < b.dataIndex
-          end
-        else
-          return aLTb == hybridSortAscending
-        end
+        return nil
       end
     end
+    return WeakAuras.ComposeSorts(
+      compareHybridStatus,
+      WeakAuras.CompareRegionData(
+        {"region", "state", "expirationTime"},
+        WeakAuras.ComposeSorts(WeakAuras.SortNilFirst, hybridSortAscending and WeakAuras.SortGreaterLast or WeakAuras.SortGreaterFirst)
+      ),
+      WeakAuras.CompareRegionData({"dataIndex"})
+    )
   end,
   ascending = function(data)
-    return function(a, b)
-      local result = compareExpirationTimes(a, b)
-      if result == nil then
-        if a.dataIndex == b.dataIndex then
-          return nil
-        else
-          return a.dataIndex < b.dataIndex
-        end
-      end
-      return result
-    end
+    return WeakAuras.ComposeSorts(
+      WeakAuras.SortAscending({"region", "state", "expirationTime"}),
+      WeakAuras.CompareRegionData({"dataIndex"}, WeakAuras.SortGreaterLast)
+    )
   end,
   descending = function(data)
-    return function(a, b)
-      local result = compareExpirationTimes(a, b)
-      if result == nil then
-        if a.dataIndex == b.dataIndex then
-          return nil
-        else
-          return a.dataIndex < b.dataIndex
-        end
-      end
-      return not result
-    end
+    return WeakAuras.ComposeSorts(
+      WeakAuras.SortDescending({"region", "state", "expirationTime"}),
+      WeakAuras.CompareRegionData({"dataIndex"}, WeakAuras.SortGreaterFirst)
+    )
   end,
   custom = function(data)
     local sortStr = data.customSort or ""

--- a/WeakAuras/RegionTypes/DynamicGroup.lua
+++ b/WeakAuras/RegionTypes/DynamicGroup.lua
@@ -189,15 +189,15 @@ end
 
 WeakAuras.SortGreaterFirst = WeakAuras.InvertSort(WeakAuras.SortGreaterLast)
 
-function WeakAuras.CompareRegionData(path, compareFunc)
+function WeakAuras.SortRegionData(path, sortFunc)
   -- takes an array-like table, and a function that takes 2 values and returns true/false/nil
-  -- creates function that accesses the value indicated by path, and compares using compareFunc
+  -- creates function that accesses the value indicated by path, and compares using sortFunc
   if type(path) ~= "table" then
     path = {}
   end
-  if type(compareFunc) ~= "function" then
-    -- if compareFunc not provided, compare by default as "<"
-    compareFunc = WeakAuras.SortGreaterLast
+  if type(sortFunc) ~= "function" then
+    -- if sortFunc not provided, compare by default as "<"
+    sortFunc = WeakAuras.SortGreaterLast
   end
   return function(a, b)
     local aValue, bValue = a, b
@@ -206,12 +206,12 @@ function WeakAuras.CompareRegionData(path, compareFunc)
       if type(bValue) ~= "table" then return nil end
       aValue, bValue = aValue[key], bValue[key]
     end
-    return compareFunc(aValue, bValue)
+    return sortFunc(aValue, bValue)
   end
 end
 
 function WeakAuras.SortAscending(path)
-  return WeakAuras.CompareRegionData(path, WeakAuras.ComposeSorts(WeakAuras.SortNilFirst, WeakAuras.SortGreaterLast))
+  return WeakAuras.SortRegionData(path, WeakAuras.ComposeSorts(WeakAuras.SortNilFirst, WeakAuras.SortGreaterLast))
 end
 
 function WeakAuras.SortDescending(path)
@@ -255,7 +255,7 @@ local sorters = {
     local sortHybridTable = data.sortHybridTable or {}
     local hybridSortAscending = data.hybridSortMode == "ascending"
     local hybridFirst = data.hybridPosition == "hybridFirst"
-    local function compareHybridStatus(a, b)
+    local function sortHybridStatus(a, b)
       if not b then return true end
       if not a then return false end
 
@@ -277,7 +277,7 @@ local sorters = {
       sortExpirationTime = WeakAuras.SortDescending({"region", "state", "expirationTime"})
     end
     return WeakAuras.ComposeSorts(
-      compareHybridStatus,
+      sortHybridStatus,
       sortExpirationTime,
       WeakAuras.SortAscending({"dataIndex"})
     )

--- a/WeakAuras/RegionTypes/DynamicGroup.lua
+++ b/WeakAuras/RegionTypes/DynamicGroup.lua
@@ -247,8 +247,8 @@ local function noop() end
 local sorters = {
   none = function(data)
     return WeakAuras.ComposeSorts(
-      WeakAuras.CompareRegionData({"dataIndex"}),
-      WeakAuras.CompareRegionData({"region", "state", "index"})
+      WeakAuras.SortAscending({"dataIndex"}),
+      WeakAuras.SortAscending({"region", "state", "index"})
     )
   end,
   hybrid = function(data)
@@ -270,25 +270,28 @@ local sorters = {
         return nil
       end
     end
+    local sortExpirationTime
+    if hybridSortAscending then
+      sortExpirationTime = WeakAuras.SortAscending({"region", "state", "expirationTime"})
+    else
+      sortExpirationTime = WeakAuras.SortDescending({"region", "state", "expirationTime"})
+    end
     return WeakAuras.ComposeSorts(
       compareHybridStatus,
-      WeakAuras.CompareRegionData(
-        {"region", "state", "expirationTime"},
-        WeakAuras.ComposeSorts(WeakAuras.SortNilFirst, hybridSortAscending and WeakAuras.SortGreaterLast or WeakAuras.SortGreaterFirst)
-      ),
-      WeakAuras.CompareRegionData({"dataIndex"})
+      sortExpirationTime,
+      WeakAuras.SortAscending({"dataIndex"})
     )
   end,
   ascending = function(data)
     return WeakAuras.ComposeSorts(
       WeakAuras.SortAscending({"region", "state", "expirationTime"}),
-      WeakAuras.CompareRegionData({"dataIndex"}, WeakAuras.SortGreaterLast)
+      WeakAuras.SortAscending({"dataIndex"})
     )
   end,
   descending = function(data)
     return WeakAuras.ComposeSorts(
       WeakAuras.SortDescending({"region", "state", "expirationTime"}),
-      WeakAuras.CompareRegionData({"dataIndex"}, WeakAuras.SortGreaterFirst)
+      WeakAuras.SortAscending({"dataIndex"})
     )
   end,
   custom = function(data)

--- a/WeakAurasOptions/RegionOptions/DynamicGroup.lua
+++ b/WeakAurasOptions/RegionOptions/DynamicGroup.lua
@@ -312,7 +312,7 @@ local function createOptions(id, data)
     -- sort options
     sort = {
       type = "select",
-      width = WeakAuras.normalWidth,
+      width = WeakAuras.doubleWidth,
       name = L["Sort"],
       order = 20,
       values = WeakAuras.group_sort_types


### PR DESCRIPTION
# Description

Perhaps will make custom sort functions a bit easier to manage. To use, write something like this in custom sort:

```lua
WeakAuras.CompareRegionData({"region", "state", "expirationTime"})
```

Seriously, that's it. There isn't even any need to wrap it in a `function(a, b) ... end`, though of course you can do so. In which case I would recommend caching the function that you get from CompareRegionData into `aura_env`, and then calling it yourself on the last line.

If you want to compare more than one value in the regionData object, you can compose them:

```lua
WeakAuras.ComposeSorts(
  WeakAuras.CompareRegionData({"region", "state", "expirationTime"}),
  WeakAuras.CompareRegionData({"region", "state", "index"})
)
```

By default, `CompareRegionData` will use the `<` operator to compare values. You can override this by providing a function as the second parameter, which will be used instead.

ComposeSorts assumes that the functions it gets are passed in priority order, and a result of "equal" (or maybe "incomparable") is indicated by a function returning a nil value. If a compare function returns nil, then the next function is checked. And then the next, and so on down the list in the same order they were passed in.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

The Great and Wonderful Tester Extraordinaire @Causese said he couldn't find any issues, and he likes the feature.

# Checklist:

- [x] Finish converting builtin sort options to use helpers themselves