### PR TITLE
fix Alternate Power trigger not active without a first UNIT_POWER_FRE…

### DIFF
--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -1890,6 +1890,7 @@ WeakAuras.event_prototypes = {
       AddUnitChangeInternalEvents(trigger.unit, result)
       return result
     end,
+    force_events = "WA_DELAYED_PLAYER_ENTERING_WORLD",
     name = L["Alternate Power"],
     init = function(trigger)
       trigger.unit = trigger.unit or "player";


### PR DESCRIPTION
…QUENT event

# Description
An aura with Alternate Power trigger is not showing on /reload or option open/close before a new UNIT_POWER_FREQUENT event.
