### PR TITLE
Tick SubRegion

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -61,6 +61,7 @@ globals = {
 	-- FrameXML misc
 	"C_Timer",
 	"ChatFrame_AddMessageEventFilter",
+	"Clamp",
 	"COMBAT_TEXT_SCROLL_FUNCTION",
 	"CombatLogGetCurrentEventInfo",
 	"CombatText_AddMessage",

--- a/WeakAuras/RegionTypes/AuraBar.lua
+++ b/WeakAuras/RegionTypes/AuraBar.lua
@@ -1192,13 +1192,13 @@ local function modify(parent, region, data)
       region.flipY = false
     end
 
-    region:UpdateEffectiveOrientation()
-
     -- Update height
     self.bar.totalHeight = region.height * scaley
     self.bar.iconHeight = iconsize * scaley
     self:SetHeight(self.bar.totalHeight);
     icon:SetHeight(self.bar.iconHeight);
+
+    region:UpdateEffectiveOrientation()
   end
   --  region:Scale(1.0, 1.0);
   if data.smoothProgress then

--- a/WeakAuras/RegionTypes/AuraBar.lua
+++ b/WeakAuras/RegionTypes/AuraBar.lua
@@ -1060,6 +1060,8 @@ local function modify(parent, region, data)
         orientVertical(region, data);
       end
     end
+
+    region.subRegionEvents:Notify("OrientationChanged")
   end
 
   -- Apply orientation alignment

--- a/WeakAuras/RegionTypes/AuraBar.lua
+++ b/WeakAuras/RegionTypes/AuraBar.lua
@@ -690,6 +690,7 @@ local funcs = {
     else
       self.bar:SetValue(1 - self.bar:GetValue());
     end
+    self.subRegionEvents:Notify("InverseChanged")
   end,
   SetOrientation = function(self, orientation)
     self.orientation = orientation
@@ -704,8 +705,13 @@ local funcs = {
   end,
   SetOverlayColor = function(self, id, r, g, b, a)
     self.bar:SetAdditionalBarColor(id, { r, g, b, a});
+  end,
+  GetEffectiveOrientation = function(self)
+    return self.effectiveOrientation
+  end,
+  GetInverse = function(self)
+    return self.inverseDirection
   end
-
 }
 
 -- Called when first creating a new region/display

--- a/WeakAuras/RegionTypes/AuraBar.lua
+++ b/WeakAuras/RegionTypes/AuraBar.lua
@@ -553,68 +553,160 @@ local barPrototype = {
   ["orientation"] = "HORIZONTAL",
 }
 
-local function AnchorSubRegion(self, subRegion, anchorType, selfPoint, anchorPoint, anchorXOffset, anchorYOffset)
-  if anchorType == "area" then
-    local anchor = self
-    if selfPoint == "bar" then
-      anchor = self
-    elseif selfPoint == "icon" then
-      anchor = self.icon
-    elseif selfPoint == "fg" then
-      anchor = self.bar.fgFrame
-    elseif selfPoint == "bg" then
-      anchor = self.bar.bg
-    end
-
-    anchorXOffset = anchorXOffset or 0
-    anchorYOffset = anchorYOffset or 0
-    subRegion:ClearAllPoints()
-    subRegion:SetPoint("bottomleft", anchor, "bottomleft", -anchorXOffset, -anchorYOffset)
-    subRegion:SetPoint("topright", anchor, "topright", anchorXOffset,  anchorYOffset)
-  else
-    subRegion:ClearAllPoints()
-    anchorPoint = anchorPoint or "CENTER"
-
-    local anchorRegion = self.bar
-
-    anchorXOffset = anchorXOffset or 0
-    anchorYOffset = anchorYOffset or 0
-
-    if anchorPoint:sub(1, 5) == "ICON_" then
-      anchorRegion = self.icon
-      anchorPoint = anchorPoint:sub(6)
-    elseif anchorPoint:sub(1, 6) == "INNER_" then
-      anchorPoint = anchorPoint:sub(7)
-
-      if anchorPoint:find("LEFT", 1, true) then
-        anchorXOffset = anchorXOffset + 2
-      elseif anchorPoint:find("RIGHT", 1, true) then
-        anchorXOffset = anchorXOffset - 2
+local funcs = {
+  AnchorSubRegion = function(self, subRegion, anchorType, selfPoint, anchorPoint, anchorXOffset, anchorYOffset)
+    if anchorType == "area" then
+      local anchor = self
+      if selfPoint == "bar" then
+        anchor = self
+      elseif selfPoint == "icon" then
+        anchor = self.icon
+      elseif selfPoint == "fg" then
+        anchor = self.bar.fgFrame
+      elseif selfPoint == "bg" then
+        anchor = self.bar.bg
       end
 
-      if anchorPoint:find("TOP", 1, true) then
-        anchorYOffset = anchorYOffset - 2
-      elseif anchorPoint:find("BOTTOM", 1, true) then
-        anchorYOffset = anchorYOffset + 2
+      anchorXOffset = anchorXOffset or 0
+      anchorYOffset = anchorYOffset or 0
+      subRegion:ClearAllPoints()
+      subRegion:SetPoint("bottomleft", anchor, "bottomleft", -anchorXOffset, -anchorYOffset)
+      subRegion:SetPoint("topright", anchor, "topright", anchorXOffset,  anchorYOffset)
+    else
+      subRegion:ClearAllPoints()
+      anchorPoint = anchorPoint or "CENTER"
+
+      local anchorRegion = self.bar
+
+      anchorXOffset = anchorXOffset or 0
+      anchorYOffset = anchorYOffset or 0
+
+      if anchorPoint:sub(1, 5) == "ICON_" then
+        anchorRegion = self.icon
+        anchorPoint = anchorPoint:sub(6)
+      elseif anchorPoint:sub(1, 6) == "INNER_" then
+        anchorPoint = anchorPoint:sub(7)
+
+        if anchorPoint:find("LEFT", 1, true) then
+          anchorXOffset = anchorXOffset + 2
+        elseif anchorPoint:find("RIGHT", 1, true) then
+          anchorXOffset = anchorXOffset - 2
+        end
+
+        if anchorPoint:find("TOP", 1, true) then
+          anchorYOffset = anchorYOffset - 2
+        elseif anchorPoint:find("BOTTOM", 1, true) then
+          anchorYOffset = anchorYOffset + 2
+        end
+      elseif anchorPoint == "SPARK" then
+        anchorRegion = self.bar.spark
+        anchorPoint = "CENTER"
       end
-    elseif anchorPoint == "SPARK" then
-      anchorRegion = self.bar.spark
-      anchorPoint = "CENTER"
+
+      selfPoint = selfPoint or "CENTER"
+
+      if not WeakAuras.point_types[selfPoint] then
+        selfPoint = "CENTER"
+      end
+
+      if not WeakAuras.point_types[anchorPoint] then
+        anchorPoint = "CENTER"
+      end
+
+      subRegion:SetPoint(selfPoint, anchorRegion, anchorPoint, anchorXOffset, anchorYOffset)
+    end
+  end,
+  SetIconColor = function(self, r, g, b, a)
+    self.icon:SetVertexColor(r, g, b, a);
+  end,
+  SetIconDesaturated = function(self, b)
+    self.icon:SetDesaturated(b);
+  end,
+  SetBackgroundColor = function (self, r, g, b, a)
+    self.bar:SetBackgroundColor(r, g, b, a);
+  end,
+  SetSparkColor = function(self, r, g, b, a)
+    self.bar.spark:SetVertexColor(r, g, b, a);
+  end,
+  SetSparkHeight = function(self, height)
+    self.bar.spark:SetHeight(height);
+  end,
+  SetSparkWidth = function(self, width)
+    self.bar.spark:SetWidth(width);
+  end,
+  SetRegionWidth = function(self, width)
+    self.width = width;
+    self:Scale(self.scalex, self.scaley);
+  end,
+  SetRegionHeight = function(self, height)
+    self.height = height;
+    self:Scale(self.scalex, self.scaley);
+  end,
+  SetValue = function(self, value, total)
+    local progress = 0;
+    if (total ~= 0) then
+      progress = value / total;
     end
 
-    selfPoint = selfPoint or "CENTER"
-
-    if not WeakAuras.point_types[selfPoint] then
-      selfPoint = "CENTER"
+    if self.inverseDirection then
+      progress = 1 - progress;
     end
 
-    if not WeakAuras.point_types[anchorPoint] then
-      anchorPoint = "CENTER"
+    if (self.smoothProgress) then
+      self.bar.targetValue = progress
+      self.bar:SetSmoothedValue(progress);
+    else
+      self.bar:SetValue(progress);
     end
-
-    subRegion:SetPoint(selfPoint, anchorRegion, anchorPoint, anchorXOffset, anchorYOffset)
+  end,
+  SetTime = function(self, duration, expirationTime, inverse)
+    local remaining = expirationTime - GetTime();
+    local progress = duration ~= 0 and remaining / duration or 0;
+    -- Need to invert?
+    if (
+      (self.inverseDirection and not inverse)
+      or (inverse and not self.inverseDirection)
+      )
+    then
+      progress = 1 - progress;
+    end
+    if (self.smoothProgress) then
+      self.bar.targetValue = progress
+      self.bar:SetSmoothedValue(progress);
+    else
+      self.bar:SetValue(progress);
+    end
+  end,
+  SetInverse = function(self, inverse)
+    if (self.inverseDirection == inverse) then
+      return;
+    end
+    self.inverseDirection = inverse;
+    if (self.smoothProgress) then
+      if (self.bar.targetValue) then
+        self.bar.targetValue = 1 - self.bar.targetValue
+        self.bar:SetSmoothedValue(self.bar.targetValue);
+      end
+    else
+      self.bar:SetValue(1 - self.bar:GetValue());
+    end
+  end,
+  SetOrientation = function(self, orientation)
+    self.orientation = orientation
+    self:UpdateEffectiveOrientation()
+    if (self.smoothProgress) then
+      if self.bar.targetValue then
+        self.bar:SetSmoothedValue(self.bar.targetValue);
+      end
+    else
+      self.bar:SetValue(self.bar:GetValue());
+    end
+  end,
+  SetOverlayColor = function(self, id, r, g, b, a)
+    self.bar:SetAdditionalBarColor(id, { r, g, b, a});
   end
-end
+
+}
 
 -- Called when first creating a new region/display
 local function create(parent)
@@ -676,7 +768,9 @@ local function create(parent)
 
   WeakAuras.regionPrototype.create(region);
 
-  region.AnchorSubRegion = AnchorSubRegion
+  for k, f in pairs(funcs) do
+    region[k] = f
+  end
 
   -- Return new display/region
   return region;
@@ -820,12 +914,6 @@ local function orientVertical(region, data)
 
   -- Save orientation
   bar:SetOrientation("VERTICAL");
-end
-
-local function orient(region, data, orientation)
-  -- Apply correct orientation
-  region.orientation = orientation;
-  region:UpdateEffectiveOrientation()
 end
 
 local function GetTexCoordZoom(texWidth)
@@ -1119,106 +1207,8 @@ local function modify(parent, region, data)
     region.PreShow = nil
   end
 
-  function region:SetValue(value, total)
-    local progress = 0;
-    if (total ~= 0) then
-      progress = value / total;
-    end
+  region.smoothProgress = data.smoothProgress
 
-    if region.inverseDirection then
-      progress = 1 - progress;
-    end
-
-    if (data.smoothProgress) then
-      region.bar.targetValue = progress
-      region.bar:SetSmoothedValue(progress);
-    else
-      region.bar:SetValue(progress);
-    end
-  end
-
-  function region:SetTime(duration, expirationTime, inverse)
-    local remaining = expirationTime - GetTime();
-    local progress = duration ~= 0 and remaining / duration or 0;
-    -- Need to invert?
-    if (
-      (region.inverseDirection and not inverse)
-      or (inverse and not region.inverseDirection)
-      )
-    then
-      progress = 1 - progress;
-    end
-    if (data.smoothProgress) then
-      region.bar.targetValue = progress
-      region.bar:SetSmoothedValue(progress);
-    else
-      region.bar:SetValue(progress);
-    end
-  end
-
-  function region:SetIconColor(r, g, b, a)
-    self.icon:SetVertexColor(r, g, b, a);
-  end
-
-  function region:SetIconDesaturated(b)
-    self.icon:SetDesaturated(b);
-  end
-
-  function region:SetBackgroundColor(r, g, b, a)
-    self.bar:SetBackgroundColor(r, g, b, a);
-  end
-
-  function region:SetSparkColor(r, g, b, a)
-    self.bar.spark:SetVertexColor(r, g, b, a);
-  end
-
-  function region:SetSparkHeight(height)
-    self.bar.spark:SetHeight(height);
-  end
-
-  function region:SetSparkWidth(width)
-    self.bar.spark:SetWidth(width);
-  end
-
-  function region:SetRegionWidth(width)
-    self.width = width;
-    self:Scale(self.scalex, self.scaley);
-  end
-
-  function region:SetRegionHeight(height)
-    self.height = height;
-    self:Scale(self.scalex, self.scaley);
-  end
-
-  function region:SetInverse(inverse)
-    if (region.inverseDirection == inverse) then
-      return;
-    end
-    region.inverseDirection = inverse;
-    if (data.smoothProgress) then
-      if (region.bar.targetValue) then
-        region.bar.targetValue = 1 - region.bar.targetValue
-        region.bar:SetSmoothedValue(region.bar.targetValue);
-      end
-    else
-      region.bar:SetValue(1 - region.bar:GetValue());
-    end
-  end
-
-  function region:SetOrientation(orientation)
-    orient(region, data, orientation);
-    if (data.smoothProgress) then
-      if region.bar.targetValue then
-        region.bar:SetSmoothedValue(region.bar.targetValue);
-      end
-    else
-      region.bar:SetValue(region.bar:GetValue());
-    end
-  end
-
-  function region:SetOverlayColor(id, r, g, b, a)
-    region.bar:SetAdditionalBarColor(id, { r, g, b, a});
-  end
   -- Update internal bar alignment
   region.bar:Update();
 

--- a/WeakAuras/RegionTypes/RegionPrototype.lua
+++ b/WeakAuras/RegionTypes/RegionPrototype.lua
@@ -24,7 +24,7 @@ local SubRegionEventSystem =
   end,
 
   RemoveSubscriber = function(self, event, subRegion)
-    tremove(self.events[event], subRegion)
+    tremove(self.events[event], tIndexOf(self.events[event], subRegion))
   end,
 
   Notify = function(self, event, ...)

--- a/WeakAuras/SubRegionTypes/Tick.lua
+++ b/WeakAuras/SubRegionTypes/Tick.lua
@@ -106,7 +106,7 @@ local funcs = {
         offset = (tonumber(percent) / 100) * width
       else
         local pixels = width / (self.parent.state.duration or self.parent.state.total or 1)
-        offset = tonumber(placement) * pixels
+        offset = math.max((tonumber(placement) * pixels), width)
       end
     end
 

--- a/WeakAuras/SubRegionTypes/Tick.lua
+++ b/WeakAuras/SubRegionTypes/Tick.lua
@@ -12,7 +12,6 @@ local default = function(parentType)
     automatic_length = true,
     tick_thickness = 2,
     tick_length = 30,
-    tick_hide_mode = "NEVER",
   }
 end
 
@@ -55,12 +54,6 @@ local properties = {
     min = 0,
     bigStep = 1,
     default = 30,
-  },
-  tick_hide_mode = {
-    display = L["Placement Mode"],
-    setter = "SetTickPlacementMode",
-    type = "list",
-    values = WeakAuras.tick_hide_modes,
   },
 }
 

--- a/WeakAuras/SubRegionTypes/Tick.lua
+++ b/WeakAuras/SubRegionTypes/Tick.lua
@@ -31,13 +31,13 @@ local properties = {
   tick_placement_mode = {
     display = L["Placement Mode"],
     setter = "SetTickPlacementMode",
-    type = "select",
+    type = "list",
     values = WeakAuras.tick_placement_modes,
   },
   tick_placement = {
     display = L["Placement"],
     setter = "SetTickPlacement",
-    type = "input",
+    type = "string",
     validate = WeakAuras.ValidateNumericOrPercent,
   },
   tick_width = {
@@ -59,7 +59,7 @@ local properties = {
   tick_hide_mode = {
     display = L["Placement Mode"],
     setter = "SetTickPlacementMode",
-    type = "select",
+    type = "list",
     values = WeakAuras.tick_hide_modes,
   },
 }
@@ -184,6 +184,7 @@ local function modify(parent, region, parentData, data, first)
   region:SetTickHeight(data.tick_height)
 
   parent.subRegionEvents:AddSubscriber("Update", region)
+  --parent.subRegionEvents:AddSubscriber("FrameTick", region)
 end
 
 local function supports(regionType)

--- a/WeakAuras/SubRegionTypes/Tick.lua
+++ b/WeakAuras/SubRegionTypes/Tick.lua
@@ -7,9 +7,9 @@ local default = function(parentType)
   return {
     tick_visible = true,
     tick_color = {1, 1, 1, 1},
-    tick_placement_mode = "STATIC",
-    tick_placement = "50%",
-    automatic_height = true,
+    tick_placement_mode = "NUMBER",
+    tick_placement = 50,
+    automatic_length = true,
     tick_thickness = 2,
     tick_length = 30,
     tick_hide_mode = "NEVER",
@@ -48,9 +48,9 @@ local properties = {
     bigStep = 1,
     default = 2,
   },
-  tick_height = {
-    display = L["Height"],
-    setter = "SetTickHeight",
+  tick_length = {
+    display = L["Length"],
+    setter = "SetTickLength",
     type = "number",
     min = 0,
     bigStep = 1,
@@ -138,12 +138,12 @@ local funcs = {
       self:SetWidth(thickness)
     end
   end,
-  SetTickHeight = function(self, height)
-    if self.automatic_height then height = self.parentTrueHeight end
+  SetTickLength = function(self, length)
+    if self.automatic_length then length = self.parentTrueHeight end
     if (self.parentOrientation == "VERTICAL") or (self.parentOrientation == "VERTICAL_INVERSE") then
-      self:SetWidth(height)
+      self:SetWidth(length)
     else
-      self:SetHeight(height)
+      self:SetHeight(length)
     end
   end,
 }
@@ -170,15 +170,15 @@ local function modify(parent, region, parentData, data, first)
   region.tick_color = data.tick_color
   region.tick_placement_mode = data.tick_placement_mode
   region.tick_placement = data.tick_placement
-  region.automatic_height = data.automatic_height
+  region.automatic_length = data.automatic_length
   region.tick_thickness = data.tick_thickness
-  region.tick_height = data.tick_height
+  region.tick_length = data.tick_length
 
 
   region:SetVisible(data.tick_visible)
   region:SetTickColor(unpack(data.tick_color))
   region:SetTickThickness(data.tick_thickness)
-  region:SetTickHeight(data.tick_height)
+  region:SetTickLength(data.tick_length)
 
   parent.subRegionEvents:AddSubscriber("Update", region)
   --parent.subRegionEvents:AddSubscriber("FrameTick", region)

--- a/WeakAuras/SubRegionTypes/Tick.lua
+++ b/WeakAuras/SubRegionTypes/Tick.lua
@@ -1,0 +1,182 @@
+if not WeakAuras.IsCorrectVersion() then return end
+
+local SharedMedia = LibStub("LibSharedMedia-3.0");
+local L = WeakAuras.L;
+
+local default = function(parentType)
+  return {
+    tick_visible = true,
+    tick_color = {1, 1, 1, 1},
+    tick_placement_mode = "STATIC",
+    tick_placement = "50%",
+    automatic_height = true,
+    tick_width = 2,
+    tick_height = 30,
+    --tick_hide_mode = "NEVER",
+  }
+end
+
+local properties = {
+  tick_visible = {
+    display = L["Visibility"],
+    setter = "SetVisible",
+    type = "bool",
+    defaultProperty = true
+  },
+  tick_color = {
+    display = L["Color"],
+    setter = "SetTickColor",
+    type = "color"
+  },
+  tick_placement = {
+    display = L["Placement"],
+    setter = "SetTickPlacement",
+    type = "input",
+    validate = WeakAuras.ValidateNumericOrPercent,
+  },
+  tick_width = {
+    display = L["Width"],
+    setter = "SetTickWidth",
+    type = "number",
+    min = 0,
+    bigStep = 1,
+    default = 2,
+  },
+  tick_height = {
+    display = L["Height"],
+    setter = "SetTickHeight",
+    type = "number",
+    min = 0,
+    bigStep = 1,
+    default = 30,
+    --hidden = function() return data.automatic_height end,
+  },
+}
+
+local auraBarTrueLeft = {
+  ["HORIZONTAL"] = "LEFT",
+  ["HORIZONTAL_INVERSE"] = "RIGHT",
+  ["VERTICAL"] = "TOP",
+  ["VERTICAL_INVERSE"] = "BOTTOM",
+}
+
+local auraBarTrueLeftInverse = {
+  ["HORIZONTAL"] = "RIGHT",
+  ["HORIZONTAL_INVERSE"] = "LEFT",
+  ["VERTICAL"] = "BOTTOM",
+  ["VERTICAL_INVERSE"] = "TOP",
+}
+
+local function create()
+  local subRegion = CreateFrame("FRAME", nil, UIParent)
+  subRegion.texture = subRegion:CreateTexture()
+  subRegion.texture:SetDrawLayer("ARTWORK", 3)
+  subRegion.texture:SetAllPoints(subRegion)
+  return subRegion
+end
+
+local function onAcquire(subRegion)
+  subRegion:Show()
+end
+
+local function onRelease(subRegion)
+  subRegion:Hide()
+end
+
+local funcs = {
+  ["Update"] = function(self)
+    self:SetTickPlacement(self.tick_placement)
+  end,
+  SetVisible = function(self, visible)
+    if visible then
+      self:Show()
+    else
+      self:Hide()
+    end
+  end,
+  SetTickColor = function(self, r, g, b, a)
+    self.texture:SetColorTexture(r, g, b, a or 1)
+  end,
+  SetTickPlacement = function(self, placement)
+    local offset, offsetx, offsety = self.tick_placement, 0, 0
+    local width = self.parentTrueWidth
+    if self.tick_placement_mode == "STATIC" then
+      local percent = string.match(placement, "(%d+)%%")
+      if percent then
+        offset = (tonumber(percent) / 100) * width
+      else
+        local pixels = width / (self.parent.state.duration or self.parent.state.total or 1)
+        offset = tonumber(placement) * pixels
+      end
+    end
+
+    if self.parentInverse ~= ((self.parentOrientation == "HORIZONTAL_INVERSE") or (self.parentOrientation == "VERTICAL")) then
+      offset = -offset
+    end
+    if (self.parentOrientation == "VERTICAL") or (self.parentOrientation == "VERTICAL_INVERSE") then
+      offsety = offset
+    else
+      offsetx = offset
+    end
+    local side = self.parentInverse and auraBarTrueLeftInverse or auraBarTrueLeft
+
+    self:ClearAllPoints()
+    self:SetPoint("CENTER", self.parent.bar, side[self.parentOrientation], offsetx, offsety)
+  end,
+  SetTickWidth = function(self, width)
+    if (self.parentOrientation == "VERTICAL") or (self.parentOrientation == "VERTICAL_INVERSE") then
+      self:SetHeight(width)
+    else
+      self:SetWidth(width)
+    end
+  end,
+  SetTickHeight = function(self, height)
+    if self.automatic_height then height = self.parentTrueHeight end
+    if (self.parentOrientation == "VERTICAL") or (self.parentOrientation == "VERTICAL_INVERSE") then
+      self:SetWidth(height)
+    else
+      self:SetHeight(height)
+    end
+  end,
+}
+
+local function modify(parent, region, parentData, data, first)
+
+  region:SetParent(parent)
+  region.parentOrientation = parentData.orientation
+  region.parentInverse = parentData.inverse
+  if (region.parentOrientation == "VERTICAL") or (region.parentOrientation == "VERTICAL_INVERSE") then
+    region.parentTrueHeight, region.parentTrueWidth = parent.bar:GetRealSize()
+  else
+    region.parentTrueWidth, region.parentTrueHeight = parent.bar:GetRealSize()
+  end
+
+  for k, v in pairs(funcs) do
+    region[k] = v
+  end
+
+  --for k, v in pairs(parent.state) do print(k, v) end
+
+  region.parent = parent
+  region.tick_visible = data.tick_visible
+  region.tick_color = data.tick_color
+  region.tick_placement_mode = data.tick_placement_mode
+  region.tick_placement = data.tick_placement
+  region.automatic_height = data.automatic_height
+  region.tick_width = data.tick_width
+  region.tick_height = data.tick_height
+
+
+  region:SetVisible(data.tick_visible)
+  region:SetTickColor(unpack(data.tick_color))
+  region:SetTickWidth(data.tick_width)
+  region:SetTickHeight(data.tick_height)
+
+  parent.subRegionEvents:AddSubscriber("Update", region)
+end
+
+local function supports(regionType)
+  return regionType == "aurabar"
+end
+
+WeakAuras.RegisterSubRegionType("subtick", L["Tick"], supports, create, modify, onAcquire, onRelease, default, nil, properties);

--- a/WeakAuras/SubRegionTypes/Tick.lua
+++ b/WeakAuras/SubRegionTypes/Tick.lua
@@ -7,8 +7,8 @@ local default = function(parentType)
   return {
     tick_visible = true,
     tick_color = {1, 1, 1, 1},
-    tick_placement_mode = "NUMBER",
-    tick_placement = 50,
+    tick_placement_mode = "ABSOLUTE",
+    tick_placement = "50",
     automatic_length = true,
     tick_thickness = 2,
     tick_length = 30,

--- a/WeakAuras/SubRegionTypes/Tick.lua
+++ b/WeakAuras/SubRegionTypes/Tick.lua
@@ -111,14 +111,11 @@ local funcs = {
   SetTickPlacement = function(self, placement)
     local offset, offsetx, offsety = self.tick_placement, 0, 0
     local width = self.parentTrueWidth
-    if self.tick_placement_mode == "STATIC" then
-      local percent = string.match(placement, "(%d+)%%")
-      if percent then
-        offset = (tonumber(percent) / 100) * width
-      else
-        local pixels = width / (self.parent.state.duration or self.parent.state.total or 1)
-        offset = math.max((tonumber(placement) * pixels), width)
-      end
+    if self.tick_placement_mode == "NUMERIC" then
+      local pixels = width / (self.parent.state.duration or self.parent.state.total or 1)
+      offset = math.max((placement * pixels), width)
+    elseif self.tick_placement_mode == "PERCENT" then
+      offset = (placement / 100) * width
     end
 
     if self.parentInverse ~= ((self.parentOrientation == "HORIZONTAL_INVERSE") or (self.parentOrientation == "VERTICAL")) then

--- a/WeakAuras/SubRegionTypes/Tick.lua
+++ b/WeakAuras/SubRegionTypes/Tick.lua
@@ -97,7 +97,6 @@ local funcs = {
     self:SetTickThickness(self.tick_thickness)
   end,
   ["OnSizeChanged"] = function(self)
-    print("size changed")
     self:SetTickPlacement(self.tick_placement)
     self:SetTickLength(self.tick_length)
     self:SetTickThickness(self.tick_thickness)
@@ -122,10 +121,9 @@ local funcs = {
     end
     local offset, offsetx, offsety = self.tick_placement, 0, 0
     local width = self.parentTrueWidth
-    print(offset, width, self.parentTrueHeight)
     if self.tick_placement_mode == "ABSOLUTE" then
       local pixels = width / (self.parent.state.duration or self.parent.state.total or 1)
-      offset = math.max((placement * pixels), width)
+      offset = math.max(math.min((placement * pixels), width), 0)
     elseif self.tick_placement_mode == "RELATIVE" then
       offset = (placement / 100) * width
     end
@@ -139,12 +137,10 @@ local funcs = {
       offsetx = offset
     end
     local side = self.parentInverse and auraBarTrueLeftInverse or auraBarTrueLeft
-    print(offset, offsetx, offsety)
     self:ClearAllPoints()
     self:SetPoint("CENTER", self.parent.bar, side[self.parentOrientation], offsetx, offsety)
   end,
   SetTickThickness = function(self, thickness)
-    self.parentOrientation = self.parent.effectiveOrientation
     if (self.parentOrientation == "VERTICAL") or (self.parentOrientation == "VERTICAL_INVERSE") then
       self:SetHeight(thickness)
     else
@@ -152,7 +148,6 @@ local funcs = {
     end
   end,
   SetTickLength = function(self, length)
-    self.parentOrientation = self.parent.effectiveOrientation
     if self.automatic_length then length = self.parentTrueHeight end
     if (self.parentOrientation == "VERTICAL") or (self.parentOrientation == "VERTICAL_INVERSE") then
       self:SetWidth(length)
@@ -197,7 +192,7 @@ local function modify(parent, region, parentData, data, first)
 
   parent.subRegionEvents:AddSubscriber("Update", region)
   parent.subRegionEvents:AddSubscriber("OrientationChanged", region)
-  parent.subRegionEvents:AddSubscriber("OnSizeChanged", region)
+  parent:SetScript("OnSizeChanged", function() region:OnSizeChanged() end)
 end
 
 local function supports(regionType)

--- a/WeakAuras/SubRegionTypes/Tick.lua
+++ b/WeakAuras/SubRegionTypes/Tick.lua
@@ -36,8 +36,8 @@ local properties = {
   tick_placement = {
     display = L["Placement"],
     setter = "SetTickPlacement",
-    type = "string",
-    validate = WeakAuras.ValidateNumericOrPercent,
+    type = "number",
+    validate = WeakAuras.ValidateNumeric,
   },
   tick_thickness = {
     display = L["Thickness"],

--- a/WeakAuras/SubRegionTypes/Tick.lua
+++ b/WeakAuras/SubRegionTypes/Tick.lua
@@ -12,7 +12,7 @@ local default = function(parentType)
     automatic_height = true,
     tick_width = 2,
     tick_height = 30,
-    --tick_hide_mode = "NEVER",
+    tick_hide_mode = "NEVER",
   }
 end
 
@@ -21,12 +21,18 @@ local properties = {
     display = L["Visibility"],
     setter = "SetVisible",
     type = "bool",
-    defaultProperty = true
+    defaultProperty = true,
   },
   tick_color = {
     display = L["Color"],
     setter = "SetTickColor",
-    type = "color"
+    type = "color",
+  },
+  tick_placement_mode = {
+    display = L["Placement Mode"],
+    setter = "SetTickPlacementMode",
+    type = "select",
+    values = WeakAuras.tick_placement_modes,
   },
   tick_placement = {
     display = L["Placement"],
@@ -49,7 +55,12 @@ local properties = {
     min = 0,
     bigStep = 1,
     default = 30,
-    --hidden = function() return data.automatic_height end,
+  },
+  tick_hide_mode = {
+    display = L["Placement Mode"],
+    setter = "SetTickPlacementMode",
+    type = "select",
+    values = WeakAuras.tick_hide_modes,
   },
 }
 

--- a/WeakAuras/SubRegionTypes/Tick.lua
+++ b/WeakAuras/SubRegionTypes/Tick.lua
@@ -10,8 +10,8 @@ local default = function(parentType)
     tick_placement_mode = "STATIC",
     tick_placement = "50%",
     automatic_height = true,
-    tick_width = 2,
-    tick_height = 30,
+    tick_thickness = 2,
+    tick_length = 30,
     tick_hide_mode = "NEVER",
   }
 end
@@ -40,9 +40,9 @@ local properties = {
     type = "string",
     validate = WeakAuras.ValidateNumericOrPercent,
   },
-  tick_width = {
-    display = L["Width"],
-    setter = "SetTickWidth",
+  tick_thickness = {
+    display = L["Thickness"],
+    setter = "SetTickThickness",
     type = "number",
     min = 0,
     bigStep = 1,
@@ -134,11 +134,11 @@ local funcs = {
     self:ClearAllPoints()
     self:SetPoint("CENTER", self.parent.bar, side[self.parentOrientation], offsetx, offsety)
   end,
-  SetTickWidth = function(self, width)
+  SetTickThickness = function(self, thickness)
     if (self.parentOrientation == "VERTICAL") or (self.parentOrientation == "VERTICAL_INVERSE") then
-      self:SetHeight(width)
+      self:SetHeight(thickness)
     else
-      self:SetWidth(width)
+      self:SetWidth(thickness)
     end
   end,
   SetTickHeight = function(self, height)
@@ -174,13 +174,13 @@ local function modify(parent, region, parentData, data, first)
   region.tick_placement_mode = data.tick_placement_mode
   region.tick_placement = data.tick_placement
   region.automatic_height = data.automatic_height
-  region.tick_width = data.tick_width
+  region.tick_thickness = data.tick_thickness
   region.tick_height = data.tick_height
 
 
   region:SetVisible(data.tick_visible)
   region:SetTickColor(unpack(data.tick_color))
-  region:SetTickWidth(data.tick_width)
+  region:SetTickThickness(data.tick_thickness)
   region:SetTickHeight(data.tick_height)
 
   parent.subRegionEvents:AddSubscriber("Update", region)

--- a/WeakAuras/Types.lua
+++ b/WeakAuras/Types.lua
@@ -375,15 +375,6 @@ WeakAuras.spark_hide_types = {
 WeakAuras.tick_placement_modes = {
   NUMBER = L["Number Value"],
   PERCENT = L["Percentage"],
-  CUSTOM  = L["Custom"]
-}
-
-WeakAuras.tick_hide_modes = {
-  NEVER = L["Never"],
-  FULL  = L["Full"],
-  EMPTY = L["Empty"],
-  BOTH  = L["Both"],
-  AUTO  = L["Automatic"],
 }
 
 WeakAuras.containment_types = {

--- a/WeakAuras/Types.lua
+++ b/WeakAuras/Types.lua
@@ -377,7 +377,7 @@ WeakAuras.tick_placement_modes = {
   STATIC = L["Static"]
 }
 
---[[WeakAuras.tick_hide_types = {
+--[[WeakAuras.tick_hide_modes = {
   NEVER = L["Never"],
   FULL  = L["Full"],
   EMPTY = L["Empty"],

--- a/WeakAuras/Types.lua
+++ b/WeakAuras/Types.lua
@@ -377,12 +377,13 @@ WeakAuras.tick_placement_modes = {
   STATIC = L["Static"]
 }
 
---[[WeakAuras.tick_hide_modes = {
+WeakAuras.tick_hide_modes = {
   NEVER = L["Never"],
   FULL  = L["Full"],
   EMPTY = L["Empty"],
+  BOTH  = L["Empty"],
   AUTO  = L["Automatic"],
-}]]--
+}
 
 WeakAuras.containment_types = {
   OUTSIDE = L["Outside"],

--- a/WeakAuras/Types.lua
+++ b/WeakAuras/Types.lua
@@ -373,8 +373,8 @@ WeakAuras.spark_hide_types = {
 }
 
 WeakAuras.tick_placement_modes = {
-  NUMBER = L["Number Value"],
-  PERCENT = L["Percentage"],
+  ABSOLUTE = L["Absolute"],
+  RELATIVE = L["Relative"],
 }
 
 WeakAuras.containment_types = {

--- a/WeakAuras/Types.lua
+++ b/WeakAuras/Types.lua
@@ -373,15 +373,16 @@ WeakAuras.spark_hide_types = {
 }
 
 WeakAuras.tick_placement_modes = {
-  AUTO = L["Automatic"],
-  STATIC = L["Static"]
+  NUMERIC = L["Number Value"],
+  PERCENT = L["Percentage"],
+  CUSTOM  = L["Custom"]
 }
 
 WeakAuras.tick_hide_modes = {
   NEVER = L["Never"],
   FULL  = L["Full"],
   EMPTY = L["Empty"],
-  BOTH  = L["Empty"],
+  BOTH  = L["Both"],
   AUTO  = L["Automatic"],
 }
 

--- a/WeakAuras/Types.lua
+++ b/WeakAuras/Types.lua
@@ -373,8 +373,10 @@ WeakAuras.spark_hide_types = {
 }
 
 WeakAuras.tick_placement_modes = {
-  ABSOLUTE = L["Absolute"],
-  RELATIVE = L["Relative"],
+  AtValue = L["At Value"],
+  AtMissingValue = L["At missing Value"],
+  AtPercent = L["At Percent"],
+  ValueOffset = L["Offset from progress"]
 }
 
 WeakAuras.containment_types = {

--- a/WeakAuras/Types.lua
+++ b/WeakAuras/Types.lua
@@ -372,6 +372,18 @@ WeakAuras.spark_hide_types = {
   BOTH  = L["Full/Empty"]
 }
 
+WeakAuras.tick_placement_modes = {
+  AUTO = L["Automatic"],
+  STATIC = L["Static"]
+}
+
+--[[WeakAuras.tick_hide_types = {
+  NEVER = L["Never"],
+  FULL  = L["Full"],
+  EMPTY = L["Empty"],
+  AUTO  = L["Automatic"],
+}]]--
+
 WeakAuras.containment_types = {
   OUTSIDE = L["Outside"],
   INSIDE = L["Inside"]

--- a/WeakAuras/Types.lua
+++ b/WeakAuras/Types.lua
@@ -373,7 +373,7 @@ WeakAuras.spark_hide_types = {
 }
 
 WeakAuras.tick_placement_modes = {
-  NUMERIC = L["Number Value"],
+  NUMBER = L["Number Value"],
   PERCENT = L["Percentage"],
   CUSTOM  = L["Custom"]
 }

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -6056,7 +6056,7 @@ end
 local function ApplyStateToRegion(id, cloneId, region, parent)
   region:Update();
 
-  region.subRegionEvents:Notify("Update")
+  region.subRegionEvents:Notify("Update", region.state, region.states)
 
   WeakAuras.UpdateMouseoverTooltip(region);
   region:Expand();

--- a/WeakAuras/WeakAuras.toc
+++ b/WeakAuras/WeakAuras.toc
@@ -59,6 +59,7 @@ RegionTypes\Model.lua
 SubRegionTypes\SubText.lua
 SubRegionTypes\Border.lua
 SubRegionTypes\Glow.lua
+SubRegionTypes\Tick.lua
 #@retail@
 SubRegionTypes\BarModel.lua
 #@end-retail@

--- a/WeakAurasOptions/SubRegionOptions/Tick.lua
+++ b/WeakAurasOptions/SubRegionOptions/Tick.lua
@@ -1,0 +1,118 @@
+if not WeakAuras.IsCorrectVersion() then return end
+
+local SharedMedia = LibStub("LibSharedMedia-3.0");
+local L = WeakAuras.L;
+
+local screenWidth, screenHeight = math.ceil(GetScreenWidth() / 20) * 20, math.ceil(GetScreenHeight() / 20) * 20;
+
+
+local indentWidth = WeakAuras.normalWidth * 0.06
+
+
+local function createOptions(parentData, data, index, subIndex)
+
+  local hiddenTickExtra = function()
+    return WeakAuras.IsCollapsed("tick", "tick", "tickextra" .. index, true);
+  end
+
+  local order = 9
+  local options = {
+    __title = L["Tick %s"]:format(subIndex),
+    __order = 1,
+    __up = function()
+      if (WeakAuras.ApplyToDataOrChildData(parentData, WeakAuras.MoveSubRegionUp, index, "subtick")) then
+        WeakAuras.ReloadOptions2(parentData.id, parentData)
+      end
+    end,
+    __down = function()
+      if (WeakAuras.ApplyToDataOrChildData(parentData, WeakAuras.MoveSubRegionDown, index, "subtick")) then
+        WeakAuras.ReloadOptions2(parentData.id, parentData)
+      end
+    end,
+    __duplicate = function()
+      if (WeakAuras.ApplyToDataOrChildData(parentData, WeakAuras.DuplicateSubRegion, index, "subtick")) then
+        WeakAuras.ReloadOptions2(parentData.id, parentData)
+      end
+    end,
+    __delete = function()
+      if (WeakAuras.ApplyToDataOrChildData(parentData, WeakAuras.DeleteSubRegion, index, "subtick")) then
+        WeakAuras.ReloadOptions2(parentData.id, parentData)
+      end
+    end,
+    tick_visible = {
+      type = "toggle",
+      width = WeakAuras.normalWidth,
+      name = L["Show Tick"],
+      order = order + 0.01,
+    },
+    tick_color = {
+      type = "color",
+      width = WeakAuras.normalWidth,
+      name = L["Color"],
+      order = order + 0.02,
+      hasAlpha = true,
+    },
+    tick_placement_mode = {
+      type = "select",
+      width = WeakAuras.normalWidth,
+      name = L["Tick Mode"],
+      order = order + 0.10,
+      values = WeakAuras.tick_placement_modes,
+      desc = L["Automatic mode moves the tick as the bar progresses"],
+    },
+    tick_placement = {
+      type = "input",
+      width = WeakAuras.normalWidth,
+      name = L["Tick Placement"],
+      order = order + 0.11,
+      validate = WeakAuras.ValidateNumericOrPercent,
+      disabled = function() return data.tick_placement_mode == "AUTO" end,
+      desc = L["Enter static or relative values with %"],
+    },
+    tick_space1 = {
+      type = "description",
+      width = WeakAuras.normalWidth,
+      name = "",
+      order = order + 0.20,
+    },
+    automatic_height = {
+      type = "toggle",
+      width = WeakAuras.normalWidth,
+      name = L["Automatic Height"],
+      order = order + 0.21,
+      desc = L["Matches the height setting of the bar."],
+    },
+    tick_width = {
+      type = "range",
+      width = WeakAuras.normalWidth,
+      name = L["Width"],
+      order = order + 0.30,
+      min = 0,
+      --softMin = 0,
+      softMax = 20,
+      step = 1,
+    },
+    tick_height = {
+      type = "range",
+      width = WeakAuras.normalWidth,
+      name = L["Height"],
+      order = order + 0.31,
+      min = 0,
+      --softMin = 0,
+      softMax = 50,
+      step = 1,
+      disabled = function() return data.automatic_height end,
+    },
+    --[[tick_hide_mode = {
+      type = "select",
+      name = L["Hide On"],
+      width = WeakAuras.normalWidth - indentWidth,
+      order = order + 1.52,
+      values = WeakAuras.tick_hide_types,
+      hidden = hiddenTickExtra,
+    },]]--
+  }
+  return options
+end
+
+WeakAuras.RegisterSubRegionOptions("subtick", createOptions, L["Places a tick on the bar"]);

--- a/WeakAurasOptions/SubRegionOptions/Tick.lua
+++ b/WeakAurasOptions/SubRegionOptions/Tick.lua
@@ -103,14 +103,14 @@ local function createOptions(parentData, data, index, subIndex)
       step = 1,
       disabled = function() return data.automatic_height end,
     },
-    --[[tick_hide_mode = {
+    tick_hide_mode = {
       type = "select",
       name = L["Hide On"],
       width = WeakAuras.normalWidth - indentWidth,
       order = order + 1.52,
-      values = WeakAuras.tick_hide_types,
+      values = WeakAuras.tick_hide_modes,
       hidden = hiddenTickExtra,
-    },]]--
+    },
   }
   return options
 end

--- a/WeakAurasOptions/SubRegionOptions/Tick.lua
+++ b/WeakAurasOptions/SubRegionOptions/Tick.lua
@@ -11,10 +11,6 @@ local indentWidth = WeakAuras.normalWidth * 0.06
 
 local function createOptions(parentData, data, index, subIndex)
 
-  local hiddenTickExtra = function()
-    return WeakAuras.IsCollapsed("tick", "tick", "tickextra" .. index, true);
-  end
-
   local order = 9
   local options = {
     __title = L["Tick %s"]:format(subIndex),
@@ -88,7 +84,6 @@ local function createOptions(parentData, data, index, subIndex)
       name = L["Thickness"],
       order = order + 0.30,
       min = 0,
-      --softMin = 0,
       softMax = 20,
       step = 1,
     },
@@ -98,18 +93,9 @@ local function createOptions(parentData, data, index, subIndex)
       name = L["Length"],
       order = order + 0.31,
       min = 0,
-      --softMin = 0,
       softMax = 50,
       step = 1,
       disabled = function() return data.automatic_length end,
-    },
-    tick_hide_mode = {
-      type = "select",
-      name = L["Hide On"],
-      width = WeakAuras.normalWidth - indentWidth,
-      order = order + 1.52,
-      values = WeakAuras.tick_hide_modes,
-      hidden = hiddenTickExtra,
     },
   }
   return options

--- a/WeakAurasOptions/SubRegionOptions/Tick.lua
+++ b/WeakAurasOptions/SubRegionOptions/Tick.lua
@@ -61,13 +61,13 @@ local function createOptions(parentData, data, index, subIndex)
       desc = L["Automatic mode moves the tick as the bar progresses"],
     },
     tick_placement = {
-      type = "number",
+      type = "input",
       width = WeakAuras.normalWidth,
       name = L["Tick Placement"],
       order = order + 0.11,
-      validate = WeakAuras.ValidateNumericOrPercent,
-      disabled = function() return data.tick_placement_mode == "AUTO" end,
-      desc = L["Enter progress values that are static or relative values with %"],
+      validate = WeakAuras.ValidateNumeric,
+      disabled = function() return data.tick_placement_mode == "CUSTOM" end,
+      desc = L["Enter in a value for the tick's placement."],
     },
     tick_space1 = {
       type = "description",

--- a/WeakAurasOptions/SubRegionOptions/Tick.lua
+++ b/WeakAurasOptions/SubRegionOptions/Tick.lua
@@ -67,7 +67,7 @@ local function createOptions(parentData, data, index, subIndex)
       order = order + 0.11,
       validate = WeakAuras.ValidateNumericOrPercent,
       disabled = function() return data.tick_placement_mode == "AUTO" end,
-      desc = L["Enter static or relative values with %"],
+      desc = L["Enter progress values that are static or relative values with %"],
     },
     tick_space1 = {
       type = "description",

--- a/WeakAurasOptions/SubRegionOptions/Tick.lua
+++ b/WeakAurasOptions/SubRegionOptions/Tick.lua
@@ -75,33 +75,33 @@ local function createOptions(parentData, data, index, subIndex)
       name = "",
       order = order + 0.20,
     },
-    automatic_height = {
+    automatic_length = {
       type = "toggle",
       width = WeakAuras.normalWidth,
-      name = L["Automatic Height"],
+      name = L["Automatic length"],
       order = order + 0.21,
-      desc = L["Matches the height setting of the bar."],
+      desc = L["Matches the height setting of a horizontal bar or width for a vertical bar."],
     },
-    tick_width = {
+    tick_thickness = {
       type = "range",
       width = WeakAuras.normalWidth,
-      name = L["Width"],
+      name = L["Thickness"],
       order = order + 0.30,
       min = 0,
       --softMin = 0,
       softMax = 20,
       step = 1,
     },
-    tick_height = {
+    tick_length = {
       type = "range",
       width = WeakAuras.normalWidth,
-      name = L["Height"],
+      name = L["Length"],
       order = order + 0.31,
       min = 0,
       --softMin = 0,
       softMax = 50,
       step = 1,
-      disabled = function() return data.automatic_height end,
+      disabled = function() return data.automatic_length end,
     },
     tick_hide_mode = {
       type = "select",

--- a/WeakAurasOptions/SubRegionOptions/Tick.lua
+++ b/WeakAurasOptions/SubRegionOptions/Tick.lua
@@ -3,15 +3,9 @@ if not WeakAuras.IsCorrectVersion() then return end
 local SharedMedia = LibStub("LibSharedMedia-3.0");
 local L = WeakAuras.L;
 
-local screenWidth, screenHeight = math.ceil(GetScreenWidth() / 20) * 20, math.ceil(GetScreenHeight() / 20) * 20;
-
-
 local indentWidth = WeakAuras.normalWidth * 0.06
 
-
 local function createOptions(parentData, data, index, subIndex)
-
-  local order = 9
   local options = {
     __title = L["Tick %s"]:format(subIndex),
     __order = 1,
@@ -39,28 +33,29 @@ local function createOptions(parentData, data, index, subIndex)
       type = "toggle",
       width = WeakAuras.normalWidth,
       name = L["Show Tick"],
-      order = order + 0.01,
+      order = 1,
     },
     tick_color = {
       type = "color",
       width = WeakAuras.normalWidth,
       name = L["Color"],
-      order = order + 0.02,
+      order = 2,
       hasAlpha = true,
     },
     tick_placement_mode = {
       type = "select",
       width = WeakAuras.normalWidth,
       name = L["Tick Mode"],
-      order = order + 0.10,
+      order = 3,
       values = WeakAuras.tick_placement_modes,
-      desc = L["Automatic mode moves the tick as the bar progresses"],
+      desc = L["Relative mode positions the tick at the position relative to the total width of the progress bar.\n" ..
+               "Absolute mode positions the tick at a fixed value."],
     },
     tick_placement = {
       type = "input",
       width = WeakAuras.normalWidth,
       name = L["Tick Placement"],
-      order = order + 0.11,
+      order = 4,
       validate = WeakAuras.ValidateNumeric,
       desc = L["Enter in a value for the tick's placement."],
     },
@@ -68,20 +63,20 @@ local function createOptions(parentData, data, index, subIndex)
       type = "description",
       width = WeakAuras.normalWidth,
       name = "",
-      order = order + 0.20,
+      order = 5,
     },
     automatic_length = {
       type = "toggle",
       width = WeakAuras.normalWidth,
       name = L["Automatic length"],
-      order = order + 0.21,
+      order = 6,
       desc = L["Matches the height setting of a horizontal bar or width for a vertical bar."],
     },
     tick_thickness = {
       type = "range",
       width = WeakAuras.normalWidth,
       name = L["Thickness"],
-      order = order + 0.30,
+      order = 7,
       min = 0,
       softMax = 20,
       step = 1,
@@ -90,7 +85,7 @@ local function createOptions(parentData, data, index, subIndex)
       type = "range",
       width = WeakAuras.normalWidth,
       name = L["Length"],
-      order = order + 0.31,
+      order = 8,
       min = 0,
       softMax = 50,
       step = 1,

--- a/WeakAurasOptions/SubRegionOptions/Tick.lua
+++ b/WeakAurasOptions/SubRegionOptions/Tick.lua
@@ -61,7 +61,7 @@ local function createOptions(parentData, data, index, subIndex)
       desc = L["Automatic mode moves the tick as the bar progresses"],
     },
     tick_placement = {
-      type = "input",
+      type = "number",
       width = WeakAuras.normalWidth,
       name = L["Tick Placement"],
       order = order + 0.11,

--- a/WeakAurasOptions/SubRegionOptions/Tick.lua
+++ b/WeakAurasOptions/SubRegionOptions/Tick.lua
@@ -62,7 +62,6 @@ local function createOptions(parentData, data, index, subIndex)
       name = L["Tick Placement"],
       order = order + 0.11,
       validate = WeakAuras.ValidateNumeric,
-      disabled = function() return data.tick_placement_mode == "CUSTOM" end,
       desc = L["Enter in a value for the tick's placement."],
     },
     tick_space1 = {

--- a/WeakAurasOptions/WeakAurasOptions.toc
+++ b/WeakAurasOptions/WeakAurasOptions.toc
@@ -38,6 +38,7 @@ SubRegionOptions\SubRegionCommon.lua
 SubRegionOptions\SubText.lua
 SubRegionOptions\Border.lua
 SubRegionOptions\Glow.lua
+SubRegionOptions\Tick.lua
 #@retail@
 SubRegionOptions\BarModel.lua
 #@end-retail@


### PR DESCRIPTION
# Description

Adds a simplistic Tick SubRegion (or Sub Element) to Aura Bar type auras. Feature allows for progress values (optionally in percentage form).

![image](https://user-images.githubusercontent.com/28709830/72752240-ed37da00-3b7e-11ea-92f9-6f79a3ec89fc.png)


Fixes #1656

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] Created aura with CD Progress and Custom triggers, tested all orientations and inverse for bar and all tick settings.
- [x] Tested Conditions.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

<!-- Is there any additional work that needs to be done? If so, add it to the above list -->
