### PR TITLE
Add raid mark textures

### DIFF
--- a/WeakAuras/Types.lua
+++ b/WeakAuras/Types.lua
@@ -975,7 +975,7 @@ WeakAuras.texture_types = {
     ["honorsystem-bar-spark"] = "Blizzard Honor System Spark",
     ["bonusobjectives-bar-spark"] = "Bonus Objectives Spark"
   },
-  ["Raid Marks"] = {
+  [BINDING_HEADER_RAID_TARGET] = {
     ["Interface\\TargetingFrame\\UI-RaidTargetingIcon_1"] = RAID_TARGET_1,
     ["Interface\\TargetingFrame\\UI-RaidTargetingIcon_2"] = RAID_TARGET_2,
     ["Interface\\TargetingFrame\\UI-RaidTargetingIcon_3"] = RAID_TARGET_3,

--- a/WeakAuras/Types.lua
+++ b/WeakAuras/Types.lua
@@ -976,14 +976,14 @@ WeakAuras.texture_types = {
     ["bonusobjectives-bar-spark"] = "Bonus Objectives Spark"
   },
   ["Raid Marks"] = {
-    ["Interface\\TargetingFrame\\UI-RaidTargetingIcon_1"] = "Star",
-    ["Interface\\TargetingFrame\\UI-RaidTargetingIcon_2"] = "Circle",
-    ["Interface\\TargetingFrame\\UI-RaidTargetingIcon_3"] = "Diamond",
-    ["Interface\\TargetingFrame\\UI-RaidTargetingIcon_4"] = "Triangle",
-    ["Interface\\TargetingFrame\\UI-RaidTargetingIcon_5"] = "Moon",
-    ["Interface\\TargetingFrame\\UI-RaidTargetingIcon_6"] = "Square",
-    ["Interface\\TargetingFrame\\UI-RaidTargetingIcon_7"] = "Cross",
-    ["Interface\\TargetingFrame\\UI-RaidTargetingIcon_8"] = "Skull",
+    ["Interface\\TargetingFrame\\UI-RaidTargetingIcon_1"] = RAID_TARGET_1,
+    ["Interface\\TargetingFrame\\UI-RaidTargetingIcon_2"] = RAID_TARGET_2,
+    ["Interface\\TargetingFrame\\UI-RaidTargetingIcon_3"] = RAID_TARGET_3,
+    ["Interface\\TargetingFrame\\UI-RaidTargetingIcon_4"] = RAID_TARGET_4,
+    ["Interface\\TargetingFrame\\UI-RaidTargetingIcon_5"] = RAID_TARGET_5,
+    ["Interface\\TargetingFrame\\UI-RaidTargetingIcon_6"] = RAID_TARGET_6,
+    ["Interface\\TargetingFrame\\UI-RaidTargetingIcon_7"] = RAID_TARGET_7,
+    ["Interface\\TargetingFrame\\UI-RaidTargetingIcon_8"] = RAID_TARGET_8,
   }
 }
 local BuildInfo = select(4, GetBuildInfo())

--- a/WeakAuras/Types.lua
+++ b/WeakAuras/Types.lua
@@ -974,6 +974,16 @@ WeakAuras.texture_types = {
     ["Legionfall_BarSpark"]= "Blizzard Legionfall Spark",
     ["honorsystem-bar-spark"] = "Blizzard Honor System Spark",
     ["bonusobjectives-bar-spark"] = "Bonus Objectives Spark"
+  },
+  ["Raid Marks"] = {
+    ["Interface\\TargetingFrame\\UI-RaidTargetingIcon_1"] = "Star",
+    ["Interface\\TargetingFrame\\UI-RaidTargetingIcon_2"] = "Circle",
+    ["Interface\\TargetingFrame\\UI-RaidTargetingIcon_3"] = "Diamond",
+    ["Interface\\TargetingFrame\\UI-RaidTargetingIcon_4"] = "Triangle",
+    ["Interface\\TargetingFrame\\UI-RaidTargetingIcon_5"] = "Moon",
+    ["Interface\\TargetingFrame\\UI-RaidTargetingIcon_6"] = "Square",
+    ["Interface\\TargetingFrame\\UI-RaidTargetingIcon_7"] = "Cross",
+    ["Interface\\TargetingFrame\\UI-RaidTargetingIcon_8"] = "Skull",
   }
 }
 local BuildInfo = select(4, GetBuildInfo())


### PR DESCRIPTION
# Description

Just added the Raid Mark textures to Types. They're very useful and I was surprised at their current exclusion.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [• ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Such a simple addition. Just made a few Texture and Progress Textures to see that it worked okay. Couldn't test on Classic as I don't have an account but AFAIK the texture paths are the same. 

# Checklist:
<!-- These can be checked off after the pull request is submitted, in case you want discussion before they’re completely ready -->

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

<!-- Is there any additional work that needs to be done? If so, add it to the above list -->
