### PR TITLE
AuraBar: Fix modify not modyfying the layout

### DIFF
--- a/WeakAuras/RegionTypes/AuraBar.lua
+++ b/WeakAuras/RegionTypes/AuraBar.lua
@@ -860,6 +860,7 @@ local function modify(parent, region, data)
   region.flipX = false
   region.flipY = false
   region.orientation = data.orientation
+  region.effectiveOrientation = nil
 
   region.overlayclip = data.overlayclip;
 


### PR DESCRIPTION
Reset the orientation flag in modify, so that we always set the new
layout.

Fixes: #1986

