### PR TITLE
classic: fix event for character points changed

### DIFF
--- a/WeakAuras/GenericTrigger.lua
+++ b/WeakAuras/GenericTrigger.lua
@@ -1869,6 +1869,8 @@ do
       cdReadyFrame:RegisterEvent("RUNE_POWER_UPDATE");
       cdReadyFrame:RegisterEvent("PLAYER_TALENT_UPDATE");
       cdReadyFrame:RegisterEvent("PLAYER_PVP_TALENT_UPDATE");
+    else
+      cdReadyFrame:RegisterEvent("CHARACTER_POINTS_CHANGED");
     end
     cdReadyFrame:RegisterEvent("SPELL_UPDATE_COOLDOWN");
     cdReadyFrame:RegisterEvent("SPELL_UPDATE_CHARGES");
@@ -1883,7 +1885,8 @@ do
       WeakAuras.StartProfileSystem("generictrigger cd tracking");
       if(event == "SPELL_UPDATE_COOLDOWN" or event == "SPELL_UPDATE_CHARGES"
         or event == "RUNE_POWER_UPDATE" or event == "ACTIONBAR_UPDATE_COOLDOWN"
-        or event == "PLAYER_TALENT_UPDATE" or event == "PLAYER_PVP_TALENT_UPDATE") then
+        or event == "PLAYER_TALENT_UPDATE" or event == "PLAYER_PVP_TALENT_UPDATE"
+        or event == "CHARACTER_POINTS_CHANGED") then
         WeakAuras.CheckCooldownReady();
       elseif(event == "SPELLS_CHANGED") then
         WeakAuras.CheckSpellKnown();

--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -1071,7 +1071,7 @@ WeakAuras.load_prototype = {
       type = "multiselect",
       values = valuesForTalentFunction,
       test = "WeakAuras.CheckTalentByIndex(%d)",
-      events = {"PLAYER_TALENT_UPDATE"}
+      events = WeakAuras.IsClassic() and {"CHARACTER_POINTS_CHANGED"} or {"PLAYER_TALENT_UPDATE"}
     },
     {
       name = "talent2",
@@ -1082,7 +1082,7 @@ WeakAuras.load_prototype = {
       enable = function(trigger)
         return trigger.use_talent ~= nil or trigger.use_talent2 ~= nil;
       end,
-      events = {"PLAYER_TALENT_UPDATE"}
+      events = WeakAuras.IsClassic() and {"CHARACTER_POINTS_CHANGED"} or {"PLAYER_TALENT_UPDATE"}
     },
     {
       name = "talent3",
@@ -1093,7 +1093,7 @@ WeakAuras.load_prototype = {
       enable = function(trigger)
         return (trigger.use_talent ~= nil and trigger.use_talent2 ~= nil) or trigger.use_talent3 ~= nil;
       end,
-      events = {"PLAYER_TALENT_UPDATE"}
+      events = WeakAuras.IsClassic() and {"CHARACTER_POINTS_CHANGED"} or {"PLAYER_TALENT_UPDATE"}
     },
     {
       name = "pvptalent",
@@ -4098,7 +4098,7 @@ WeakAuras.event_prototypes = {
         ["events"] = events
       }
     end,
-    force_events = "PLAYER_TALENT_UPDATE",
+    force_events = WeakAuras.IsClassic() and "CHARACTER_POINTS_CHANGED" or "PLAYER_TALENT_UPDATE",
     name = L["Talent Selected"],
     init = function(trigger)
       local inverse = trigger.use_inverse;

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -2173,6 +2173,8 @@ if not WeakAuras.IsClassic() then
   loadFrame:RegisterEvent("UPDATE_OVERRIDE_ACTIONBAR");
   loadFrame:RegisterEvent("CHALLENGE_MODE_COMPLETED")
   loadFrame:RegisterEvent("CHALLENGE_MODE_START")
+else
+  loadFrame:RegisterEvent("CHARACTER_POINTS_CHANGED")
 end
 loadFrame:RegisterEvent("GROUP_ROSTER_UPDATE");
 loadFrame:RegisterEvent("ZONE_CHANGED");


### PR DESCRIPTION
# Description
Talents points on classic doesn't use same events as in retail, fixed some places where the event is use.

(reported on discord)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Wiped talents, made aura with load condition for a specific talent point, added point.
Was not working, now fixed