### PR TITLE
Make Cooldown Progress (Equipment slot) able to use Mainhand and Offhand on retail.

### DIFF
--- a/WeakAuras/Types.lua
+++ b/WeakAuras/Types.lua
@@ -1709,6 +1709,8 @@ WeakAuras.item_slot_types = {
   [13] = TRINKET0SLOT_UNIQUE,
   [14] = TRINKET1SLOT_UNIQUE,
   [15] = BACKSLOT,
+  [16] = MAINHANDSLOT,
+  [17] = SECONDARYHANDSLOT,
   [19] = TABARDSLOT
 }
 
@@ -2228,8 +2230,6 @@ if WeakAuras.IsClassic() then
   WeakAuras.actual_unit_types.focus = nil
   WeakAuras.unit_types_range_check.focus = nil
   WeakAuras.item_slot_types[0] = AMMOSLOT
-  WeakAuras.item_slot_types[16] = MAINHANDSLOT
-  WeakAuras.item_slot_types[17] = SECONDARYHANDSLOT
   WeakAuras.item_slot_types[18] = RANGEDSLOT
 
   local reset_swing_spell_list = {


### PR DESCRIPTION
# Description

https://www.wowhead.com/item=168973/neural-synapse-enhancer&bonus=4777

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Created an aura using Cooldown Progress (Equipment Slot) with Main Hand selected. I did not have an item with a cooldown to test further.

# Checklist:
<!-- These can be checked off after the pull request is submitted, in case you want discussion before they’re completely ready -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

<!-- Is there any additional work that needs to be done? If so, add it to the above list -->
