### PR TITLE
Disable destName in inverse cast trigger

### DIFF
--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -5846,6 +5846,7 @@ WeakAuras.event_prototypes = {
         display = L["Name of Caster's Target"],
         store = true,
         hidden = true,
+        enable = function(trigger) return not trigger.use_inverse end,
         test = "true",
         init = "UnitName(destUnit)"
       },


### PR DESCRIPTION
# Description

The unit trigger rework pushed to alpha a couple of days ago made one of my auras to throw errors when it loaded. Cast trigger's `destName` initialization was calling `UnitName` with a nil value because `destUnit` was disabled when the trigger is inverted. Fix by adding the same enable check `destUnit` has.

Alternatively init could be `UnitName(unit .. '-target')`, but I don't think target's name will be of much interest in a not casting trigger.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Tested in-game that an inverse casting trigger no longer throws an error on load and works as expected

# Checklist:
<!-- These can be checked off after the pull request is submitted, in case you want discussion before they’re completely ready -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

<!-- Is there any additional work that needs to be done? If so, add it to the above list -->
