### PR TITLE
Allow separators to force a "page break" in custom options

### DIFF
--- a/WeakAuras/Types.lua
+++ b/WeakAuras/Types.lua
@@ -2017,6 +2017,7 @@ WeakAuras.author_option_fields = {
   header = {
     useName = false,
     text = "",
+    noMerge = false
   },
   group = {
     groupType = "simple",

--- a/WeakAurasOptions/AuthorOptions.lua
+++ b/WeakAurasOptions/AuthorOptions.lua
@@ -1092,6 +1092,15 @@ typeControlAdders = {
         return not option.useName
       end
     }
+    args[prefix .. "noMerge"] = {
+      type = "toggle",
+      name = name(option, "noMerge", L["Prevent Merging"]),
+      desc = desc(option, "noMerge", L["If checked, then this separator will not merge with other separators when selecting multiple auras."]),
+      order = order(),
+      width = WeakAuras.doubleWidth,
+      get = get(option, "noMerge"),
+      set = set(data, option, "noMerge"),
+    }
   end,
   group = function(options, args, data, order, prefix, i)
     local option = options[i]
@@ -2275,23 +2284,29 @@ local function mergeOptions(mergedOptions, data, options, config, prepath, paren
     -- find the best place to start inserting the next option to merge
     local nextToMerge = options[i]
     local shouldMerge = false
-    for j = nextInsert, #mergedOptions + 1 do
-      local mergedOption = mergedOptions[j]
-      if not mergedOption then
-        break
-      end -- no more options to check, so must insert
-      local validMerge = true
-      for field in pairs(significantFieldsForMerge) do
-        if nextToMerge[field] ~= mergedOption[field] then
-          validMerge = false
+    if not nextToMerge.noMerge then
+      for j = nextInsert, #mergedOptions + 1 do
+        local mergedOption = mergedOptions[j]
+        if not mergedOption then
+          break
+        end -- no more options to check, so must insert
+        local validMerge = not mergedOption.noMerge
+        if validMerge then
+          for field in pairs(significantFieldsForMerge) do
+            if nextToMerge[field] ~= mergedOption[field] then
+              validMerge = false
+              break
+            end
+          end
+        end
+        if validMerge then
+          shouldMerge = true
+          nextInsert = j
           break
         end
       end
-      if validMerge then
-        shouldMerge = true
-        nextInsert = j
-        break
-      end
+    else
+      nextInsert = #mergedOptions + 1
     end
     -- now we know at what point to add nextToMerge
     if shouldMerge then


### PR DESCRIPTION
I don't know if this is actually worth doing, but it was pretty easy to implement.

Basically, allow separators to force a break in merging, as well as visually. So if you have two complex sections in separate auras, not in a group, you can add a breaking separator to the top of each set of options, and WeakAuras will not attempt to merge them and possibly create a huge mess.

To see the difference:
https://wago.io/x4D57HonC (without separators)
https://wago.io/SZeDvSABI (with separators)