### PR TITLE
[WIP] Auto re-anchor unitframes & slightly different anchors for nameplates addons

### DIFF
--- a/WeakAuras/RegionTypes/DynamicGroup.lua
+++ b/WeakAuras/RegionTypes/DynamicGroup.lua
@@ -93,14 +93,7 @@ local function releaseControlPoint(self, controlPoint)
   controlPoint:ClearAnchorPoint()
   local regionData = controlPoint.regionData
   if regionData then
-    local guid = regionData.unitframe_monitor
-    if guid then
-      WeakAuras.dyngroup_unitframe_monitor[guid][regionData] = nil
-      if not next(WeakAuras.dyngroup_unitframe_monitor[guid]) then
-        WeakAuras.dyngroup_unitframe_monitor[guid] = nil
-      end
-      regionData.unitframe_monitor = nil
-    end
+    WeakAuras.dyngroup_unitframe_monitor[regionData] = nil
     controlPoint.regionData = nil
     regionData.controlPoint = nil
   end
@@ -1014,6 +1007,7 @@ local function modify(parent, region, data)
   end
 
   region.growFunc = createGrowFunc(data)
+  region.anchorPerUnit = data.useAnchorPerUnit and data.anchorPerUnit
 
   local animate = data.animate
   function region:PositionChildren()
@@ -1053,14 +1047,8 @@ local function modify(parent, region, data)
       controlPoint:SetShown(show)
       controlPoint:SetWidth(regionData.dimensions.width)
       controlPoint:SetHeight(regionData.dimensions.height)
-      if regionData.useAnchorPerUnit and regionData.anchorPerUnit == "UNITFRAME" then
-        local guid = UnitGUID(regionData.region.state.unit)
-        if guid then
-          WeakAuras.dyngroup_unitframe_monitor = WeakAuras.dyngroup_unitframe_monitor or {}
-          WeakAuras.dyngroup_unitframe_monitor[guid] = WeakAuras.dyngroup_unitframe_monitor[guid] or {}
-          WeakAuras.dyngroup_unitframe_monitor[guid][regionData] = frame
-          regionData.unitframe_monitor = guid
-        end
+      if self.anchorPerUnit == "UNITFRAME" then
+        WeakAuras.dyngroup_unitframe_monitor[regionData] = frame
       end
       if animate then
         WeakAuras.CancelAnimation(regionData.controlPoint, true)

--- a/WeakAuras/RegionTypes/DynamicGroup.lua
+++ b/WeakAuras/RegionTypes/DynamicGroup.lua
@@ -342,7 +342,7 @@ local anchorers = {
       for _, regionData in ipairs(activeRegions) do
         local unit = regionData.region.state and regionData.region.state.unit
         if unit then
-          local frame = C_NamePlate.GetNamePlateForUnit(unit)
+          local frame = WeakAuras.GetUnitNameplate(unit)
           if frame then
             frames[frame] = frames[frame] or {}
             tinsert(frames[frame], regionData)

--- a/WeakAuras/RegionTypes/DynamicGroup.lua
+++ b/WeakAuras/RegionTypes/DynamicGroup.lua
@@ -54,9 +54,9 @@ local controlPointFunctions = {
   ["ClearAnchorPoint"] = function(self)
     self.point, self.relativeFrame, self.relativePoint, self.offsetX, self.offsetY = nil, nil, nil, nil, nil
   end,
-  ["ReAnchor"] = function(self, point)
+  ["ReAnchor"] = function(self, frame)
     self:ClearAllPoints()
-    self.point = point
+    self.relativeFrame = frame
     if self.relativeFrame and self.relativePoint then
       self:SetPoint(self.point, self.relativeFrame, self.relativePoint, self.totalOffsetX, self.totalOffsetY)
     else

--- a/WeakAuras/RegionTypes/DynamicGroup.lua
+++ b/WeakAuras/RegionTypes/DynamicGroup.lua
@@ -92,7 +92,9 @@ local function releaseControlPoint(self, controlPoint)
   controlPoint:ClearAnchorPoint()
   local regionData = controlPoint.regionData
   if regionData then
-    WeakAuras.dyngroup_unitframe_monitor[regionData] = nil
+    if self.parent.anchorPerUnit == "UNITFRAME" then
+      WeakAuras.dyngroup_unitframe_monitor[regionData] = nil
+    end
     controlPoint.regionData = nil
     regionData.controlPoint = nil
   end

--- a/WeakAuras/RegionTypes/DynamicGroup.lua
+++ b/WeakAuras/RegionTypes/DynamicGroup.lua
@@ -2,7 +2,6 @@ if not WeakAuras.IsCorrectVersion() then return end
 
 local WeakAuras = WeakAuras
 local SharedMedia = LibStub("LibSharedMedia-3.0")
---local LGF = LibStub("LibGetFrame-1.0")
 
 local default = {
   controlledChildren = {},

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -6936,7 +6936,7 @@ local function GetAnchorFrame(data, region, parent)
 
   if (anchorFrameType == "NAMEPLATE") then
     local unit = region.state.unit
-    return unit and C_NamePlate.GetNamePlateForUnit(unit)
+    return unit and WeakAuras.GetUnitNameplate(unit)
   end
 
   if (anchorFrameType == "UNITFRAME") then

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -6944,18 +6944,15 @@ local function GetAnchorFrame(data, region, parent)
   if (anchorFrameType == "UNITFRAME") then
     local unit = region.state.unit
     if unit then
-      local guid = UnitGUID(unit)
-      if guid then
-        local frame = WeakAuras.GetUnitFrame(unit)
-        if frame then
-          anchor_unitframe_monitor = anchor_unitframe_monitor or {}
-          anchor_unitframe_monitor[region] = {
-            data = data,
-            parent = parent,
-            frame = frame
-          }
-          return frame
-        end
+      local frame = WeakAuras.GetUnitFrame(unit)
+      if frame then
+        anchor_unitframe_monitor = anchor_unitframe_monitor or {}
+        anchor_unitframe_monitor[region] = {
+          data = data,
+          parent = parent,
+          frame = frame
+        }
+        return frame
       end
     end
   end

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -4687,6 +4687,7 @@ end
 
 local glow_frame_monitor
 local anchor_unitframe_monitor
+WeakAuras.dyngroup_unitframe_monitor = {}
 do
   LGF.RegisterCallback("WeakAuras", "FRAME_GUID_UPDATE", function(event, frame, guid)
     if type(glow_frame_monitor) == "table" then
@@ -4722,6 +4723,19 @@ do
             local new_frame = WeakAuras.GetUnitFrame(data.region.state.unit)
             if new_frame and new_frame ~= data.frame then
               WeakAuras.AnchorFrame(data.data, data.region, data.parent)
+            end
+          end
+        end
+      end
+    end
+    if type(WeakAuras.dyngroup_unitframe_monitor) == "table" then
+      local frames = WeakAuras.dyngroup_unitframe_monitor
+      if frames then
+        for data, data_frame in pairs(frames) do
+          if data_frame ~= frame then
+            local new_frame = WeakAuras.GetUnitFrame(data.region.state.unit)
+            if new_frame and new_frame ~= data.frame then
+              data.controlPoint:ReAnchor(new_frame)
             end
           end
         end


### PR DESCRIPTION
# Description
Use LibGetFrame's FRAME_UNIT_UPDATE callback for automatic re-anchor with anchor on Unit Frames
- For single auras/clones => Fixes #2051 
- For dynamic groups => replaced previous method that was re-sorting everything, this should improve performance a lot

Use WeakAuras.GetUnitNameplate for all anchors to nameplates => this will do a regression for people using nameplate addons.

# TODO
- ~~Handle region.state.unit's guid changed.~~
- Maybe move region.unitframe_monitor cleaning out of WeakAuras.PerformActions
- More testing.


