### PR TITLE
Eased translate animations

### DIFF
--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -546,6 +546,24 @@ WeakAuras.anim_function_strings = {
     function()
     return 0
     end
+  ]],
+  easeIn = [[
+    function(progress, startX, startY, deltaX, deltaY)
+    progress = EasingUtil.InCubic(progress)
+    return startX + (progress * deltaX), startY + (progress * deltaY)
+    end
+  ]],
+  easeOut = [[
+    function(progress, startX, startY, deltaX, deltaY)
+    progress = EasingUtil.OutCubic(progress)
+    return startX + (progress * deltaX), startY + (progress * deltaY)
+    end
+  ]],
+  easeInOut = [[
+    function(progress, startX, startY, deltaX, deltaY)
+    progress = EasingUtil.InCubic(progress)
+    return startX + (progress * deltaX), startY + (progress * deltaY)
+    end
   ]]
 };
 

--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -561,7 +561,7 @@ WeakAuras.anim_function_strings = {
   ]],
   easeInOut = [[
     function(progress, startX, startY, deltaX, deltaY)
-    progress = EasingUtil.InCubic(progress)
+    progress = EasingUtil.InOutCubic(progress)
     return startX + (progress * deltaX), startY + (progress * deltaY)
     end
   ]]

--- a/WeakAuras/Types.lua
+++ b/WeakAuras/Types.lua
@@ -1321,10 +1321,10 @@ WeakAuras.anim_translate_types = {
   shake = L["Shake"],
   bounce = L["Bounce"],
   bounceDecay = L["Bounce with Decay"],
-  custom = L["Custom Function"],
   easeIn = L["Ease In"],
   easeOut = L["Ease Out"],
-  easeInOut = L["Ease In and Out"]
+  easeInOut = L["Ease In and Out"],
+  custom = L["Custom Function"]
 }
 
 WeakAuras.anim_scale_types = {

--- a/WeakAuras/Types.lua
+++ b/WeakAuras/Types.lua
@@ -1321,7 +1321,10 @@ WeakAuras.anim_translate_types = {
   shake = L["Shake"],
   bounce = L["Bounce"],
   bounceDecay = L["Bounce with Decay"],
-  custom = L["Custom Function"]
+  custom = L["Custom Function"],
+  easeIn = L["Ease In"],
+  easeOut = L["Ease Out"],
+  easeInOut = L["Ease In and Out"]
 }
 
 WeakAuras.anim_scale_types = {


### PR DESCRIPTION
# Description

Saw a gif on Discord of someone using a translate animation (https://cdn.discordapp.com/attachments/218087027042811905/694561955016343573/Rogue_WA_Slide.gif from user <Holte#6934>) on Start and Finish, and felt that straight translates _really_ need a little easing to not look horrible. After some playing with arithmetic myself I saw that Blizz has some simple easing functions already. I chose what I feel is a good balance between subtle enough easing while still applying to noticeable effect. 

Example with Easing applied: https://i.imgur.com/zaz6Lip.gifv

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Only tested on Retail but the EasingUtil exists in Classic files too (<https://github.com/tomrus88/BlizzardInterfaceCode/blob/classic/Interface/SharedXML/EasingUtil.lua>) and the addition is very self-contained. 

- [ ] Test A
- [ ] Test B

# Checklist:
<!-- These can be checked off after the pull request is submitted, in case you want discussion before they’re completely ready -->

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

<!-- Is there any additional work that needs to be done? If so, add it to the above list -->
