### PR TITLE
Add Text's Automatic Width and Word Warp for Subtext

### DIFF
--- a/WeakAuras/SubRegionTypes/SubText.lua
+++ b/WeakAuras/SubRegionTypes/SubText.lua
@@ -24,6 +24,10 @@ local default = function(parentType)
       text_shadowXOffset = 0,
       text_shadowYOffset = 0,
       rotateText = "NONE",
+
+      text_automaticWidth = "Auto",
+      text_fixedWidth = 64,
+      text_wordWrap = "WordWrap",
     }
   else
     -- With Shadow, without Outline
@@ -45,6 +49,10 @@ local default = function(parentType)
       text_shadowXOffset = 1,
       text_shadowYOffset = -1,
       rotateText = "NONE",
+
+      text_automaticWidth = "Auto",
+      text_fixedWidth = 64,
+      text_wordWrap = "WordWrap",
     }
   end
 end
@@ -144,6 +152,9 @@ local function create()
   -- the issue. Also see #1778
   text:SetPoint("CENTER", UIParent, "CENTER")
 
+  text:SetWordWrap(true)
+  text:SetNonSpaceWrap(true)
+
   return region;
 end
 
@@ -191,6 +202,24 @@ local function modify(parent, region, parentData, data, first)
   text:SetShadowColor(unpack(data.text_shadowColor))
   text:SetShadowOffset(data.text_shadowXOffset, data.text_shadowYOffset)
   text:SetJustifyH(data.text_justify or "CENTER")
+
+  if (data.text_automaticWidth == "Fixed") then
+    if (data.text_wordWrap == "WordWrap") then
+      text:SetWordWrap(true);
+      text:SetNonSpaceWrap(true);
+    else
+      text:SetWordWrap(false);
+      text:SetNonSpaceWrap(false);
+    end
+
+    text:SetWidth(data.text_fixedWidth);
+    region:SetWidth(data.text_fixedWidth);
+    region.width = data.text_fixedWidth;
+  else
+    text:SetWidth(0);
+    text:SetWordWrap(true);
+    text:SetNonSpaceWrap(true);
+  end
 
   if first then
     -- Certain data is stored directly on the parent, because it's shared between multiple texts

--- a/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasExpandSmall.lua
+++ b/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasExpandSmall.lua
@@ -1,0 +1,142 @@
+--[[-----------------------------------------------------------------------------
+Button Widget for our Expand button
+-------------------------------------------------------------------------------]]
+if not WeakAuras.IsCorrectVersion() then return end
+
+local Type, Version = "WeakAurasExpandSmall", 1
+
+local AceGUI = LibStub and LibStub("AceGUI-3.0", true)
+if not AceGUI or (AceGUI:GetWidgetVersion(Type) or 0) >= Version then return end
+
+-- Lua APIs
+local select, pairs, print = select, pairs, print
+
+-- WoW APIs
+local CreateFrame, UIParent = CreateFrame, UIParent
+
+--[[-----------------------------------------------------------------------------
+Scripts
+-------------------------------------------------------------------------------]]
+local function Control_OnEnter(frame)
+	frame.obj:Fire("OnEnter")
+end
+
+local function Control_OnLeave(frame)
+	frame.obj:Fire("OnLeave")
+end
+
+local function Button_OnClick(frame, button)
+	frame.obj:Fire("OnClick", button)
+	AceGUI:ClearFocus()
+end
+
+--[[-----------------------------------------------------------------------------
+Methods
+-------------------------------------------------------------------------------]]
+local methods = {
+	["OnAcquire"] = function(self)
+		self:SetHeight(20)
+		self:SetWidth(110)
+		self:SetLabel()
+		self:SetImage(nil)
+		self:SetImageSize(24, 24)
+		self:SetDisabled(false)
+	end,
+
+	-- ["OnRelease"] = nil,
+
+	["SetLabel"] = function(self, text)
+		if text and text ~= "" then
+			self.label:Show()
+			self.label:SetText(text)
+			self:SetHeight(max(self.label:GetStringHeight(), self.image:GetHeight()))
+		else
+			self.label:Hide()
+			self:SetHeight(self.image:GetHeight())
+		end
+	end,
+
+	["SetImage"] = function(self, path, ...)
+		local image = self.image
+		image:SetTexture(path)
+
+		if image:GetTexture() then
+			local n = select("#", ...)
+			if n == 4 or n == 8 then
+				image:SetTexCoord(...)
+			else
+				image:SetTexCoord(0, 1, 0, 1)
+			end
+		end
+	end,
+
+	["SetImageSize"] = function(self, width, height)
+		self.image:SetWidth(width)
+		self.image:SetHeight(height)
+		--self.frame:SetWidth(width + 30)
+		if self.label:IsShown() then
+			self:SetHeight(max(self.label:GetStringHeight(), self.image:GetHeight()))
+		else
+			self:SetHeight(self.image:GetHeight())
+		end
+	end,
+
+	["SetDisabled"] = function(self, disabled)
+		self.disabled = disabled
+		if disabled then
+			self.frame:Disable()
+			self.label:SetTextColor(0.5, 0.5, 0.5)
+			self.image:SetVertexColor(0.5, 0.5, 0.5, 0.5)
+		else
+			self.frame:Enable()
+			self.label:SetTextColor(1, 1, 1)
+			self.image:SetVertexColor(1, 1, 1, 1)
+		end
+	end
+}
+
+--[[-----------------------------------------------------------------------------
+Constructor
+-------------------------------------------------------------------------------]]
+local function Constructor()
+	local frame = CreateFrame("Button", nil, UIParent)
+	frame:Hide()
+
+	frame:EnableMouse(true)
+	frame:SetScript("OnEnter", Control_OnEnter)
+	frame:SetScript("OnLeave", Control_OnLeave)
+	frame:SetScript("OnClick", Button_OnClick)
+
+	local image = frame:CreateTexture(nil, "BACKGROUND")
+	image:SetWidth(64)
+	image:SetHeight(64)
+	image:SetPoint("RIGHT", 0, 0)
+
+	local label = frame:CreateFontString(nil, "BACKGROUND", "GameFontHighlight")
+	label:SetJustifyH("LEFT")
+	label:SetJustifyV("CENTER")
+	label:SetPoint("RIGHT", image, "LEFT", -5, 0)
+	label:SetPoint("TOP")
+	label:SetPoint("BOTTOM")
+	label:SetPoint("LEFT")
+
+	local highlight = frame:CreateTexture(nil, "HIGHLIGHT")
+	highlight:SetAllPoints(frame)
+	highlight:SetTexture("Interface\\AddOns\\WeakAuras\\Media\\Textures\\Square_White")
+	highlight:SetVertexColor(0.2, 0.4, 0.8, 0.2)
+	highlight:SetBlendMode("ADD")
+
+	local widget = {
+		label = label,
+		image = image,
+		frame = frame,
+		type  = Type
+	}
+	for method, func in pairs(methods) do
+		widget[method] = func
+	end
+
+	return AceGUI:RegisterAsWidget(widget)
+end
+
+AceGUI:RegisterWidgetType(Type, Constructor, Version)

--- a/WeakAurasOptions/RegionOptions/Icon.lua
+++ b/WeakAurasOptions/RegionOptions/Icon.lua
@@ -65,7 +65,8 @@ local function createOptions(id, data)
       order = 6
     },
     iconExtraDescription = {
-      type = "description",
+      type = "execute",
+      control = "WeakAurasExpandSmall",
       name = function()
         local line = L["|cFFffcc00Extra Options:|r"]
         local changed = false
@@ -90,18 +91,8 @@ local function createOptions(id, data)
         end
         return line
       end,
-      width = WeakAuras.doubleWidth - 0.15,
+      width = WeakAuras.doubleWidth,
       order = 7,
-      fontSize = "medium"
-    },
-    iconExtraExpand = {
-      type = "execute",
-      name = function()
-        local collapsed = WeakAuras.IsCollapsed("icon", "icon", "iconextra", true)
-        return collapsed and L["Show Extra Options"] or L["Hide Extra Options"]
-      end,
-      order = 7.01,
-      width = 0.15,
       image = function()
         local collapsed = WeakAuras.IsCollapsed("icon", "icon", "iconextra", true);
         return collapsed and "Interface\\AddOns\\WeakAuras\\Media\\Textures\\edit" or "Interface\\AddOns\\WeakAuras\\Media\\Textures\\editdown"
@@ -112,7 +103,6 @@ local function createOptions(id, data)
         local collapsed = WeakAuras.IsCollapsed("icon", "icon", "iconextra", true);
         WeakAuras.SetCollapsed("icon", "icon", "iconextra", not collapsed);
       end,
-      control = "WeakAurasIcon"
     },
     iconExtra_space1 = {
       type = "description",

--- a/WeakAurasOptions/SubRegionOptions/Glow.lua
+++ b/WeakAurasOptions/SubRegionOptions/Glow.lua
@@ -61,7 +61,8 @@ local function createOptions(parentData, data, index, subIndex)
       hidden = function() return parentData.regionType ~= "aurabar" end
     },
     glowExtraDescription = {
-      type = "description",
+      type = "execute",
+      control = "WeakAurasExpandSmall",
       name = function()
         local line = L["|cFFffcc00Extra Options:|r"]
         local color = L["Default Color"]
@@ -104,18 +105,8 @@ local function createOptions(parentData, data, index, subIndex)
         end
         return line
       end,
-      width = WeakAuras.doubleWidth - 0.15,
+      width = WeakAuras.doubleWidth,
       order = order + 1,
-      fontSize = "medium"
-    },
-    glowExpand = {
-      type = "execute",
-      name = function()
-        local collapsed = WeakAuras.IsCollapsed("glow", "glow", "glowextra" .. index, true)
-        return collapsed and L["Show Extra Options"] or L["Hide Extra Options"]
-      end,
-      order = order + 1.01,
-      width = 0.15,
       image = function()
         local collapsed = WeakAuras.IsCollapsed("glow", "glow", "glowextra" .. index, true);
         return collapsed and "Interface\\AddOns\\WeakAuras\\Media\\Textures\\edit" or "Interface\\AddOns\\WeakAuras\\Media\\Textures\\editdown"
@@ -126,7 +117,6 @@ local function createOptions(parentData, data, index, subIndex)
         local collapsed = WeakAuras.IsCollapsed("glow", "glow", "glowextra" .. index, true);
         WeakAuras.SetCollapsed("glow", "glow", "glowextra" .. index, not collapsed);
       end,
-      control = "WeakAurasIcon"
     },
     glow_space1 = {
       type = "description",

--- a/WeakAurasOptions/SubRegionOptions/SubText.lua
+++ b/WeakAurasOptions/SubRegionOptions/SubText.lua
@@ -95,7 +95,8 @@ local function createOptions(parentData, data, index, subIndex)
       step = 1,
     },
     text_fontFlagsDescription = {
-      type = "description",
+      type = "execute",
+      control = "WeakAurasExpandSmall",
       name = function()
         local textFlags = WeakAuras.font_flags[data.text_fontType]
         local color = format("%02x%02x%02x%02x",
@@ -133,25 +134,18 @@ local function createOptions(parentData, data, index, subIndex)
 
         return secondline
       end,
-      width = WeakAuras.doubleWidth - 0.15,
+      width = WeakAuras.doubleWidth,
       order = 44,
-      fontSize = "medium"
-    },
-    text_fontFlagsExpand = {
-      type = "execute",
-      name = "",
-      order = 44.1,
-      width = 0.15,
+      func = function()
+        local collapsed = WeakAuras.IsCollapsed("subtext", "subtext", "fontflags" .. index, true)
+        WeakAuras.SetCollapsed("subtext", "subtext", "fontflags" .. index, not collapsed)
+      end,
       image = function()
         local collapsed = WeakAuras.IsCollapsed("subtext", "subtext", "fontflags" .. index, true)
         return collapsed and "Interface\\AddOns\\WeakAuras\\Media\\Textures\\edit" or "Interface\\AddOns\\WeakAuras\\Media\\Textures\\editdown"
       end,
       imageWidth = 24,
-      imageHeight = 24,
-      func = function()
-        local collapsed = WeakAuras.IsCollapsed("subtext", "subtext", "fontflags" .. index, true)
-        WeakAuras.SetCollapsed("subtext", "subtext", "fontflags" .. index, not collapsed)
-      end
+      imageHeight = 24
     },
 
     text_font_space = {
@@ -296,7 +290,8 @@ local function createOptions(parentData, data, index, subIndex)
   end
   -- Anchor Options
   options.text_anchorsDescription = {
-    type = "description",
+    type = "execute",
+    control = "WeakAurasExpandSmall",
     name = function()
       local selfPoint = data.text_selfPoint ~= "AUTO" and self_point_types[data.text_selfPoint]
       local anchorPoint = anchors[data.text_anchorPoint or "CENTER"] or anchors["CENTER"]
@@ -322,16 +317,8 @@ local function createOptions(parentData, data, index, subIndex)
         end
       end
     end,
-    width = WeakAuras.doubleWidth - 0.15,
+    width = WeakAuras.doubleWidth,
     order = 60,
-    fontSize = "medium"
-  }
-
-  options.text_expandAnchors = {
-    type = "execute",
-    name = "",
-    order = 60.1,
-    width = 0.15,
     image = function()
       local collapsed = WeakAuras.IsCollapsed("subregion", "text_anchors", tostring(index), true)
       return collapsed and "Interface\\AddOns\\WeakAuras\\Media\\Textures\\edit" or "Interface\\AddOns\\WeakAuras\\Media\\Textures\\editdown"
@@ -343,6 +330,7 @@ local function createOptions(parentData, data, index, subIndex)
       WeakAuras.SetCollapsed("subregion", "text_anchors", tostring(index), not collapsed)
     end
   }
+
 
   local hiddenFunction = function()
     return WeakAuras.IsCollapsed("subregion", "text_anchors", tostring(index), true)

--- a/WeakAurasOptions/SubRegionOptions/SubText.lua
+++ b/WeakAurasOptions/SubRegionOptions/SubText.lua
@@ -118,7 +118,18 @@ local function createOptions(parentData, data, index, subIndex)
           textRotate = " " .. L["and rotated right"]
         end
 
-        local secondline = L["|cFFffcc00Font Flags:|r |cFFFF0000%s|r and shadow |c%sColor|r with offset |cFFFF0000%s/%s|r%s%s"]:format(textFlags, color, data.text_shadowXOffset, data.text_shadowYOffset, textRotate, textJustify)
+        local textWidth = ""
+        if data.text_automaticWidth == "Fixed" then
+          local wordWarp = ""
+          if data.text_wordWrap == "WordWrap" then
+            wordWarp = L["wrapping"]
+          else
+            wordWarp = L["eliding"]
+          end
+          textWidth = " "..L["and with width |cFFFF0000%s|r and %s"]:format(data.text_fixedWidth, wordWarp)
+        end
+
+        local secondline = L["|cFFffcc00Font Flags:|r |cFFFF0000%s|r and shadow |c%sColor|r with offset |cFFFF0000%s/%s|r%s%s%s"]:format(textFlags, color, data.text_shadowXOffset, data.text_shadowYOffset, textRotate, textJustify, textWidth)
 
         return secondline
       end,
@@ -218,7 +229,54 @@ local function createOptions(parentData, data, index, subIndex)
       values = WeakAuras.justify_types,
       order = 50.5,
       hidden = hiddenFontExtra
-    }
+    },
+    text_font_space5 = {
+      type = "description",
+      name = "",
+      order = 51,
+      hidden = hiddenFontExtra,
+      width = indentWidth
+    },
+    text_automaticWidth = {
+      type = "select",
+      width = WeakAuras.normalWidth - indentWidth,
+      name = L["Width"],
+      order = 51.5,
+      values = WeakAuras.text_automatic_width,
+      hidden = hiddenFontExtra
+    },
+    text_font_space6 = {
+      type = "description",
+      name = "",
+      order = 52,
+      hidden = hiddenFontExtra,
+      width = WeakAuras.normalWidth
+    },
+    text_font_space7 = {
+      type = "description",
+      name = "",
+      order = 52.5,
+      width = indentWidth,
+      hidden = function() return hiddenFontExtra() or data.text_automaticWidth ~= "Fixed" end
+    },
+    text_fixedWidth = {
+      name = L["Width"],
+      width = WeakAuras.normalWidth - indentWidth,
+      order = 53,
+      type = "range",
+      min = 1,
+      softMax = 200,
+      bigStep = 1,
+      hidden = function() return hiddenFontExtra() or data.text_automaticWidth ~= "Fixed" end
+    },
+    text_wordWrap = {
+      type = "select",
+      width = WeakAuras.normalWidth,
+      name = L["Overflow"],
+      order = 54,
+      values = WeakAuras.text_word_wrap,
+      hidden = function() return hiddenFontExtra() or data.text_automaticWidth ~= "Fixed" end
+    },
   }
 
   -- Note: Anchor Options need to be generalized once there are multiple sub regions

--- a/WeakAurasOptions/WeakAurasOptions.lua
+++ b/WeakAurasOptions/WeakAurasOptions.lua
@@ -237,20 +237,10 @@ function WeakAuras.ConstructOptions(prototype, data, startorder, triggernum, tri
     local reloadOptions = arg.reloadOptions;
     if (name and arg.type == "collapse") then
       options["summary_" .. arg.name] = {
-        type = "description",
-        width = WeakAuras.doubleWidth - 0.15,
-        name = type(arg.display) == "function" and arg.display(trigger) or arg.display,
-        order = order,
-        fontSize = "medium"
-      }
-      order = order + 1;
-      options["button_" .. arg.name] = {
         type = "execute",
-        width = 0.15,
-        name = function()
-          local collapsed = WeakAuras.IsCollapsed("trigger", name, "", true)
-          return collapsed and L["Show Extra Options"] or L["Hide Extra Options"]
-        end,
+        control = "WeakAurasExpandSmall",
+        width = WeakAuras.doubleWidth,
+        name = type(arg.display) == "function" and arg.display(trigger) or arg.display,
         order = order,
         image = function()
           local collapsed = WeakAuras.IsCollapsed("trigger", name, "", true)
@@ -263,7 +253,6 @@ function WeakAuras.ConstructOptions(prototype, data, startorder, triggernum, tri
           WeakAuras.SetCollapsed("trigger", name, "", not collapsed)
           WeakAuras.ReloadTriggerOptions(data);
         end,
-        control = "WeakAurasIcon"
       }
       order = order + 1;
 

--- a/WeakAurasOptions/WeakAurasOptions.toc
+++ b/WeakAurasOptions/WeakAurasOptions.toc
@@ -70,6 +70,7 @@ OptionsFrames\MoverSizer.lua
 OptionsFrames\FrameChooser.lua
 
 AceGUI-Widgets\AceGUIWidget-WeakAurasExpand.lua
+AceGUI-Widgets\AceGUIWidget-WeakAurasExpandSmall.lua
 AceGUI-Widgets\AceGUIWidget-WeakAurasIcon.lua
 AceGUI-Widgets\AceGUIWidget-WeakAurasNewHeaderButton.lua
 AceGUI-Widgets\AceGUIWidget-WeakAurasLoadedHeaderButton.lua
@@ -83,4 +84,3 @@ AceGUI-Widgets\AceGUIWidget-WeakAurasSortedDropDown.lua
 AceGUI-Widgets\AceGUIWidget-WeakAurasToolbarButton.lua
 AceGUI-Widgets\AceGUIWidget-WeakAurasTwoColumnDropDown.lua
 AceGUI-Widgets\AceGUIContainer-WeakAurasTreeGroup.lua
-


### PR DESCRIPTION
# Description

Some Auras may block each other because the subtext is too long.
![批注 2020-04-02 171057](https://user-images.githubusercontent.com/5201743/78231186-00631080-7505-11ea-9d35-04054d095769.png)
So I transplanted the Auto Width and Word Warp options in the text display to the subtext.
![批注 2020-04-02 171505](https://user-images.githubusercontent.com/5201743/78231544-8aab7480-7505-11ea-91ad-f1f571494337.png)
![批注 2020-04-02 172702](https://user-images.githubusercontent.com/5201743/78232704-399c8000-7507-11ea-80d4-97e25fab21b4.png)
<!-- If it is a GitHub ticket, then #ticketNum will be sufficient. A WowAce ticket should include a URL. -->

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Create Subtext in aura and modify text and automatic width, width, and word warp

- [ ] Test A
- [ ] Test B

# Checklist:
<!-- These can be checked off after the pull request is submitted, in case you want discussion before they’re completely ready -->

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

<!-- Is there any additional work that needs to be done? If so, add it to the above list -->
