### PR TITLE
Universal animation easing

### DIFF
--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -546,24 +546,6 @@ WeakAuras.anim_function_strings = {
     function()
     return 0
     end
-  ]],
-  easeIn = [[
-    function(progress, startX, startY, deltaX, deltaY)
-    progress = EasingUtil.InCubic(progress)
-    return startX + (progress * deltaX), startY + (progress * deltaY)
-    end
-  ]],
-  easeOut = [[
-    function(progress, startX, startY, deltaX, deltaY)
-    progress = EasingUtil.OutCubic(progress)
-    return startX + (progress * deltaX), startY + (progress * deltaY)
-    end
-  ]],
-  easeInOut = [[
-    function(progress, startX, startY, deltaX, deltaY)
-    progress = EasingUtil.InOutCubic(progress)
-    return startX + (progress * deltaX), startY + (progress * deltaY)
-    end
   ]]
 };
 

--- a/WeakAuras/Types.lua
+++ b/WeakAuras/Types.lua
@@ -1321,9 +1321,6 @@ WeakAuras.anim_translate_types = {
   shake = L["Shake"],
   bounce = L["Bounce"],
   bounceDecay = L["Bounce with Decay"],
-  easeIn = L["Ease In"],
-  easeOut = L["Ease Out"],
-  easeInOut = L["Ease In and Out"],
   custom = L["Custom Function"]
 }
 

--- a/WeakAuras/Types.lua
+++ b/WeakAuras/Types.lua
@@ -1312,6 +1312,29 @@ WeakAuras.anim_types = {
   preset = L["Preset"],
   custom = L["Custom"]
 }
+  
+WeakAuras.anim_ease_types = {
+  none = L["None"],
+  easeIn = L["Ease In"],
+  easeOut = L["Ease Out"],
+  easeOutIn = L["Ease In and Out"]
+}
+
+WeakAuras.anim_ease_functions = {
+  none = function(percent) return percent end,
+  easeIn = function(percent, power)
+    return percent ^ power;
+  end,
+  easeOut = function(percent, power)
+    return 1.0 - (1.0 - percent) ^ power;
+  end,
+  easeOutIn = function(percent, power)
+    if percent < .5 then
+        return (percent * 2.0) ^ power * .5;
+    end
+    return 1.0 - ((1.0 - percent) * 2.0) ^ power * .5;
+  end
+}
 
 WeakAuras.anim_translate_types = {
   straightTranslate = L["Normal"],

--- a/WeakAuras/Types.lua
+++ b/WeakAuras/Types.lua
@@ -1942,14 +1942,20 @@ WeakAuras.data_stub = {
     start = {
       type = "none",
       duration_type = "seconds",
+      easeType = "none",
+      easeStrength = 3,
     },
     main = {
       type = "none",
       duration_type = "seconds",
+      easeType = "none",
+      easeStrength = 3,
     },
     finish = {
       type = "none",
       duration_type = "seconds",
+      easeType = "none",
+      easeStrength = 3,
     },
   },
   conditions = {},

--- a/WeakAuras/Types.lua
+++ b/WeakAuras/Types.lua
@@ -1312,7 +1312,7 @@ WeakAuras.anim_types = {
   preset = L["Preset"],
   custom = L["Custom"]
 }
-  
+
 WeakAuras.anim_ease_types = {
   none = L["None"],
   easeIn = L["Ease In"],

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -5149,7 +5149,7 @@ function WeakAuras.Animate(namespace, data, type, anim, region, inverse, onFinis
       region:ColorAnim(nil);
     end
     easeFunc = WeakAuras.anim_ease_functions[anim.easeType or "none"]
-    
+
     duration = WeakAuras.ParseNumber(anim.duration) or 0;
     progress = 0;
     if(namespace == "display" and type == "main" and not onFinished and not anim.duration_type == "relative") then

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -4905,6 +4905,7 @@ function WeakAuras.UpdateAnimations()
       anim.progress = 1;
     end
     local progress = anim.inverse and (1 - anim.progress) or anim.progress;
+    progress = anim.easeFunc(progress, anim.easeStrength or 3)
     WeakAuras.ActivateAuraEnvironment(anim.name, anim.cloneId, anim.region.state, anim.region.states);
     if(anim.translateFunc) then
       if (anim.region.SetOffsetAnim) then
@@ -5027,8 +5028,8 @@ function WeakAuras.Animate(namespace, data, type, anim, region, inverse, onFinis
     valid = true;
   end
   if(valid) then
-    local progress, duration, selfPoint, anchor, anchorPoint, startX, startY, startAlpha, startWidth, startHeight, startRotation;
-    local translateFunc, alphaFunc, scaleFunc, rotateFunc, colorFunc;
+    local progress, duration, selfPoint, anchor, anchorPoint, startX, startY, startAlpha, startWidth, startHeight, startRotation, easeType, easeStrength;
+    local translateFunc, alphaFunc, scaleFunc, rotateFunc, colorFunc, easeFunc;
     if(animations[key]) then
       if(animations[key].type == type and not loop) then
         return "no replace";
@@ -5199,6 +5200,9 @@ function WeakAuras.Animate(namespace, data, type, anim, region, inverse, onFinis
     animation.duration = duration
     animation.duration_type = anim.duration_type or "seconds"
     animation.inverse = inverse
+    animation.easeType = anim.easeType
+    animation.easeFunc = easeFunc
+    animation.easeStrength = anim.easeStrength
     animation.type = type
     animation.loop = loop
     animation.onFinished = onFinished

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -5148,7 +5148,8 @@ function WeakAuras.Animate(namespace, data, type, anim, region, inverse, onFinis
     elseif(region.ColorAnim) then
       region:ColorAnim(nil);
     end
-
+    easeFunc = WeakAuras.anim_ease_functions[anim.easeType or "none"]
+    
     duration = WeakAuras.ParseNumber(anim.duration) or 0;
     progress = 0;
     if(namespace == "display" and type == "main" and not onFinished and not anim.duration_type == "relative") then

--- a/WeakAurasOptions/AnimationOptions.lua
+++ b/WeakAurasOptions/AnimationOptions.lua
@@ -13,6 +13,7 @@ local anim_main_preset_types = WeakAuras.anim_main_preset_types;
 local anim_finish_preset_types = WeakAuras.anim_finish_preset_types;
 local duration_types = WeakAuras.duration_types;
 local duration_types_no_choice = WeakAuras.duration_types_no_choice;
+local anim_ease_types = WeakAuras.anim_ease_types;
 
 local function filterAnimPresetTypes(intable, id)
   local ret = {};
@@ -171,6 +172,24 @@ function WeakAuras.AddAnimationOption(id, data)
           end
         end,
         order = 33.5,
+        hidden = function() return data.animation.start.type ~= "custom" end
+      },
+      start_easeType = {
+        type = "select",
+        width = WeakAuras.normalWidth,
+        name = L["Ease type"],
+        values = anim_ease_types,
+        order = 33.7,
+        hidden = function() return data.animation.start.type ~= "custom" end
+      },
+      start_easeStrength = {
+        type = "range",
+        width = WeakAuras.normalWidth,
+        name = L["Ease Strength"],
+        order = 33.8,
+        min = 1,
+        max = 5,
+        bigStep = 1,
         hidden = function() return data.animation.start.type ~= "custom" end
       },
       start_use_alpha = {
@@ -403,6 +422,24 @@ function WeakAuras.AddAnimationOption(id, data)
         order = 53.5,
         hidden = function() return data.animation.main.type ~= "custom" end
       },
+      main_easeType = {
+        type = "select",
+        width = WeakAuras.normalWidth,
+        name = L["Ease type"],
+        values = anim_ease_types,
+        order = 53.7,
+        hidden = function() return data.animation.main.type ~= "custom" end
+      },
+      main_easeStrength = {
+        type = "range",
+        width = WeakAuras.normalWidth,
+        name = L["Ease Strength"],
+        order = 53.8,
+        min = 1,
+        max = 5,
+        bigStep = 1,
+        hidden = function() return data.animation.main.type ~= "custom" end
+      },
       main_use_alpha = {
         type = "toggle",
         width = WeakAuras.normalWidth,
@@ -604,6 +641,24 @@ function WeakAuras.AddAnimationOption(id, data)
         name = L["Duration (s)"],
         desc = L["The duration of the animation in seconds. The finish animation does not start playing until after the display would normally be hidden."],
         order = 73.5,
+        hidden = function() return data.animation.finish.type ~= "custom" end
+      },
+      finish_easeType = {
+        type = "select",
+        width = WeakAuras.normalWidth,
+        name = L["Ease type"],
+        values = anim_ease_types,
+        order = 73.7,
+        hidden = function() return data.animation.finish.type ~= "custom" end
+      },
+      finish_easeStrength = {
+        type = "range",
+        width = WeakAuras.normalWidth,
+        name = L["Ease Strength"],
+        order = 73.8,
+        min = 1,
+        max = 5,
+        bigStep = 1,
         hidden = function() return data.animation.finish.type ~= "custom" end
       },
       finish_use_alpha = {

--- a/WeakAurasOptions/AnimationOptions.lua
+++ b/WeakAurasOptions/AnimationOptions.lua
@@ -190,7 +190,8 @@ function WeakAuras.AddAnimationOption(id, data)
         min = 1,
         max = 5,
         bigStep = 1,
-        hidden = function() return data.animation.start.type ~= "custom" end
+        hidden = function() return data.animation.start.type ~= "custom" end,
+        disabled = function() return data.animation.start.easeType == "none" end
       },
       start_use_alpha = {
         type = "toggle",
@@ -438,7 +439,8 @@ function WeakAuras.AddAnimationOption(id, data)
         min = 1,
         max = 5,
         bigStep = 1,
-        hidden = function() return data.animation.main.type ~= "custom" end
+        hidden = function() return data.animation.main.type ~= "custom" end,
+        disabled = function() return data.animation.main.easeType == "none" end
       },
       main_use_alpha = {
         type = "toggle",
@@ -659,7 +661,8 @@ function WeakAuras.AddAnimationOption(id, data)
         min = 1,
         max = 5,
         bigStep = 1,
-        hidden = function() return data.animation.finish.type ~= "custom" end
+        hidden = function() return data.animation.finish.type ~= "custom" end,
+        disabled = function() return data.animation.finish.easeType == "none" end
       },
       finish_use_alpha = {
         type = "toggle",


### PR DESCRIPTION
# Description

A more thorough approach to adding some easing to animations. An Ease Type and Ease Strength setting is added to Start, Main and Finish custom animations.  Type being "In", "Out" and "InOut", and Strength being how aggressively the easing effect is applied. 

Easing code is from Blizz functions, https://github.com/tomrus88/BlizzardInterfaceCode/blob/46d53f88664c14d16a702c0f68c1cd215d9efd14/Interface/SharedXML/EasingUtil.lua#L3 - not sure what acknowledgements are needed. 

This would supersede my previous PR with a couple of specific Eased functions. Can that one be easily unmerged or is it not that simple? 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested on Retail. 

- [ ] Test A
- [ ] Test B

# Checklist:
<!-- These can be checked off after the pull request is submitted, in case you want discussion before they’re completely ready -->

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

<!-- Is there any additional work that needs to be done? If so, add it to the above list -->
