### PR TITLE
Profiling Improvements

### DIFF
--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -2215,7 +2215,7 @@ loadFrame:RegisterEvent("UNIT_INVENTORY_CHANGED")
 loadFrame:RegisterEvent("PLAYER_EQUIPMENT_CHANGED")
 
 local unitLoadFrame = CreateFrame("FRAME");
-WeakAuras.loadFrame = unitLoadFrame;
+WeakAuras.unitLoadFrame = unitLoadFrame;
 WeakAuras.frames["Display Load Handling 2"] = unitLoadFrame;
 
 unitLoadFrame:RegisterUnitEvent("UNIT_FLAGS", "player");

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -1,5 +1,8 @@
 local internalVersion = 29;
 
+-- Lua APIs
+local insert = table.insert
+
 -- WoW APIs
 local GetTalentInfo, IsAddOnLoaded, InCombatLockdown = GetTalentInfo, IsAddOnLoaded, InCombatLockdown
 local LoadAddOn, UnitName, GetRealmName, UnitRace, UnitFactionGroup, IsInRaid
@@ -87,7 +90,7 @@ function WeakAuras.PrintHelp()
   print(L["Usage:"])
   print(L["/wa help - Show this message"])
   print(L["/wa minimap - Toggle the minimap icon"])
-  print(L["/wa pstart - Start profiling"])
+  print(L["/wa pstart - Start profiling. Optionally include a duration in seconds after which profiling automatically stops. To profile the next combat/encounter, pass a \"combat\" or \"encounter\" argument."])
   print(L["/wa pstop - Finish profiling"])
   print(L["/wa pprint - Show the results from the most recent profiling"])
   print(L["/wa repair - Repair tool"])
@@ -95,18 +98,27 @@ function WeakAuras.PrintHelp()
 end
 
 SLASH_WEAKAURAS1, SLASH_WEAKAURAS2 = "/weakauras", "/wa";
-function SlashCmdList.WEAKAURAS(msg)
+function SlashCmdList.WEAKAURAS(input)
   if not WeakAuras.IsCorrectVersion() then
     prettyPrint(WeakAuras.wrongTargetMessage)
     return
   end
-  msg = string.lower(msg)
+  local args, msg = {}
+  for v in string.gmatch(input, "%S+") do
+    if not msg then
+      msg = v
+    else
+      insert(args, v)
+    end
+  end
   if msg == "pstart" then
-    WeakAuras.StartProfile();
+    WeakAuras.StartProfile(args[1]);
   elseif msg == "pstop" then
     WeakAuras.StopProfile();
   elseif msg == "pprint" then
-    WeakAuras.PrintProfile();
+    WeakAuras.PrintProfile(args[1]);
+  elseif msg == "pcancel" then
+    WeakAuras.CancelScheduledProfile()
   elseif msg == "minimap" then
     WeakAuras.ToggleMinimap();
   elseif msg == "help" then


### PR DESCRIPTION
# Description

Provides several improvements to profiling:
- Largest time spent in a single debugprofilestop session
- Less empty space in profiling report
- Ability to profile the next instance of combat or encounter
- Save Real Time Profiling Window location between sessions
- Adds combat and encounter buttons to Real Time Profiling Window 

~~Experimental change:~~
~~- Most amount of time spent in a rolling x second window, configurable~~

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:
<!-- These can be checked off after the pull request is submitted, in case you want discussion before they’re completely ready -->

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

<!-- Is there any additional work that needs to be done? If so, add it to the above list -->
