### PR TITLE
disable trigger "Crowd Controlled" for classic

### DIFF
--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -6741,6 +6741,7 @@ if WeakAuras.IsClassic() then
   WeakAuras.event_prototypes["Alternate Power"] = nil
   WeakAuras.event_prototypes["Equipment Set"] = nil
   WeakAuras.event_prototypes["Spell Activation Overlay"] = nil
+  WeakAuras.event_prototypes["Crowd Controlled"] = nil
 else
   WeakAuras.event_prototypes["Queued Action"] = nil
 end


### PR DESCRIPTION
fixes #2145

# Description

The function `HasFullControl()` exists on classic and i found it work with Polymorph, but not with Ice Nova, Gouge, Sap, ... So not reliable enough to keep it on classic.
