### PR TITLE
DG anchored to Unit Frames: fix #2051

### DIFF
--- a/WeakAuras/RegionTypes/DynamicGroup.lua
+++ b/WeakAuras/RegionTypes/DynamicGroup.lua
@@ -367,7 +367,7 @@ local anchorers = {
       for _, regionData in ipairs(activeRegions) do
         local unit = regionData.region.state and regionData.region.state.unit
         if unit then
-          local frame = WeakAuras.GetUnitFrame(unit)
+          local frame = WeakAuras.GetUnitFrame(unit) or WeakAuras.HiddenFrames
           if frame then
             frames[frame] = frames[frame] or {}
             tinsert(frames[frame], regionData)
@@ -1045,7 +1045,7 @@ local function modify(parent, region, data)
         data.anchorPoint,
         x + data.xOffset, y + data.yOffset
       )
-      controlPoint:SetShown(show)
+      controlPoint:SetShown(show and frame ~= WeakAuras.HiddenFrames)
       controlPoint:SetWidth(regionData.dimensions.width)
       controlPoint:SetHeight(regionData.dimensions.height)
       if self.anchorPerUnit == "UNITFRAME" then

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -4787,6 +4787,22 @@ do
         end
         if new_frame and new_frame ~= data_frame then
           regionData.controlPoint:ReAnchor(new_frame)
+          regionData.controlPoint:SetShown(regionData.shown)
+          WeakAuras.dyngroup_unitframe_monitor[regionData] = new_frame
+        end
+      end
+    end
+  end)
+
+  LGF.RegisterCallback("WeakAuras", "FRAME_UNIT_REMOVED", function(event, frame, unit)
+    for regionData, data_frame in pairs(WeakAuras.dyngroup_unitframe_monitor) do
+      if regionData.region and regionData.region.state and regionData.region.state.unit == unit
+      and data_frame == frame
+      then
+        local new_frame = WeakAuras.GetUnitFrame(unit) or WeakAuras.HiddenFrames
+        if new_frame and new_frame ~= data_frame then
+          regionData.controlPoint:ReAnchor(new_frame)
+          regionData.controlPoint:SetShown(regionData.shown and new_frame ~= WeakAuras.HiddenFrames)
           WeakAuras.dyngroup_unitframe_monitor[regionData] = new_frame
         end
       end
@@ -6948,6 +6964,7 @@ end
 
 local HiddenFrames = CreateFrame("FRAME", "WeakAurasHiddenFrames")
 HiddenFrames:Hide()
+WeakAuras.HiddenFrames = HiddenFrames
 
 local function GetAnchorFrame(data, region, parent)
   local id = region.id


### PR DESCRIPTION
- anchor to hidden frame when can't find a unitframe
- handle new LibGetFrame Callback: FRAME_UNIT_REMOVED

# Description

Dynamic group anchoring to an invisible when GetFrame return nil fix an issue where the region is not registered in WeakAuras.dyngroup_unitframe_monitor for future FRAME_UNIT_UPDATE callback

FRAME_UNIT_REMOVED fix an issue with auras on "player" raid frame still showing after quitting a group


This change was made to LibGetFrame https://github.com/mrbuds/LibGetFrame/commit/33fd99afba2ab7a2e56ebc44e3e135c261af9cf8

Fixes #2051

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
