### PR TITLE
Add a way to overwrite default font and font size

### DIFF
--- a/WeakAuras/Init.lua
+++ b/WeakAuras/Init.lua
@@ -50,7 +50,7 @@ WeakAuras.wrongTargetMessage = "This version of WeakAuras was packaged for World
                               (intendedWoWProject == WOW_PROJECT_MAINLINE and "Retail" or "Classic") ..
                               ". Please install the " .. (WOW_PROJECT_ID == WOW_PROJECT_MAINLINE and "Retail" or "Classic") ..
                               " version instead.\nIf you are using the Twitch Client, then " ..
-                              " please contact the twitch support for further assistance."
+                              " contact Twitch support for further assistance and reinstall WeakAuras manually."
 
 if not WeakAuras.IsCorrectVersion() then
   C_Timer.After(1, function() WeakAuras.prettyPrint(WeakAuras.wrongTargetMessage) end)
@@ -63,11 +63,11 @@ end
 WeakAuras.PowerAurasPath = "Interface\\Addons\\WeakAuras\\PowerAurasMedia\\Auras\\"
 WeakAuras.PowerAurasSoundPath = "Interface\\Addons\\WeakAuras\\PowerAurasMedia\\Sounds\\"
 
--- force enable WeakAurasCompanion and Archive because some addon managers interfere with it
+-- Force enable WeakAurasCompanion and Archive because some addon managers interfere with it
 EnableAddOn("WeakAurasCompanion")
 EnableAddOn("WeakAurasArchive")
 
---These function stubs are defined here to reduce the number of errors that occur if WeakAuras.lua fails to compile
+-- These function stubs are defined here to reduce the number of errors that occur if WeakAuras.lua fails to compile
 function WeakAuras.RegisterRegionType()
 end
 
@@ -86,7 +86,7 @@ end
 function WeakAuras.StopProfileAura()
 end
 
--- if weakauras shuts down due to being installed on the wrong target, keep the bindings from erroring
+-- If WeakAuras shuts down due to being installed on the wrong target, keep the bindings from erroring
 function WeakAuras.StartProfile()
 end
 

--- a/WeakAuras/RegionTypes/ProgressTexture.lua
+++ b/WeakAuras/RegionTypes/ProgressTexture.lua
@@ -2,6 +2,10 @@ if not WeakAuras.IsCorrectVersion() then return end
 
 local L = WeakAuras.L;
 local GetAtlasInfo = WeakAuras.IsClassic() and GetAtlasInfo or C_Texture.GetAtlasInfo
+
+local defaultFont = WeakAuras.defaultFont
+local defaultFontSize = WeakAuras.defaultFontSize
+
 -- Credit to CommanderSirow for taking the time to properly craft the TransformPoint function
 -- to the enhance the abilities of Progress Textures.
 -- Also Credit to Semlar for explaining how circular progress can be shown
@@ -45,8 +49,8 @@ local default = {
   anchorFrameType = "SCREEN",
   xOffset = 0,
   yOffset = 0,
-  font = "Friz Quadrata TT",
-  fontSize = 12,
+  font = defaultFont,
+  fontSize = defaultFontSize,
   mirror = false,
   frameStrata = 1,
   slantMode = "INSIDE"

--- a/WeakAuras/RegionTypes/Text.lua
+++ b/WeakAuras/RegionTypes/Text.lua
@@ -3,6 +3,9 @@ if not WeakAuras.IsCorrectVersion() then return end
 local SharedMedia = LibStub("LibSharedMedia-3.0");
 local L = WeakAuras.L;
 
+local defaultFont = WeakAuras.defaultFont
+local defaultFontSize = WeakAuras.defaultFontSize
+
 local default = {
   displayText = "%p",
   outline = "OUTLINE",
@@ -13,8 +16,8 @@ local default = {
   anchorFrameType = "SCREEN",
   xOffset = 0,
   yOffset = 0,
-  font = "Friz Quadrata TT",
-  fontSize = 12,
+  font = defaultFont,
+  fontSize = defaultFontSize,
   frameStrata = 1,
   customTextUpdate = "event",
   automaticWidth = "Auto",

--- a/WeakAuras/SubRegionTypes/SubText.lua
+++ b/WeakAuras/SubRegionTypes/SubText.lua
@@ -3,14 +3,17 @@ if not WeakAuras.IsCorrectVersion() then return end
 local SharedMedia = LibStub("LibSharedMedia-3.0");
 local L = WeakAuras.L;
 
+local defaultFont = WeakAuras.defaultFont
+local defaultFontSize = WeakAuras.defaultFontSize
+
 local default = function(parentType)
   if parentType == "icon" then
     -- No Shadow, but Outline
     return {
       text_text = "%p",
       text_color = {1, 1, 1, 1},
-      text_font = "Friz Quadrata TT",
-      text_fontSize = 12,
+      text_font = defaultFont,
+      text_fontSize = defaultFontSize,
       text_fontType = "OUTLINE",
       text_visible = true,
       text_justify = "CENTER",
@@ -34,8 +37,8 @@ local default = function(parentType)
     return {
       text_text = "%n",
       text_color = {1, 1, 1, 1},
-      text_font = "Friz Quadrata TT",
-      text_fontSize = 12,
+      text_font = defaultFont,
+      text_fontSize = defaultFontSize,
       text_fontType = "None",
       text_visible = true,
       text_justify = "CENTER",
@@ -396,8 +399,8 @@ local function addDefaultsForNewAura(data)
       ["type"] = "subtext",
       text_text = "%p",
       text_color = {1, 1, 1, 1},
-      text_font = "Friz Quadrata TT",
-      text_fontSize = 12,
+      text_font = defaultFont,
+      text_fontSize = defaultFontSize,
       text_fontType = "None",
       text_justify = "CENTER",
       text_visible = true,
@@ -418,8 +421,8 @@ local function addDefaultsForNewAura(data)
       ["type"] = "subtext",
       text_text = "%n",
       text_color = {1, 1, 1, 1},
-      text_font = "Friz Quadrata TT",
-      text_fontSize = 12,
+      text_font = defaultFont,
+      text_fontSize = defaultFontSize,
       text_fontType = "None",
       text_justify = "CENTER",
       text_visible = true,
@@ -440,8 +443,8 @@ local function addDefaultsForNewAura(data)
       ["type"] = "subtext",
       text_text = "%s",
       text_color = {1, 1, 1, 1},
-      text_font = "Friz Quadrata TT",
-      text_fontSize = 12,
+      text_font = defaultFont,
+      text_fontSize = defaultFontSize,
       text_fontType = "OUTLINE",
       text_justify = "CENTER",
       text_visible = true,

--- a/WeakAurasOptions/ActionOptions.lua
+++ b/WeakAurasOptions/ActionOptions.lua
@@ -2,7 +2,6 @@ if not WeakAuras.IsCorrectVersion() then return end
 
 local L = WeakAuras.L
 
-
 local send_chat_message_types = WeakAuras.send_chat_message_types;
 local sound_types = WeakAuras.sound_types;
 

--- a/WeakAurasOptions/DefaultOptions.lua
+++ b/WeakAurasOptions/DefaultOptions.lua
@@ -1,0 +1,4 @@
+--[[ Manual override for the default font and font size until proper options are built ]]
+
+WeakAuras.defaultFont = "Friz Quadrata TT"
+WeakAuras.defaultFontSize = 12

--- a/WeakAurasOptions/WeakAurasOptions.toc
+++ b/WeakAurasOptions/WeakAurasOptions.toc
@@ -54,6 +54,7 @@ WeakAurasOptions.lua
 ExternalAddons.lua
 ConditionOptions.lua
 AuthorOptions.lua
+DefaultOptions.lua
 
 OptionsFrames\OptionsFrame.lua
 # -- Groups


### PR DESCRIPTION
# Description

Adds a manual overwrite for the default font and font size until proper options are built

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] It works
- [x] so far

# Checklist:
<!-- These can be checked off after the pull request is submitted, in case you want discussion before they’re completely ready -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

<!-- Is there any additional work that needs to be done? If so, add it to the above list -->
