### PR TITLE
Add more precision types to format large durations neatly 

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -3223,6 +3223,8 @@ globals = {
 	"SearchLFGJoin",
 	"SearchLFGLeave",
 	"SearchLFGSort",
+	"SecondsFormatter", -- from SecondsFormatterMixin
+	"SecondsFormatterMixin",
 	"SecureCmdOptionParse",
 	"SelectActiveQuest",
 	"SelectAvailableQuest",

--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -6930,32 +6930,8 @@ WeakAuras.dynamic_texts = {
         if not state.expirationTime or not state.duration then
           return ""
         end
-        local remaining  = state.expirationTime - GetTime();
-        local duration  = state.duration;
 
-        local remainingStr     = "";
-        if remaining == math.huge then
-          remainingStr     = " ";
-        elseif remaining > 60 then
-          remainingStr     = string.format("%i:", math.floor(remaining / 60));
-          remaining        = remaining % 60;
-          remainingStr     = remainingStr..string.format("%02i", remaining);
-        elseif remaining > 0 then
-          local progressPrecision = region.progressPrecision and math.abs(region.progressPrecision) or 1
-          -- remainingStr = remainingStr..string.format("%."..(data.progressPrecision or 1).."f", remaining);
-          if progressPrecision == 4 and remaining <= 3 then
-            remainingStr = remainingStr..string.format("%.1f", remaining);
-          elseif progressPrecision == 5 and remaining <= 3 then
-            remainingStr = remainingStr..string.format("%.2f", remaining);
-          elseif (progressPrecision == 4 or progressPrecision == 5) and remaining > 3 then
-            remainingStr = remainingStr..string.format("%d", remaining);
-          else
-            remainingStr = remainingStr..string.format("%.".. progressPrecision .."f", remaining);
-          end
-        else
-          remainingStr     = " ";
-        end
-        return remainingStr
+        return WeakAuras.SecondsToTime(state.expirationTime - GetTime(), region.progressPrecision and math.abs(region.progressPrecision))
       end
     end
   },
@@ -6969,30 +6945,8 @@ WeakAuras.dynamic_texts = {
         if not state.duration then
           return ""
         end
-        -- Format a duration time string
-        local durationStr     = "";
-        local duration = state.duration
-        if math.abs(duration) == math.huge or tostring(duration) == "nan" then
-          durationStr = " ";
-        elseif duration > 60 then
-          durationStr     = string.format("%i:", math.floor(duration / 60));
-          duration       = duration % 60;
-          durationStr     = durationStr..string.format("%02i", duration);
-        elseif duration > 0 then
-          local totalPrecision = region.totalPrecision and math.abs(region.totalPrecision) or 1
-          if totalPrecision == 4 and duration <= 3 then
-            durationStr = durationStr..string.format("%.1f", duration);
-          elseif totalPrecision == 5 and duration <= 3 then
-            durationStr = durationStr..string.format("%.2f", duration);
-          elseif (totalPrecision == 4 or totalPrecision == 5) and duration > 3 then
-            durationStr = durationStr..string.format("%d", duration);
-          else
-            durationStr = durationStr..string.format("%."..totalPrecision.."f", duration);
-          end
-        else
-          durationStr     = " ";
-        end
-        return durationStr
+
+        return WeakAuras.SecondsToTime(state.expirationTime - GetTime(), region.totalPrecision and math.abs(region.totalPrecision))
       end
     end
   },

--- a/WeakAuras/Types.lua
+++ b/WeakAuras/Types.lua
@@ -96,7 +96,6 @@ WeakAuras.precision_types = {
 
   -- 1h 3m | 3m 7s | 43s | 9.5 | 2.9
   [9] = "|cffffff001h 3m|r |cff424242|||r |cffffff003m 7s|r |cff424242|||r 42s |cff424242|||r 9|cffffff00.5|r |cff424242|||r 1|cffffff00.9|r",
-
 }
 
 WeakAuras.sound_channel_types = {

--- a/WeakAuras/Types.lua
+++ b/WeakAuras/Types.lua
@@ -67,12 +67,36 @@ WeakAuras.group_hybrid_sort_types = {
 }
 
 WeakAuras.precision_types = {
-  [0] = "12",
-  [1] = "12.3",
-  [2] = "12.34",
-  [3] = "12.345",
-  [4] = "Dynamic 12.3", -- will show 1 digit precision when time is lower than 3 seconds, hardcoded
-  [5] = "Dynamic 12.34" -- will show 2 digits precision when time is lower than 3 seconds, hardcoded
+  -- 63:42 | 3:07 | 42 | 9
+  [0] = "63:42 |cff424242|||r 3:07 |cff424242|||r 42 |cff424242|||r 9",
+
+  -- 63:42 | 3:07 | 42.1 | 9.5
+  [1] = "63:42 |cff424242|||r 3:07 |cff424242|||r 42|cffffff00.1|r |cff424242|||r 9|cffffff00.5|r",
+
+  -- 63:42 | 3:07 | 42.12 | 9.47
+  [2] = "63:42 |cff424242|||r 3:07 |cff424242|||r 42|cffffff00.12|r |cff424242|||r 9|cffffff00.47|r",
+
+  -- 63:42 | 3:07 | 42.123 | 9.469
+  [3] = "63:42 |cff424242|||r 3:07 |cff424242|||r 42|cffffff00.123|r |cff424242|||r 9|cffffff00.469|r",
+
+  -- 63:42 | 3:07 | 42 | 9 | 2.9
+  [4] = "63:42 |cff424242|||r 3:07 |cff424242|||r 42 |cff424242|||r 9 |cff424242|||r 2|cffffff00.9|r",
+
+  -- 63:42 | 3:07 | 42 | 9 | 2.93
+  [5] = "63:42 |cff424242|||r 3:07 |cff424242|||r 42 |cff424242|||r 9 |cff424242|||r 2|cffffff00.93|r",
+
+  -- 2h | 11m | 3:07 | 42 | 9 | 3
+  [6] = "|cffffff002h|r |cff424242|||r |cffffff0011m|r |cff424242|||r 3:07 |cff424242|||r 42 |cff424242|||r 9 |cff424242|||r 3",
+
+  -- 2h | 11m | 3:07 | 42 | 9 | 2.9
+  [7] = "|cffffff002h|r |cff424242|||r |cffffff0011m|r |cff424242|||r 3:07 |cff424242|||r 42 |cff424242|||r 9 |cff424242|||r 2|cffffff00.9|r",
+
+  -- 1h 3m | 3m 7s | 43s | 10s | 3s
+  [8] = "|cffffff001h 3m|r |cff424242|||r |cffffff003m 7s|r |cff424242|||r 42|cffffff00s|r |cff424242|||r 10|cffffff00s|r |cff424242|||r 3|cffffff00s|r",
+
+  -- 1h 3m | 3m 7s | 43s | 9.5 | 2.9
+  [9] = "|cffffff001h 3m|r |cff424242|||r |cffffff003m 7s|r |cff424242|||r 42s |cff424242|||r 9|cffffff00.5|r |cff424242|||r 1|cffffff00.9|r",
+
 }
 
 WeakAuras.sound_channel_types = {


### PR DESCRIPTION
# Description

Currently WeakAuras formats every duration above 60s as mm:ss, as seen here:
https://github.com/WeakAuras/WeakAuras2/blob/master/WeakAuras/Prototypes.lua#L6939-L6942

For larger durations, that's not the the nicest solution imo. 

This pull request adds more precision types, while maintaining old behavior.

![Wow_2020-05-06_00-12-20](https://user-images.githubusercontent.com/8883045/81121262-9936e280-8f2e-11ea-8c74-f7303b42c94b.png)

I also tried to highlight the differences between all options by giving more examples in general. This is what I ended up with. Feedback welcome.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Running tests to ensure the expected output:
https://gist.github.com/elvador/aa842df0b46854fc5df5026ae56ae0e4

According to the WeakAuras Profiling, there is no performance difference between this implementation and the current master branch with my setup.

If this gets merged, I'd recommend an extensive alpha test, as this touches core functionality.

# Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
