### PR TITLE
Threat Situation trigger rework and enable it for WoW 1.13.5

### DIFF
--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -14,6 +14,7 @@ local UnitAlternatePowerInfo, UnitAlternatePowerTextureInfo = UnitAlternatePower
 local GetSpellInfo, GetItemInfo, GetItemCount, GetItemIcon = GetSpellInfo, GetItemInfo, GetItemCount, GetItemIcon
 local GetShapeshiftFormInfo, GetShapeshiftForm = GetShapeshiftFormInfo, GetShapeshiftForm
 local GetRuneCooldown, UnitCastingInfo, UnitChannelInfo = GetRuneCooldown, UnitCastingInfo, UnitChannelInfo
+local UnitDetailedThreatSituation, UnitThreatSituation = UnitDetailedThreatSituation, UnitThreatSituation
 local CastingInfo, ChannelInfo = CastingInfo, ChannelInfo
 
 local WeakAuras = WeakAuras
@@ -5712,26 +5713,37 @@ WeakAuras.event_prototypes = {
   },
   ["Threat Situation"] = {
     type = "status",
-    events = {
-      ["unit_events"] = {
-        ["player"] = {"UNIT_THREAT_SITUATION_UPDATE"}
-      }
-    },
-    internal_events = function(trigger)
+    events = function(trigger)
       local result = {}
-      AddUnitChangeInternalEvents(trigger.unit, result)
+      if trigger.threatUnit and trigger.threatUnit ~= "none" then
+        AddUnitEventForEvents(result, trigger.threatUnit, "UNIT_THREAT_LIST_UPDATE")
+      else
+        AddUnitEventForEvents(result, "player", "UNIT_THREAT_SITUATION_UPDATE")
+      end
       return result
     end,
-    force_events = "UNIT_THREAT_SITUATION_UPDATE",
+    internal_events = function(trigger)
+      local result = {}
+      AddUnitChangeInternalEvents(trigger.threatUnit, result)
+      return result
+    end,
+    force_events = "UNIT_THREAT_LIST_UPDATE",
     name = L["Threat Situation"],
     init = function(trigger)
       local ret = [[
-        local status = UnitThreatSituation('player', %s) or -1;
-        local aggro = status == 2 or status == 3;
+        local unit = %s
+        local aggro, status, threatpct, rawthreatpct, threatvalue
+        if unit then
+          aggro, status, threatpct, rawthreatpct, threatvalue = UnitDetailedThreatSituation('player', unit)
+        else
+          status = UnitThreatSituation('player')
+          aggro = status == 2 or status == 3
+          threatpct, rawthreatpct, threatvalue = 100, 100, 0
+        end
       ]];
-
       return ret:format(trigger.threatUnit and trigger.threatUnit ~= "none" and "[["..trigger.threatUnit.."]]" or "nil");
     end,
+    statesParameter = "unit",
     args = {
       {
         name = "threatUnit",
@@ -5754,10 +5766,45 @@ WeakAuras.event_prototypes = {
         type = "tristate"
       },
       {
-        hidden = true,
-        test = "status ~= -1"
+        name = "threatpct",
+        display = L["Threat Percent"],
+        desc = L["Your threat on the mob as a percentage of the amount required to pull aggro. Will pull aggro at 100."],
+        type = "number",
+        store = true,
+        conditionType = "number",
+        enable = function(trigger) return trigger.threatUnit ~= "none" end,
       },
+      {
+        name = "rawthreatpct",
+        display = L["Raw Threat Percent"],
+        desc = L["Your threat as a percentage of the tank's current threat."],
+        type = "number",
+        store = true,
+        conditionType = "number",
+        enable = function(trigger) return trigger.threatUnit ~= "none" end,
+      },
+      {
+        name = "threatvalue",
+        display = L["Threat Value"],
+        desc = L["Your total threat on the mob."],
+        type = "number",
+        store = true,
+        conditionType = "number",
+        enable = function(trigger) return trigger.threatUnit ~= "none" end,
+      },
+      {
+        hidden = true,
+        test = "status ~= nil"
+      }
     },
+    durationFunc = function(trigger)
+      if trigger.threatUnit and trigger.threatUnit ~= "none" then
+        local _, _, threatpct = UnitDetailedThreatSituation("player", trigger.threatUnit)
+        return threatpct, 100, true;
+      else
+        return 100, 100, true
+      end
+    end,
     automaticrequired = true
   },
   ["Crowd Controlled"] = {
@@ -6919,7 +6966,9 @@ WeakAuras.event_prototypes = {
 };
 
 if WeakAuras.IsClassic() then
-  WeakAuras.event_prototypes["Threat Situation"] = nil
+  if not UnitDetailedThreatSituation then
+    WeakAuras.event_prototypes["Threat Situation"] = nil
+  end
   WeakAuras.event_prototypes["Death Knight Rune"] = nil
   WeakAuras.event_prototypes["Alternate Power"] = nil
   WeakAuras.event_prototypes["Equipment Set"] = nil

--- a/WeakAuras/Types.lua
+++ b/WeakAuras/Types.lua
@@ -2303,6 +2303,7 @@ if WeakAuras.IsClassic() then
   WeakAuras.actual_unit_types_cast.focus = nil
   WeakAuras.actual_unit_types.focus = nil
   WeakAuras.unit_types_range_check.focus = nil
+  WeakAuras.threat_unit_types.focus = nil
   WeakAuras.item_slot_types[0] = AMMOSLOT
   WeakAuras.item_slot_types[18] = RANGEDSLOT
 


### PR DESCRIPTION
…e more informations

If unit is not "At Least One Enemy"
- use UNIT_THREAT_LIST_UPDATE instead of UNIT_THREAT_SITUATION_UPDATE
- use UnitDetailedThreatSituation instead of UnitThreatSituation
- %threatpct, %rawthreatpct and %threatvalue can be use
- duration function use threatpct