### PR TITLE
Add LibSerialize

### DIFF
--- a/.pkgmeta
+++ b/.pkgmeta
@@ -20,6 +20,7 @@ externals:
   WeakAuras/Libs/LibDBIcon-1.0: https://repos.wowace.com/wow/libdbicon-1-0/trunk/LibDBIcon-1.0
   WeakAuras/Libs/LibGetFrame-1.0: https://github.com/mrbuds/LibGetFrame
   WeakAuras/Libs/Archivist: https://github.com/emptyrivers/Archivist
+  WeakAuras/Libs/LibSerialize: https://github.com/emptyrivers/LibSerialize
 
 enable-nolib-creation: no
 

--- a/.pkgmeta
+++ b/.pkgmeta
@@ -20,7 +20,9 @@ externals:
   WeakAuras/Libs/LibDBIcon-1.0: https://repos.wowace.com/wow/libdbicon-1-0/trunk/LibDBIcon-1.0
   WeakAuras/Libs/LibGetFrame-1.0: https://github.com/mrbuds/LibGetFrame
   WeakAuras/Libs/Archivist: https://github.com/emptyrivers/Archivist
-  WeakAuras/Libs/LibSerialize: https://github.com/rossnichols/LibSerialize
+  WeakAuras/Libs/LibSerialize:
+    url: https://github.com/rossnichols/LibSerialize
+    tag: v1.0.0
 
 enable-nolib-creation: no
 

--- a/.pkgmeta
+++ b/.pkgmeta
@@ -20,7 +20,7 @@ externals:
   WeakAuras/Libs/LibDBIcon-1.0: https://repos.wowace.com/wow/libdbicon-1-0/trunk/LibDBIcon-1.0
   WeakAuras/Libs/LibGetFrame-1.0: https://github.com/mrbuds/LibGetFrame
   WeakAuras/Libs/Archivist: https://github.com/emptyrivers/Archivist
-  WeakAuras/Libs/LibSerialize: https://github.com/emptyrivers/LibSerialize
+  WeakAuras/Libs/LibSerialize: https://github.com/rossnichols/LibSerialize
 
 enable-nolib-creation: no
 

--- a/.pkgmeta-classic
+++ b/.pkgmeta-classic
@@ -23,6 +23,9 @@ externals:
   WeakAuras/Libs/LibRangeCheck-2.0: https://repos.wowace.com/wow/librangecheck-2-0/trunk/LibRangeCheck-2.0
   WeakAuras/Libs/LibClassicSpellActionCount-1.0: https://github.com/Ennea/LibClassicSpellActionCount-1.0
   WeakAuras/Libs/Archivist: https://github.com/emptyrivers/Archivist
+  WeakAuras/Libs/LibSerialize:
+    url: https://github.com/rossnichols/LibSerialize
+    tag: v1.0.0
 
 enable-nolib-creation: no
 

--- a/WeakAuras/ArchiveTypes/Repository.lua
+++ b/WeakAuras/ArchiveTypes/Repository.lua
@@ -112,7 +112,12 @@ local prototype = {
   end,
   Close = function(self, store)
     return store
-  end
+  end,
+  Delete = function(self, image)
+    for id in pairs(image.stores) do
+      Archivist:Delete("ReadOnly", id)
+    end
+  end,
 }
 
 Archivist:RegisterStoreType(prototype)

--- a/WeakAuras/History.lua
+++ b/WeakAuras/History.lua
@@ -73,4 +73,3 @@ end
 function WeakAuras.GetMigrationSnapshot(uid)
   return loadMigrations():GetData(uid)
 end
-

--- a/WeakAuras/Transmission.lua
+++ b/WeakAuras/Transmission.lua
@@ -670,16 +670,11 @@ function StringToTable(inString, fromChat)
   -- version 1: b64 string prepended with "!", compressed with LD and serialized with AS
   -- version 2+: b64 string prepended with !WA:N! (where N is encode version)
   --   compressed with LD and serialized with LS
-  local encodeVersion = 0
-  local encoded = ""
-  if inString:find("^%!") then
-    local header
-    inString:gsub("^%!WA%:%d+!", function(m) header = m return "" end)
-    if not header then
-      encodeVersion = 1
-    else
-      encodeVersion = tonumber(header:match("%d+"))
-    end
+  local _, _, encodeVersion, encoded = inString:find("^(!WA:%d+!)(.+)$")
+  if encodeVersion then
+    encodeVersion = tonumber(encodeVersion:match("%d+"))
+  else
+    encoded, encodeVersion = inString:gsub("^%!", "")
   end
 
   local decoded

--- a/WeakAuras/Transmission.lua
+++ b/WeakAuras/Transmission.lua
@@ -581,9 +581,13 @@ end)
 
 local Compresser = LibStub:GetLibrary("LibCompress")
 local LibDeflate = LibStub:GetLibrary("LibDeflate")
+local Serializer = LibStub:GetLibrary("AceSerializer-3.0")
+local LibSerialize = LibStub("LibSerialize")
+local Comm = LibStub:GetLibrary("AceComm-3.0")
 local configForDeflate = {level = 9} -- the biggest bottleneck by far is in transmission and printing; so use maximal compression
-local Serializer = LibStub:GetLibrary("AceSerializer-3.0");
-local Comm = LibStub:GetLibrary("AceComm-3.0");
+local configForLS = {
+  errorOnUnserializableType =  false
+}
 
 local tooltipLoading;
 local receivedData;
@@ -632,7 +636,7 @@ end);
 local compressedTablesCache = {}
 
 function TableToString(inTable, forChat)
-  local serialized = Serializer:Serialize(inTable)
+  local serialized = LibSerialize:SerializeEx(configForLS, inTable)
   local compressed
   -- get from / add to cache
   if compressedTablesCache[serialized] then
@@ -651,9 +655,7 @@ function TableToString(inTable, forChat)
       compressedTablesCache[k] = nil
     end
   end
-  -- prepend with "!" so that we know that it is not a legacy compression
-  -- also this way, old versions of weakauras will error out due to the "bad" encoding
-  local encoded = "!"
+  local encoded = "!WA:2!"
   if(forChat) then
     encoded = encoded .. LibDeflate:EncodeForPrint(compressed)
   else
@@ -663,11 +665,26 @@ function TableToString(inTable, forChat)
 end
 
 function StringToTable(inString, fromChat)
-  -- if gsub strips off a ! at the beginning then we know that this is not a legacy encoding
-  local encoded, usesDeflate = inString:gsub("^%!", "")
+  -- encoding format:
+  -- version 0: simple b64 string, compressed with LC and serialized with AS
+  -- version 1: b64 string prepended with "!", compressed with LD and serialized with AS
+  -- version 2+: b64 string prepended with !WA:N! (where N is encode version)
+  --   compressed with LD and serialized with LS
+  local encodeVersion = 0
+  local encoded = ""
+  if inString:find("^%!") then
+    local header
+    inString:gsub("^%!WA%:%d+!", function(m) header = m return "" end)
+    if not header then
+      encodeVersion = 1
+    else
+      encodeVersion = tonumber(header:match("%d+"))
+    end
+  end
+
   local decoded
   if(fromChat) then
-    if usesDeflate == 1 then
+    if encodeVersion > 0 then
       decoded = LibDeflate:DecodeForPrint(encoded)
     else
       decoded = decodeB64(encoded)
@@ -681,7 +698,7 @@ function StringToTable(inString, fromChat)
   end
 
   local decompressed, errorMsg = nil, "unknown compression method"
-  if usesDeflate == 1 then
+  if encodeVersion > 0 then
     decompressed = LibDeflate:DecompressDeflate(decoded)
   else
     decompressed, errorMsg = Compresser:Decompress(decoded)
@@ -690,11 +707,16 @@ function StringToTable(inString, fromChat)
     return "Error decompressing: " .. errorMsg
   end
 
-  local success, deserialized = Serializer:Deserialize(decompressed);
-  if not(success) then
-    return "Error deserializing "..deserialized;
+  local success, deserialized
+  if encodeVersion < 2 then
+    success, deserialized = Serializer:Deserialize(decompressed)
+  else
+    success, deserialized = LibSerialize:Deserialize(decompressed)
   end
-  return deserialized;
+  if not(success) then
+    return "Error deserializing "..deserialized
+  end
+  return deserialized
 end
 
 function WeakAuras.DisplayToString(id, forChat)

--- a/WeakAuras/embeds.xml
+++ b/WeakAuras/embeds.xml
@@ -25,4 +25,5 @@
   @end-non-retail@-->
   <Script file="Libs\LibGetFrame-1.0\LibGetFrame-1.0.lua"/>
   <Include file="Libs\Archivist\Archivist.xml"/>
+  <Include file="Libs\LibSerialize\lib.xml"/>
 </Ui>


### PR DESCRIPTION
# Description

We have a new option for serializing arbitrary data, thanks to @rossnichols. From experiments, it looks to be about a 20-25% reduction in the final size of the exported string, which is good enough imo to warrant adoption.

Since this change is not forwards-compatible, it warrants a minor version upgrade to `2.18`, I think. And once it's been released, we should advise people to ensure that they are up to date.

Build artifact will fail to load properly in game, until [this](https://github.com/rossnichols/LibSerialize/pull/1) change is complete.

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested

as always, I was lazy and haven't done any thorough testing beyond the initial experiments.

