### PR TITLE
Fix weapon enchant name pattern

### DIFF
--- a/WeakAuras/GenericTrigger.lua
+++ b/WeakAuras/GenericTrigger.lua
@@ -3168,10 +3168,9 @@ do
           if(v:GetObjectType() == "FontString") then
             local text = v:GetText();
             if(text) then
-              local _, _, name = text:find("^(.+) %(%d+ [^%)]+%)$");
+              local _, _, name, shortenedName = text:find("^((.-) ?+?[VI%d]*) %(%d+ .+%)$");
               if(name) then
-                local _, _, shortenedName = name:find("^(.+) [VI%d]+$")
-                return name, shortenedName or name;
+                return name, shortenedName;
               end
             end
           end


### PR DESCRIPTION
# Description

This fix weapon enchant name pattern not working as expected with weapon enchant that have charge. It also fix some cases where `shortenedName` wasn't shortened as expected.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested

Tested in game on retail with a fishing pole and shiny bauble.
Tested on lua 5.1 with those cases:
* `Instant Poison IV (30 min) (70 charges)` ➔ Capture `Instant Poison IV` and `Instant Poison`
* `Windfury 4 (5 min)` ➔ Capture `Windfury 4` and `Windfury`
* `Crippling Poison (30 min)` ➔ Capture `Crippling Poison` and `Crippling Poison`
* `Sharpened +2 (30 min)` ➔ Capture `Sharpened +2` and `Sharpened`
* `(20 damage per second)` ➔ Doesn't match

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
