### PR TITLE
Fixes for Queued Spell and Threat Situation triggers

### DIFF
--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -7067,15 +7067,23 @@ WeakAuras.event_prototypes = {
     },
     name = L["Queued Action"],
     init = function(trigger)
+      trigger.spellName = trigger.spellName or 0
+      local spellName
+      if trigger.use_exact_spellName then
+        spellName = trigger.spellName
+      else
+        spellName = type(trigger.spellName) == "number" and GetSpellInfo(trigger.spellName) or trigger.spellName
+      end
       local ret = [=[
-        local spellid = select(7, GetSpellInfo(%q))
+        local spellname = %q
+        local spellid = select(7, GetSpellInfo(spellname))
         local button
         if spellid then
             local slotList = C_ActionBar.FindSpellActionButtons(spellid)
             button = slotList and slotList[1]
         end
       ]=]
-      return ret:format(trigger.spellName or "")
+      return ret:format(spellName)
     end,
     args = {
       {
@@ -7084,6 +7092,7 @@ WeakAuras.event_prototypes = {
         display = L["Spell"],
         type = "spell",
         test = "true",
+        showExactOption = true,
       },
       {
         hidden = true,

--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -5867,7 +5867,7 @@ WeakAuras.event_prototypes = {
         local aggro, status, threatpct, rawthreatpct, threatvalue, threattotal
         if unit then
           aggro, status, threatpct, rawthreatpct, threatvalue = WeakAuras.UnitDetailedThreatSituation('player', unit)
-          threattotal = (threatvalue or 0) * 100 / (threatpct or 1)
+          threattotal = (threatvalue or 0) * 100 / (threatpct ~= 0 and threatpct or 1)
         else
           status = UnitThreatSituation('player')
           aggro = status == 2 or status == 3


### PR DESCRIPTION
# Description

- Add an exact spell option for "Queued Spell", this fixes an issue where the trigger won't work after learning a new rank
- Fix division per 0 in Threat Situation trigger

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)