### PR TITLE
Tiny change to tidy up the texture picker

### DIFF
--- a/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasTextureButton.lua
+++ b/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasTextureButton.lua
@@ -34,7 +34,7 @@ local methods = {
     if (GetAtlasInfo(texturePath)) then
       self.texture:SetAtlas(texturePath);
     else
-      self.texture:SetTexture(texturePath);
+      self.texture:SetTexture(texturePath, "CLAMPTOBLACKADDITIVE", "CLAMPTOBLACKADDITIVE");
     end
     self.texture.path = texturePath;
     self.texture.name = name;


### PR DESCRIPTION
Set the wrap mode on all the textures in the TexturePicker window so they don't repeat at the edges

# Description

Textures in the picker that don't have a >0px zero alpha border will repeat their edges. This looks unsightly but more importantly makes it difficult to discern the actual shape of the texture. Changing the wrap mode in the picker solves that. This change doesn't intend to do anything about how textures are used once selected. 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [*] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist
<!-- These can be checked off after the pull request is submitted, in case you want discussion before they are completely ready -->

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

<!-- Is there any additional work that needs to be done? If so, add it to the above list -->
