### PR TITLE
Make CD Widget functional when using a static progress type on an icon aura.

### DIFF
--- a/WeakAuras/RegionTypes/Icon.lua
+++ b/WeakAuras/RegionTypes/Icon.lua
@@ -462,9 +462,14 @@ local function modify(parent, region, data)
   cooldown:Hide()
   if(data.cooldown) then
     function region:SetValue(value, total)
-      cooldown.duration = 0
-      cooldown.expirationTime = math.huge
-      cooldown:Hide();
+      cooldown.value = value
+      cooldown.total = total
+      if (value >= 0 and value <= total) then
+        cooldown:Show()
+        cooldown:SetCooldown(GetTime() - (total - value), total)
+      else
+        cooldown:Hide();
+      end
     end
 
     function region:SetTime(duration, expirationTime)
@@ -484,6 +489,7 @@ local function modify(parent, region, data)
       if (cooldown.duration and cooldown.duration > 0.01) then
         cooldown:Show();
         cooldown:SetCooldown(cooldown.expirationTime - cooldown.duration, cooldown.duration);
+        cooldown:Resume()
       end
     end
 
@@ -510,6 +516,7 @@ local function modify(parent, region, data)
         end
 
         region:SetTime(max - adjustMin, expirationTime - adjustMin, state.inverse);
+        cooldown:Resume()
       elseif state.progressType == "static" then
         local value = state.value or 0;
         local total = state.total or 0;
@@ -519,6 +526,7 @@ local function modify(parent, region, data)
         local adjustMin = region.adjustedMin or region.adjustedMinRel or 0;
         local max = region.adjustedMax or region.adjustedMaxRel or total;
         region:SetValue(value - adjustMin, max - adjustMin);
+        cooldown:Pause()
       else
         region:SetTime(0, math.huge)
       end


### PR DESCRIPTION
# Description

A user in discord reported that icon auras with a static progress type didn't display the CD widget. Upon investigation, it was never implemented. It currently simply hides the widget if the progress type is static. This PR would make the CD widget work as expected, showing a static CD widget set to the given progress values.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested

- [x] Used an aura with multiple triggers to test switching between multiple progress types and values.

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

<!-- Is there any additional work that needs to be done? If so, add it to the above list -->
