### PR TITLE
Set an absolute minimum to border size of 1

### DIFF
--- a/WeakAurasOptions/CommonOptions.lua
+++ b/WeakAurasOptions/CommonOptions.lua
@@ -1159,7 +1159,7 @@ local function BorderOptions(id, data, showBackDropOptions, hiddenFunc, order)
       width = WeakAuras.normalWidth,
       name = L["Border Size"],
       order = order + 0.4,
-      softMin = 1,
+      min = 1,
       softMax = 64,
       bigStep = 1,
       hidden = function() return hiddenFunc and hiddenFunc() or not data.border end,

--- a/WeakAurasOptions/SubRegionOptions/Border.lua
+++ b/WeakAurasOptions/SubRegionOptions/Border.lua
@@ -64,7 +64,7 @@ local function createOptions(parentData, data, index, subIndex)
       width = WeakAuras.normalWidth,
       name = L["Border Size"],
       order = 6,
-      softMin = 1,
+      min = 1,
       softMax = 64,
       bigStep = 1,
     },


### PR DESCRIPTION
Because otherwise we risk a division by 0 error in the backdrop mixin
