### PR TITLE
re-anchor dynamic groups on Resume() fixes #2317

### DIFF
--- a/WeakAuras/RegionTypes/DynamicGroup.lua
+++ b/WeakAuras/RegionTypes/DynamicGroup.lua
@@ -804,6 +804,7 @@ local function modify(parent, region, data)
       self.suspended = self.suspended - 1
     end
     if not self:IsSuspended() then
+      WeakAuras.AnchorFrame(data, self, self.parent)
       if self.needToReload then
         self:ReloadControlledChildren()
       end


### PR DESCRIPTION
# Description
Fixes dynamic group anchor not set on Resume()


## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
