### PR TITLE
Add a confirmation popup when deleting trigger

### DIFF
--- a/WeakAurasOptions/TriggerOptions.lua
+++ b/WeakAurasOptions/TriggerOptions.lua
@@ -266,10 +266,25 @@ function WeakAuras.AddTriggerMetaFunctions(options, data, triggernum)
     end,
     func = function()
       if #data.triggers > 1 then
-        tremove(data.triggers, triggernum)
-        DeleteConditionsForTrigger(data, triggernum);
-        WeakAuras.Add(data)
-        WeakAuras.ClearAndUpdateOptions(data.id)
+        StaticPopupDialogs["WEAKAURAS_CONFIRM_TRIGGER_DELETE"] = {
+          text = L["You are about to delete a trigger. |cFFFF0000This cannot be undone!|r Would you like to continue?"],
+          button1 = L["Delete"],
+          button2 = L["Cancel"],
+          OnAccept = function()
+            tremove(data.triggers, triggernum)
+            DeleteConditionsForTrigger(data, triggernum)
+            WeakAuras.Add(data)
+            WeakAuras.ClearAndUpdateOptions(data.id)
+            WeakAuras.FillOptions()
+          end,
+          OnCancel = function()
+            -- no-op
+          end,
+          showAlert = true,
+          whileDead = true,
+          preferredindex = STATICPOPUP_NUMDIALOGS,
+        }
+        StaticPopup_Show("WEAKAURAS_CONFIRM_TRIGGER_DELETE")
       end
     end
   }


### PR DESCRIPTION
# Description

When multiple triggers are present they are shown within the same page. Accidentally clicking the "delete" button immediately removes the trigger with no way to undo. This change introduces a confirmation popup for this action to avoid accidental deletion.

<!-- If it is a GitHub ticket, then #ticketNum will be sufficient. A WowAce ticket should include a URL. -->
Fixes #2350

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] happy: Add additional trigger and click the X. Confirm popup is displayed
- [X] Trigger is removed after "Delete" is pressed on popup
- [X] Trigger is **not** removed upon cancel press on pop
- [X] Regression: verified add/dup/moveup/movedown still function as expected
- [X] Regression: verified other similar headers (e..g Text) do not have this functionality added for their delete buttons

# Checklist
<!-- These can be checked off after the pull request is submitted, in case you want discussion before they are completely ready -->

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings

<!-- Is there any additional work that needs to be done? If so, add it to the above list -->
