### PR TITLE
re-enable model region for classic

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -31,7 +31,7 @@ jobs:
         path: .release/
 
     - name: Create Classic Package
-      run: curl -s https://raw.githubusercontent.com/BigWigsMods/packager/master/release.sh | bash -s -- -d -z -g 1.13.3 -m .pkgmeta-classic
+      run: curl -s https://raw.githubusercontent.com/BigWigsMods/packager/master/release.sh | bash -s -- -d -z -g 1.13.5 -m .pkgmeta-classic
       env:
         CF_API_KEY: ${{ secrets.CF_API_KEY }}
         GITHUB_OAUTH: ${{ secrets.GITHUB_OAUTH }}

--- a/.pkgmeta
+++ b/.pkgmeta
@@ -36,6 +36,7 @@ ignore:
   - babelfish.lua
   - wowace_translations.sh
   - generate_changelog.sh
+  - WeakAurasModelPaths/ModelPathsClassic.lua
 
 move-folders:
   WeakAuras/WeakAuras: WeakAuras

--- a/.pkgmeta-classic
+++ b/.pkgmeta-classic
@@ -39,12 +39,11 @@ ignore:
   - babelfish.lua
   - wowace_translations.sh
   - generate_changelog.sh
-  - WeakAuras/RegionTypes/Model.lua
-  - WeakAurasOptions/RegionOptions/Model.lua
-  - WeakAurasModelPaths
+  - WeakAurasModelPaths/ModelPaths.lua
 
 move-folders:
   WeakAuras/WeakAuras: WeakAuras
   WeakAuras/WeakAurasOptions: WeakAurasOptions
+  WeakAuras/WeakAurasModelPaths: WeakAurasModelPaths
   WeakAuras/WeakAurasTemplates: WeakAurasTemplates
   WeakAuras/WeakAurasArchive: WeakAurasArchive

--- a/WeakAuras/RegionTypes/Model.lua
+++ b/WeakAuras/RegionTypes/Model.lua
@@ -2,11 +2,10 @@ if not WeakAuras.IsCorrectVersion() then return end
 
 local SharedMedia = LibStub("LibSharedMedia-3.0");
 local L = WeakAuras.L;
-if WeakAuras.IsClassic() then return end -- Models disabled for classic
 
 -- Default settings
 local default = {
-  model_path = "Creature/Arthaslichking/arthaslichking.m2",
+  model_path = "spells/arcanepower_state_chest.m2", -- arthas is not a thing on classic
   model_fileId = "122968", -- Creature/Arthaslichking/arthaslichking.m2
   modelIsUnit = false,
   api = false, -- false ==> SetPosition + SetFacing; true ==> SetTransform
@@ -134,7 +133,7 @@ local function AcquireModel(region, data)
     model:RegisterEvent("UNIT_MODEL_CHANGED");
     if (data.model_fileId == "target") then
       model:RegisterEvent("PLAYER_TARGET_CHANGED");
-    elseif (data.model_fileId == "focus") then
+    elseif not WeakAuras.IsClassic() and data.model_fileId == "focus" then
       model:RegisterEvent("PLAYER_FOCUS_CHANGED");
     end
     model:SetScript("OnEvent", function(self, event, unitId)
@@ -148,7 +147,9 @@ local function AcquireModel(region, data)
   else
     model:UnregisterEvent("UNIT_MODEL_CHANGED");
     model:UnregisterEvent("PLAYER_TARGET_CHANGED");
-    model:UnregisterEvent("PLAYER_FOCUS_CHANGED");
+    if not WeakAuras.IsClassic() then
+      model:UnregisterEvent("PLAYER_FOCUS_CHANGED");
+    end
     model:SetScript("OnEvent", nil);
   end
 
@@ -172,7 +173,9 @@ local function ReleaseModel(model)
   model:Hide()
   model:UnregisterEvent("UNIT_MODEL_CHANGED");
   model:UnregisterEvent("PLAYER_TARGET_CHANGED");
-  model:UnregisterEvent("PLAYER_FOCUS_CHANGED");
+  if not WeakAuras.IsClassic() then
+    model:UnregisterEvent("PLAYER_FOCUS_CHANGED");
+  end
   model:SetScript("OnEvent", nil);
   local pool = model.api and poolNewApi or poolOldApi
   pool:Release(model)

--- a/WeakAuras/SubRegionTypes/BarModel.lua
+++ b/WeakAuras/SubRegionTypes/BarModel.lua
@@ -3,8 +3,6 @@ if not WeakAuras.IsCorrectVersion() then return end
 local SharedMedia = LibStub("LibSharedMedia-3.0");
 local L = WeakAuras.L;
 
-if WeakAuras.IsClassic() then return end -- Models disabled for classic
-
 local default = function(parentType)
   return {
     bar_model_visible = true,
@@ -24,6 +22,7 @@ local default = function(parentType)
     model_st_us = 40,
 
     model_fileId = "235338",
+    model_path = "spells/arcanepower_state_chest.m2",
     bar_model_clip = true
   }
 end
@@ -70,7 +69,12 @@ local function AcquireModel(region, data)
   model:Show()
 
   -- Adjust model
-  local modelId = tonumber(data.model_fileId)
+  local modelId
+  if WeakAuras.IsClassic() then
+    modelId = data.model_path
+  else
+    modelId = tonumber(data.model_fileId)
+  end
   if modelId then
     model:SetModel(modelId)
   end

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -7455,12 +7455,22 @@ function WeakAuras.FindUnusedId(prefix)
 end
 
 function WeakAuras.SetModel(frame, model_path, model_fileId, isUnit, isDisplayInfo)
-  if isDisplayInfo then
-    pcall(frame.SetDisplayInfo, frame, tonumber(model_fileId))
-  elseif isUnit then
-    pcall(frame.SetUnit, frame, model_fileId)
+  if WeakAuras.IsClassic() then
+    if isDisplayInfo then
+      pcall(frame.SetDisplayInfo, frame, tonumber(model_path))
+    elseif isUnit then
+      pcall(frame.SetUnit, frame, model_path)
+    else
+      pcall(frame.SetModel, frame, model_path)
+    end
   else
-    pcall(frame.SetModel, frame, tonumber(model_fileId))
+    if isDisplayInfo then
+      pcall(frame.SetDisplayInfo, frame, tonumber(model_fileId))
+    elseif isUnit then
+      pcall(frame.SetUnit, frame, model_fileId)
+    else
+      pcall(frame.SetModel, frame, tonumber(model_fileId))
+    end
   end
 end
 

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -1501,6 +1501,9 @@ function WeakAuras.CreatePvPTalentCache()
 end
 
 function WeakAuras.CountWagoUpdates()
+  if not (WeakAurasCompanion and WeakAurasCompanion.slugs) then
+    return 0
+  end
   local WeakAurasSaved = WeakAurasSaved
   local updatedSlugs, updatedSlugsCount = {}, 0
   for id, aura in pairs(WeakAurasSaved.displays) do

--- a/WeakAuras/WeakAuras.toc
+++ b/WeakAuras/WeakAuras.toc
@@ -52,15 +52,11 @@ RegionTypes\Icon.lua
 RegionTypes\Text.lua
 RegionTypes\Group.lua
 RegionTypes\DynamicGroup.lua
-#@retail@
 RegionTypes\Model.lua
-#@end-retail@
 
 # sub region support
 SubRegionTypes\SubText.lua
 SubRegionTypes\Border.lua
 SubRegionTypes\Glow.lua
 SubRegionTypes\Tick.lua
-#@retail@
 SubRegionTypes\BarModel.lua
-#@end-retail@

--- a/WeakAurasModelPaths/ModelPathsClassic.lua
+++ b/WeakAurasModelPaths/ModelPathsClassic.lua
@@ -1,0 +1,4123 @@
+WeakAuras.ModelPaths = {
+  {
+      ["value"] = "spells",
+      ["text"] = "spells",
+      ["children"] = {
+          {
+              ["value"] = "enchantments",
+              ["text"] = "enchantments",
+              ["children"] = {
+                  {
+                      ["value"] = "blackflame_low.m2",
+                      ["text"] = "blackflame_low.m2",
+                      ["fileId"] = "165991",
+                  },
+
+                  {
+                      ["value"] = "blackglow_high.m2",
+                      ["text"] = "blackglow_high.m2",
+                      ["fileId"] = "165992",
+                  },
+
+                  {
+                      ["value"] = "blackglow_low.m2",
+                      ["text"] = "blackglow_low.m2",
+                      ["fileId"] = "165993",
+                  },
+
+                  {
+                      ["value"] = "blueflame_high.m2",
+                      ["text"] = "blueflame_high.m2",
+                      ["fileId"] = "165994",
+                  },
+
+                  {
+                      ["value"] = "blueflame_low.m2",
+                      ["text"] = "blueflame_low.m2",
+                      ["fileId"] = "165995",
+                  },
+
+                  {
+                      ["value"] = "blueglow_high.m2",
+                      ["text"] = "blueglow_high.m2",
+                      ["fileId"] = "165996",
+                  },
+
+                  {
+                      ["value"] = "blueglow_low.m2",
+                      ["text"] = "blueglow_low.m2",
+                      ["fileId"] = "165997",
+                  },
+
+                  {
+                      ["value"] = "blueglow_med.m2",
+                      ["text"] = "blueglow_med.m2",
+                      ["fileId"] = "165998",
+                  },
+
+                  {
+                      ["value"] = "greenflame_low.m2",
+                      ["text"] = "greenflame_low.m2",
+                      ["fileId"] = "166003",
+                  },
+
+                  {
+                      ["value"] = "greenglow_high.m2",
+                      ["text"] = "greenglow_high.m2",
+                      ["fileId"] = "166004",
+                  },
+
+                  {
+                      ["value"] = "greenglow_low.m2",
+                      ["text"] = "greenglow_low.m2",
+                      ["fileId"] = "166005",
+                  },
+
+                  {
+                      ["value"] = "poisondrip.m2",
+                      ["text"] = "poisondrip.m2",
+                      ["fileId"] = "166007",
+                  },
+
+                  {
+                      ["value"] = "purpleflame_low.m2",
+                      ["text"] = "purpleflame_low.m2",
+                      ["fileId"] = "166008",
+                  },
+
+                  {
+                      ["value"] = "purpleglow_high.m2",
+                      ["text"] = "purpleglow_high.m2",
+                      ["fileId"] = "166009",
+                  },
+
+                  {
+                      ["value"] = "purpleglow_low.m2",
+                      ["text"] = "purpleglow_low.m2",
+                      ["fileId"] = "166010",
+                  },
+
+                  {
+                      ["value"] = "redflame_low.m2",
+                      ["text"] = "redflame_low.m2",
+                      ["fileId"] = "166011",
+                  },
+
+                  {
+                      ["value"] = "redglow_high.m2",
+                      ["text"] = "redglow_high.m2",
+                      ["fileId"] = "166012",
+                  },
+
+                  {
+                      ["value"] = "redglow_low.m2",
+                      ["text"] = "redglow_low.m2",
+                      ["fileId"] = "166013",
+                  },
+
+                  {
+                      ["value"] = "rune_intellect.m2",
+                      ["text"] = "rune_intellect.m2",
+                      ["fileId"] = "166014",
+                  },
+
+                  {
+                      ["value"] = "shaman_fire.m2",
+                      ["text"] = "shaman_fire.m2",
+                      ["fileId"] = "166016",
+                  },
+
+                  {
+                      ["value"] = "shaman_frost.m2",
+                      ["text"] = "shaman_frost.m2",
+                      ["fileId"] = "166017",
+                  },
+
+                  {
+                      ["value"] = "shaman_green.m2",
+                      ["text"] = "shaman_green.m2",
+                      ["fileId"] = "166018",
+                  },
+
+                  {
+                      ["value"] = "shaman_purple.m2",
+                      ["text"] = "shaman_purple.m2",
+                      ["fileId"] = "166019",
+                  },
+
+                  {
+                      ["value"] = "shaman_red.m2",
+                      ["text"] = "shaman_red.m2",
+                      ["fileId"] = "166020",
+                  },
+
+                  {
+                      ["value"] = "shaman_rock.m2",
+                      ["text"] = "shaman_rock.m2",
+                      ["fileId"] = "166021",
+                  },
+
+                  {
+                      ["value"] = "shaman_wind.m2",
+                      ["text"] = "shaman_wind.m2",
+                      ["fileId"] = "166022",
+                  },
+
+                  {
+                      ["value"] = "shaman_yellow.m2",
+                      ["text"] = "shaman_yellow.m2",
+                      ["fileId"] = "166023",
+                  },
+
+                  {
+                      ["value"] = "skullballs.m2",
+                      ["text"] = "skullballs.m2",
+                      ["fileId"] = "166024",
+                  },
+
+                  {
+                      ["value"] = "sparkle_a.m2",
+                      ["text"] = "sparkle_a.m2",
+                      ["fileId"] = "166027",
+                  },
+
+                  {
+                      ["value"] = "whiteflame_low.m2",
+                      ["text"] = "whiteflame_low.m2",
+                      ["fileId"] = "166030",
+                  },
+
+                  {
+                      ["value"] = "whiteglow_high.m2",
+                      ["text"] = "whiteglow_high.m2",
+                      ["fileId"] = "166031",
+                  },
+
+                  {
+                      ["value"] = "whiteglow_low.m2",
+                      ["text"] = "whiteglow_low.m2",
+                      ["fileId"] = "166032",
+                  },
+
+                  {
+                      ["value"] = "yellowflame_low.m2",
+                      ["text"] = "yellowflame_low.m2",
+                      ["fileId"] = "166033",
+                  },
+
+                  {
+                      ["value"] = "yellowglow_high.m2",
+                      ["text"] = "yellowglow_high.m2",
+                      ["fileId"] = "166034",
+                  },
+
+                  {
+                      ["value"] = "yellowglow_low.m2",
+                      ["text"] = "yellowglow_low.m2",
+                      ["fileId"] = "166035",
+                  },
+
+              },
+          },
+          {
+              ["value"] = "abolishmagic_base.m2",
+              ["text"] = "abolishmagic_base.m2",
+              ["fileId"] = "165529",
+          },
+
+          {
+              ["value"] = "acidbreath.m2",
+              ["text"] = "acidbreath.m2",
+              ["fileId"] = "165532",
+          },
+
+          {
+              ["value"] = "acidburn.m2",
+              ["text"] = "acidburn.m2",
+              ["fileId"] = "165533",
+          },
+
+          {
+              ["value"] = "acidcloudbreath.m2",
+              ["text"] = "acidcloudbreath.m2",
+              ["fileId"] = "165549",
+          },
+
+          {
+              ["value"] = "acidliquidbreath.m2",
+              ["text"] = "acidliquidbreath.m2",
+              ["fileId"] = "165552",
+          },
+
+          {
+              ["value"] = "adrenalinerush_cast_base.m2",
+              ["text"] = "adrenalinerush_cast_base.m2",
+              ["fileId"] = "165554",
+          },
+
+          {
+              ["value"] = "aegis.m2",
+              ["text"] = "aegis.m2",
+              ["fileId"] = "165556",
+          },
+
+          {
+              ["value"] = "alliancectfflag_spell.m2",
+              ["text"] = "alliancectfflag_spell.m2",
+              ["fileId"] = "165560",
+          },
+
+          {
+              ["value"] = "amplifymagic_impact_base.m2",
+              ["text"] = "amplifymagic_impact_base.m2",
+              ["fileId"] = "165562",
+          },
+
+          {
+              ["value"] = "antimagic_precast_hand.m2",
+              ["text"] = "antimagic_precast_hand.m2",
+              ["fileId"] = "165563",
+          },
+
+          {
+              ["value"] = "antimagic_state_base.m2",
+              ["text"] = "antimagic_state_base.m2",
+              ["fileId"] = "165564",
+          },
+
+          {
+              ["value"] = "arcaneexplosion_base.m2",
+              ["text"] = "arcaneexplosion_base.m2",
+              ["fileId"] = "165576",
+          },
+
+          {
+              ["value"] = "arcaneexplosion_impact_chest.m2",
+              ["text"] = "arcaneexplosion_impact_chest.m2",
+              ["fileId"] = "165578",
+          },
+
+          {
+              ["value"] = "arcaneintellect_impact_base.m2",
+              ["text"] = "arcaneintellect_impact_base.m2",
+              ["fileId"] = "165585",
+          },
+
+          {
+              ["value"] = "arcanepower_state_chest.m2",
+              ["text"] = "arcanepower_state_chest.m2",
+              ["fileId"] = "165589",
+          },
+
+          {
+              ["value"] = "arcaneshot_area.m2",
+              ["text"] = "arcaneshot_area.m2",
+              ["fileId"] = "165591",
+          },
+
+          {
+              ["value"] = "arcaneshot_missile.m2",
+              ["text"] = "arcaneshot_missile.m2",
+              ["fileId"] = "165592",
+          },
+
+          {
+              ["value"] = "arcanespirit_impact_base.m2",
+              ["text"] = "arcanespirit_impact_base.m2",
+              ["fileId"] = "165594",
+          },
+
+          {
+              ["value"] = "arcanevolley_missile.m2",
+              ["text"] = "arcanevolley_missile.m2",
+              ["fileId"] = "165596",
+          },
+
+          {
+              ["value"] = "arcane_missile.m2",
+              ["text"] = "arcane_missile.m2",
+              ["fileId"] = "165569",
+          },
+
+          {
+              ["value"] = "arcane_missile_lvl1.m2",
+              ["text"] = "arcane_missile_lvl1.m2",
+              ["fileId"] = "165570",
+          },
+
+          {
+              ["value"] = "arcane_missile_lvl2.m2",
+              ["text"] = "arcane_missile_lvl2.m2",
+              ["fileId"] = "165571",
+          },
+
+          {
+              ["value"] = "arcane_missile_lvl3.m2",
+              ["text"] = "arcane_missile_lvl3.m2",
+              ["fileId"] = "165572",
+          },
+
+          {
+              ["value"] = "arcane_missile_lvl4.m2",
+              ["text"] = "arcane_missile_lvl4.m2",
+              ["fileId"] = "165573",
+          },
+
+          {
+              ["value"] = "aspectbeast_impact_head.m2",
+              ["text"] = "aspectbeast_impact_head.m2",
+              ["fileId"] = "165613",
+          },
+
+          {
+              ["value"] = "aspectcheetah_impact_head.m2",
+              ["text"] = "aspectcheetah_impact_head.m2",
+              ["fileId"] = "165614",
+          },
+
+          {
+              ["value"] = "aspecthawk_impact_head.m2",
+              ["text"] = "aspecthawk_impact_head.m2",
+              ["fileId"] = "165615",
+          },
+
+          {
+              ["value"] = "aspectmonkey_impact_head.m2",
+              ["text"] = "aspectmonkey_impact_head.m2",
+              ["fileId"] = "165616",
+          },
+
+          {
+              ["value"] = "aspectsnake_impact_head.m2",
+              ["text"] = "aspectsnake_impact_head.m2",
+              ["fileId"] = "165617",
+          },
+
+          {
+              ["value"] = "aspectwolf_impact_head.m2",
+              ["text"] = "aspectwolf_impact_head.m2",
+              ["fileId"] = "165619",
+          },
+
+          {
+              ["value"] = "astral_recall_impact_base.m2",
+              ["text"] = "astral_recall_impact_base.m2",
+              ["fileId"] = "165622",
+          },
+
+          {
+              ["value"] = "backstab_cast_base.m2",
+              ["text"] = "backstab_cast_base.m2",
+              ["fileId"] = "165645",
+          },
+
+          {
+              ["value"] = "backstab_impact_chest.m2",
+              ["text"] = "backstab_impact_chest.m2",
+              ["fileId"] = "165646",
+          },
+
+          {
+              ["value"] = "balanceofnature_impact_base.m2",
+              ["text"] = "balanceofnature_impact_base.m2",
+              ["fileId"] = "165647",
+          },
+
+          {
+              ["value"] = "banish_chest.m2",
+              ["text"] = "banish_chest.m2",
+              ["fileId"] = "165648",
+          },
+
+          {
+              ["value"] = "banish_chest_purple.m2",
+              ["text"] = "banish_chest_purple.m2",
+              ["fileId"] = "165651",
+          },
+
+          {
+              ["value"] = "barkshield_state_base.m2",
+              ["text"] = "barkshield_state_base.m2",
+              ["fileId"] = "165654",
+          },
+
+          {
+              ["value"] = "barkskin_state_base.m2",
+              ["text"] = "barkskin_state_base.m2",
+              ["fileId"] = "165655",
+          },
+
+          {
+              ["value"] = "baseflagcapred_impact_base.m2",
+              ["text"] = "baseflagcapred_impact_base.m2",
+              ["fileId"] = "165656",
+          },
+
+          {
+              ["value"] = "basicstrike.m2",
+              ["text"] = "basicstrike.m2",
+              ["fileId"] = "165657",
+          },
+
+          {
+              ["value"] = "battleshout_cast_base.m2",
+              ["text"] = "battleshout_cast_base.m2",
+              ["fileId"] = "165658",
+          },
+
+          {
+              ["value"] = "battlestance_impact_head.m2",
+              ["text"] = "battlestance_impact_head.m2",
+              ["fileId"] = "165659",
+          },
+
+          {
+              ["value"] = "bearfrenzy.m2",
+              ["text"] = "bearfrenzy.m2",
+              ["fileId"] = "165664",
+          },
+
+          {
+              ["value"] = "bearfrenzyimpact.m2",
+              ["text"] = "bearfrenzyimpact.m2",
+              ["fileId"] = "165665",
+          },
+
+          {
+              ["value"] = "beastcall_impact_head.m2",
+              ["text"] = "beastcall_impact_head.m2",
+              ["fileId"] = "165668",
+          },
+
+          {
+              ["value"] = "beastlore_impact_base.m2",
+              ["text"] = "beastlore_impact_base.m2",
+              ["fileId"] = "165669",
+          },
+
+          {
+              ["value"] = "beastlore_impact_head.m2",
+              ["text"] = "beastlore_impact_head.m2",
+              ["fileId"] = "165670",
+          },
+
+          {
+              ["value"] = "beastragecaster.m2",
+              ["text"] = "beastragecaster.m2",
+              ["fileId"] = "165672",
+          },
+
+          {
+              ["value"] = "beastragestate.m2",
+              ["text"] = "beastragestate.m2",
+              ["fileId"] = "165673",
+          },
+
+          {
+              ["value"] = "beastsoothe_impact_head.m2",
+              ["text"] = "beastsoothe_impact_head.m2",
+              ["fileId"] = "165674",
+          },
+
+          {
+              ["value"] = "beastsoothe_state_head.m2",
+              ["text"] = "beastsoothe_state_head.m2",
+              ["fileId"] = "165675",
+          },
+
+          {
+              ["value"] = "berzerkerstance_impact_head.m2",
+              ["text"] = "berzerkerstance_impact_head.m2",
+              ["fileId"] = "165678",
+          },
+
+          {
+              ["value"] = "bestowdisease_impact_chest.m2",
+              ["text"] = "bestowdisease_impact_chest.m2",
+              ["fileId"] = "165679",
+          },
+
+          {
+              ["value"] = "bind2_impact_base.m2",
+              ["text"] = "bind2_impact_base.m2",
+              ["fileId"] = "165680",
+          },
+
+          {
+              ["value"] = "bind_impact_base.m2",
+              ["text"] = "bind_impact_base.m2",
+              ["fileId"] = "165681",
+          },
+
+          {
+              ["value"] = "blackshot_missile.m2",
+              ["text"] = "blackshot_missile.m2",
+              ["fileId"] = "165687",
+          },
+
+          {
+              ["value"] = "blessingofagility_base.m2",
+              ["text"] = "blessingofagility_base.m2",
+              ["fileId"] = "165690",
+          },
+
+          {
+              ["value"] = "blessingofprotection_base.m2",
+              ["text"] = "blessingofprotection_base.m2",
+              ["fileId"] = "165700",
+          },
+
+          {
+              ["value"] = "blessingofstamina_base.m2",
+              ["text"] = "blessingofstamina_base.m2",
+              ["fileId"] = "165710",
+          },
+
+          {
+              ["value"] = "blessingofstrength_base.m2",
+              ["text"] = "blessingofstrength_base.m2",
+              ["fileId"] = "165711",
+          },
+
+          {
+              ["value"] = "blindingshot_impact.m2",
+              ["text"] = "blindingshot_impact.m2",
+              ["fileId"] = "165713",
+          },
+
+          {
+              ["value"] = "blindingshot_missile.m2",
+              ["text"] = "blindingshot_missile.m2",
+              ["fileId"] = "165714",
+          },
+
+          {
+              ["value"] = "blink_impact_chest.m2",
+              ["text"] = "blink_impact_chest.m2",
+              ["fileId"] = "165715",
+          },
+
+          {
+              ["value"] = "blizzard_impact_base.m2",
+              ["text"] = "blizzard_impact_base.m2",
+              ["fileId"] = "165716",
+          },
+
+          {
+              ["value"] = "bloodboil_impact_chest.m2",
+              ["text"] = "bloodboil_impact_chest.m2",
+              ["fileId"] = "165722",
+          },
+
+          {
+              ["value"] = "bloodbolt_chest.m2",
+              ["text"] = "bloodbolt_chest.m2",
+              ["fileId"] = "165723",
+          },
+
+          {
+              ["value"] = "bloodbolt_missile_low.m2",
+              ["text"] = "bloodbolt_missile_low.m2",
+              ["fileId"] = "165724",
+          },
+
+          {
+              ["value"] = "bloodlust_cast_hand.m2",
+              ["text"] = "bloodlust_cast_hand.m2",
+              ["fileId"] = "165725",
+          },
+
+          {
+              ["value"] = "bloodlust_state_hand.m2",
+              ["text"] = "bloodlust_state_hand.m2",
+              ["fileId"] = "165728",
+          },
+
+          {
+              ["value"] = "bloodyexplosion.m2",
+              ["text"] = "bloodyexplosion.m2",
+              ["fileId"] = "165737",
+          },
+
+          {
+              ["value"] = "bloodyexplosiongreen.m2",
+              ["text"] = "bloodyexplosiongreen.m2",
+              ["fileId"] = "165738",
+          },
+
+          {
+              ["value"] = "bomb_explosiona.m2",
+              ["text"] = "bomb_explosiona.m2",
+              ["fileId"] = "165744",
+          },
+
+          {
+              ["value"] = "bonearmor_head.m2",
+              ["text"] = "bonearmor_head.m2",
+              ["fileId"] = "165749",
+          },
+
+          {
+              ["value"] = "bonearmor_recursive.m2",
+              ["text"] = "bonearmor_recursive.m2",
+              ["fileId"] = "165750",
+          },
+
+          {
+              ["value"] = "bonearmor_state_chest.m2",
+              ["text"] = "bonearmor_state_chest.m2",
+              ["fileId"] = "165751",
+          },
+
+          {
+              ["value"] = "bouldergiant_missile.m2",
+              ["text"] = "bouldergiant_missile.m2",
+              ["fileId"] = "165757",
+          },
+
+          {
+              ["value"] = "boulder_missile.m2",
+              ["text"] = "boulder_missile.m2",
+              ["fileId"] = "165756",
+          },
+
+          {
+              ["value"] = "brillianceaura.m2",
+              ["text"] = "brillianceaura.m2",
+              ["fileId"] = "165759",
+          },
+
+          {
+              ["value"] = "bubble_drunk.m2",
+              ["text"] = "bubble_drunk.m2",
+              ["fileId"] = "165760",
+          },
+
+          {
+              ["value"] = "burningintellect_impact_base.m2",
+              ["text"] = "burningintellect_impact_base.m2",
+              ["fileId"] = "165761",
+          },
+
+          {
+              ["value"] = "burningspirit_impact_base.m2",
+              ["text"] = "burningspirit_impact_base.m2",
+              ["fileId"] = "165762",
+          },
+
+          {
+              ["value"] = "burningspirit_impact_head.m2",
+              ["text"] = "burningspirit_impact_head.m2",
+              ["fileId"] = "165763",
+          },
+
+          {
+              ["value"] = "burrowearth_brown_missile.m2",
+              ["text"] = "burrowearth_brown_missile.m2",
+              ["fileId"] = "165765",
+          },
+
+          {
+              ["value"] = "calllightning_impact.m2",
+              ["text"] = "calllightning_impact.m2",
+              ["fileId"] = "165768",
+          },
+
+          {
+              ["value"] = "catmark.m2",
+              ["text"] = "catmark.m2",
+              ["fileId"] = "165778",
+          },
+
+          {
+              ["value"] = "chainlightning_impact_chest.m2",
+              ["text"] = "chainlightning_impact_chest.m2",
+              ["fileId"] = "165780",
+          },
+
+          {
+              ["value"] = "chainsofice_low_base.m2",
+              ["text"] = "chainsofice_low_base.m2",
+              ["fileId"] = "165782",
+          },
+
+          {
+              ["value"] = "challengingshout_cast_base.m2",
+              ["text"] = "challengingshout_cast_base.m2",
+              ["fileId"] = "165783",
+          },
+
+          {
+              ["value"] = "chargetrail.m2",
+              ["text"] = "chargetrail.m2",
+              ["fileId"] = "165784",
+          },
+
+          {
+              ["value"] = "cheapshot_cast_base.m2",
+              ["text"] = "cheapshot_cast_base.m2",
+              ["fileId"] = "165785",
+          },
+
+          {
+              ["value"] = "cheapshot_impact_chest.m2",
+              ["text"] = "cheapshot_impact_chest.m2",
+              ["fileId"] = "165786",
+          },
+
+          {
+              ["value"] = "cheapshot_state_head.m2",
+              ["text"] = "cheapshot_state_head.m2",
+              ["fileId"] = "165787",
+          },
+
+          {
+              ["value"] = "cinematic_omni_light.m2",
+              ["text"] = "cinematic_omni_light.m2",
+              ["fileId"] = "1083712",
+          },
+
+          {
+              ["value"] = "clearcasting_impact_chest.m2",
+              ["text"] = "clearcasting_impact_chest.m2",
+              ["fileId"] = "165795",
+          },
+
+          {
+              ["value"] = "cleave_cast_base.m2",
+              ["text"] = "cleave_cast_base.m2",
+              ["fileId"] = "165796",
+          },
+
+          {
+              ["value"] = "cleave_impact_chest.m2",
+              ["text"] = "cleave_impact_chest.m2",
+              ["fileId"] = "165798",
+          },
+
+          {
+              ["value"] = "clense_base.m2",
+              ["text"] = "clense_base.m2",
+              ["fileId"] = "165799",
+          },
+
+          {
+              ["value"] = "coneofcold_geo.m2",
+              ["text"] = "coneofcold_geo.m2",
+              ["fileId"] = "165810",
+          },
+
+          {
+              ["value"] = "coneofcold_hand.m2",
+              ["text"] = "coneofcold_hand.m2",
+              ["fileId"] = "165811",
+          },
+
+          {
+              ["value"] = "coneoffire_hand.m2",
+              ["text"] = "coneoffire_hand.m2",
+              ["fileId"] = "165812",
+          },
+
+          {
+              ["value"] = "conflagrate_impact_chest.m2",
+              ["text"] = "conflagrate_impact_chest.m2",
+              ["fileId"] = "165813",
+          },
+
+          {
+              ["value"] = "confused_state_head.m2",
+              ["text"] = "confused_state_head.m2",
+              ["fileId"] = "165815",
+          },
+
+          {
+              ["value"] = "conjureitem.m2",
+              ["text"] = "conjureitem.m2",
+              ["fileId"] = "165816",
+          },
+
+          {
+              ["value"] = "conjureitemcast.m2",
+              ["text"] = "conjureitemcast.m2",
+              ["fileId"] = "165817",
+          },
+
+          {
+              ["value"] = "consecration_impact_base.m2",
+              ["text"] = "consecration_impact_base.m2",
+              ["fileId"] = "165818",
+          },
+
+          {
+              ["value"] = "corrosivesandbreath.m2",
+              ["text"] = "corrosivesandbreath.m2",
+              ["fileId"] = "165820",
+          },
+
+          {
+              ["value"] = "corruption_impactdot_med_base.m2",
+              ["text"] = "corruption_impactdot_med_base.m2",
+              ["fileId"] = "165821",
+          },
+
+          {
+              ["value"] = "counterspell_impact_chest.m2",
+              ["text"] = "counterspell_impact_chest.m2",
+              ["fileId"] = "165822",
+          },
+
+          {
+              ["value"] = "createsoulstone_cast.m2",
+              ["text"] = "createsoulstone_cast.m2",
+              ["fileId"] = "165824",
+          },
+
+          {
+              ["value"] = "creature_spellportal_blue.m2",
+              ["text"] = "creature_spellportal_blue.m2",
+              ["fileId"] = "165826",
+          },
+
+          {
+              ["value"] = "creature_spellportal_purple.m2",
+              ["text"] = "creature_spellportal_purple.m2",
+              ["fileId"] = "165829",
+          },
+
+          {
+              ["value"] = "cripple_impact_base.m2",
+              ["text"] = "cripple_impact_base.m2",
+              ["fileId"] = "165837",
+          },
+
+          {
+              ["value"] = "cripple_state_base.m2",
+              ["text"] = "cripple_state_base.m2",
+              ["fileId"] = "165838",
+          },
+
+          {
+              ["value"] = "cripple_state_chest.m2",
+              ["text"] = "cripple_state_chest.m2",
+              ["fileId"] = "165839",
+          },
+
+          {
+              ["value"] = "crow_baked.m2",
+              ["text"] = "crow_baked.m2",
+              ["fileId"] = "165840",
+          },
+
+          {
+              ["value"] = "cthuneeyeattack.m2",
+              ["text"] = "cthuneeyeattack.m2",
+              ["fileId"] = "165850",
+          },
+
+          {
+              ["value"] = "curseelements_impact_head.m2",
+              ["text"] = "curseelements_impact_head.m2",
+              ["fileId"] = "165851",
+          },
+
+          {
+              ["value"] = "curseofagony_head.m2",
+              ["text"] = "curseofagony_head.m2",
+              ["fileId"] = "165852",
+          },
+
+          {
+              ["value"] = "curseoffrailty_head.m2",
+              ["text"] = "curseoffrailty_head.m2",
+              ["fileId"] = "165853",
+          },
+
+          {
+              ["value"] = "curseofmannoroth_head.m2",
+              ["text"] = "curseofmannoroth_head.m2",
+              ["fileId"] = "165854",
+          },
+
+          {
+              ["value"] = "curseofrecklessness_impact_chest.m2",
+              ["text"] = "curseofrecklessness_impact_chest.m2",
+              ["fileId"] = "165855",
+          },
+
+          {
+              ["value"] = "curseoftongues_impact.m2",
+              ["text"] = "curseoftongues_impact.m2",
+              ["fileId"] = "165856",
+          },
+
+          {
+              ["value"] = "curseoftongues_state_chest.m2",
+              ["text"] = "curseoftongues_state_chest.m2",
+              ["fileId"] = "165857",
+          },
+
+          {
+              ["value"] = "curseofweakness_head.m2",
+              ["text"] = "curseofweakness_head.m2",
+              ["fileId"] = "165858",
+          },
+
+          {
+              ["value"] = "cycloneearth_state.m2",
+              ["text"] = "cycloneearth_state.m2",
+              ["fileId"] = "165863",
+          },
+
+          {
+              ["value"] = "cyclonefire_state.m2",
+              ["text"] = "cyclonefire_state.m2",
+              ["fileId"] = "165864",
+          },
+
+          {
+              ["value"] = "cyclonegeo.m2",
+              ["text"] = "cyclonegeo.m2",
+              ["fileId"] = "165865",
+          },
+
+          {
+              ["value"] = "cyclonegeo2.m2",
+              ["text"] = "cyclonegeo2.m2",
+              ["fileId"] = "165866",
+          },
+
+          {
+              ["value"] = "cyclonegeo2_additive.m2",
+              ["text"] = "cyclonegeo2_additive.m2",
+              ["fileId"] = "165867",
+          },
+
+          {
+              ["value"] = "cyclonegeo3.m2",
+              ["text"] = "cyclonegeo3.m2",
+              ["fileId"] = "165868",
+          },
+
+          {
+              ["value"] = "cyclonegeo3_additive.m2",
+              ["text"] = "cyclonegeo3_additive.m2",
+              ["fileId"] = "165869",
+          },
+
+          {
+              ["value"] = "cyclonegeo_additive.m2",
+              ["text"] = "cyclonegeo_additive.m2",
+              ["fileId"] = "165870",
+          },
+
+          {
+              ["value"] = "cyclonerock1.m2",
+              ["text"] = "cyclonerock1.m2",
+              ["fileId"] = "165871",
+          },
+
+          {
+              ["value"] = "cyclonerock2.m2",
+              ["text"] = "cyclonerock2.m2",
+              ["fileId"] = "165872",
+          },
+
+          {
+              ["value"] = "cyclonewater_state.m2",
+              ["text"] = "cyclonewater_state.m2",
+              ["fileId"] = "165873",
+          },
+
+          {
+              ["value"] = "cyclone_state.m2",
+              ["text"] = "cyclone_state.m2",
+              ["fileId"] = "165862",
+          },
+
+          {
+              ["value"] = "dampenmagic_impact_base.m2",
+              ["text"] = "dampenmagic_impact_base.m2",
+              ["fileId"] = "165874",
+          },
+
+          {
+              ["value"] = "darkritual_precast_base.m2",
+              ["text"] = "darkritual_precast_base.m2",
+              ["fileId"] = "165879",
+          },
+
+          {
+              ["value"] = "deathanddecay_area_base.m2",
+              ["text"] = "deathanddecay_area_base.m2",
+              ["fileId"] = "165887",
+          },
+
+          {
+              ["value"] = "deathbolt_missile_low.m2",
+              ["text"] = "deathbolt_missile_low.m2",
+              ["fileId"] = "165889",
+          },
+
+          {
+              ["value"] = "deathcoil_impact_chest.m2",
+              ["text"] = "deathcoil_impact_chest.m2",
+              ["fileId"] = "165890",
+          },
+
+          {
+              ["value"] = "deathcoil_missile.m2",
+              ["text"] = "deathcoil_missile.m2",
+              ["fileId"] = "165891",
+          },
+
+          {
+              ["value"] = "deathwish_state_hand.m2",
+              ["text"] = "deathwish_state_hand.m2",
+              ["fileId"] = "165908",
+          },
+
+          {
+              ["value"] = "decisivestrike_impact_chest.m2",
+              ["text"] = "decisivestrike_impact_chest.m2",
+              ["fileId"] = "165913",
+          },
+
+          {
+              ["value"] = "defensivestance_impact_chest.m2",
+              ["text"] = "defensivestance_impact_chest.m2",
+              ["fileId"] = "165914",
+          },
+
+          {
+              ["value"] = "defensivestance_impact_head.m2",
+              ["text"] = "defensivestance_impact_head.m2",
+              ["fileId"] = "165915",
+          },
+
+          {
+              ["value"] = "demonarmor_impact_head.m2",
+              ["text"] = "demonarmor_impact_head.m2",
+              ["fileId"] = "165918",
+          },
+
+          {
+              ["value"] = "demonbreath_impact_head.m2",
+              ["text"] = "demonbreath_impact_head.m2",
+              ["fileId"] = "165919",
+          },
+
+          {
+              ["value"] = "demonicsacrifice_felhunter_chest.m2",
+              ["text"] = "demonicsacrifice_felhunter_chest.m2",
+              ["fileId"] = "165923",
+          },
+
+          {
+              ["value"] = "demonicsacrifice_imp_chest.m2",
+              ["text"] = "demonicsacrifice_imp_chest.m2",
+              ["fileId"] = "165924",
+          },
+
+          {
+              ["value"] = "demonicsacrifice_succubus_chest.m2",
+              ["text"] = "demonicsacrifice_succubus_chest.m2",
+              ["fileId"] = "165925",
+          },
+
+          {
+              ["value"] = "demonicsacrifice_voidwalker_chest.m2",
+              ["text"] = "demonicsacrifice_voidwalker_chest.m2",
+              ["fileId"] = "165926",
+          },
+
+          {
+              ["value"] = "demoralizingshout_cast_base.m2",
+              ["text"] = "demoralizingshout_cast_base.m2",
+              ["fileId"] = "165930",
+          },
+
+          {
+              ["value"] = "demoralizingshout_impact_head.m2",
+              ["text"] = "demoralizingshout_impact_head.m2",
+              ["fileId"] = "165931",
+          },
+
+          {
+              ["value"] = "detectinvis_impact_base.m2",
+              ["text"] = "detectinvis_impact_base.m2",
+              ["fileId"] = "165940",
+          },
+
+          {
+              ["value"] = "detectinvis_impact_head.m2",
+              ["text"] = "detectinvis_impact_head.m2",
+              ["fileId"] = "165941",
+          },
+
+          {
+              ["value"] = "detectmagic_base.m2",
+              ["text"] = "detectmagic_base.m2",
+              ["fileId"] = "165942",
+          },
+
+          {
+              ["value"] = "detectmagic_recursive.m2",
+              ["text"] = "detectmagic_recursive.m2",
+              ["fileId"] = "165943",
+          },
+
+          {
+              ["value"] = "deterrence_state_base.m2",
+              ["text"] = "deterrence_state_base.m2",
+              ["fileId"] = "165947",
+          },
+
+          {
+              ["value"] = "devotionaura_base.m2",
+              ["text"] = "devotionaura_base.m2",
+              ["fileId"] = "165948",
+          },
+
+          {
+              ["value"] = "disarm_impact_chest.m2",
+              ["text"] = "disarm_impact_chest.m2",
+              ["fileId"] = "165949",
+          },
+
+          {
+              ["value"] = "disenchant_cast_hand.m2",
+              ["text"] = "disenchant_cast_hand.m2",
+              ["fileId"] = "165953",
+          },
+
+          {
+              ["value"] = "disenchant_precast_hand.m2",
+              ["text"] = "disenchant_precast_hand.m2",
+              ["fileId"] = "165954",
+          },
+
+          {
+              ["value"] = "dispel_low_base.m2",
+              ["text"] = "dispel_low_base.m2",
+              ["fileId"] = "165955",
+          },
+
+          {
+              ["value"] = "dispel_low_recursive.m2",
+              ["text"] = "dispel_low_recursive.m2",
+              ["fileId"] = "165956",
+          },
+
+          {
+              ["value"] = "distract_impact_base.m2",
+              ["text"] = "distract_impact_base.m2",
+              ["fileId"] = "165957",
+          },
+
+          {
+              ["value"] = "distract_impact_chest.m2",
+              ["text"] = "distract_impact_chest.m2",
+              ["fileId"] = "165958",
+          },
+
+          {
+              ["value"] = "divinebubble_low_base.m2",
+              ["text"] = "divinebubble_low_base.m2",
+              ["fileId"] = "165959",
+          },
+
+          {
+              ["value"] = "divineshield_low_base.m2",
+              ["text"] = "divineshield_low_base.m2",
+              ["fileId"] = "165961",
+          },
+
+          {
+              ["value"] = "divineshield_low_chest.m2",
+              ["text"] = "divineshield_low_chest.m2",
+              ["fileId"] = "165962",
+          },
+
+          {
+              ["value"] = "dragonflamebreath.m2",
+              ["text"] = "dragonflamebreath.m2",
+              ["fileId"] = "165964",
+          },
+
+          {
+              ["value"] = "dragonflamebreath180.m2",
+              ["text"] = "dragonflamebreath180.m2",
+              ["fileId"] = "165965",
+          },
+
+          {
+              ["value"] = "druidmorph_aqua_impact_base.m2",
+              ["text"] = "druidmorph_aqua_impact_base.m2",
+              ["fileId"] = "165969",
+          },
+
+          {
+              ["value"] = "druidmorph_impact_base.m2",
+              ["text"] = "druidmorph_impact_base.m2",
+              ["fileId"] = "165970",
+          },
+
+          {
+              ["value"] = "dustcloud_land.m2",
+              ["text"] = "dustcloud_land.m2",
+              ["fileId"] = "165976",
+          },
+
+          {
+              ["value"] = "dustnova_cast_base.m2",
+              ["text"] = "dustnova_cast_base.m2",
+              ["fileId"] = "165977",
+          },
+
+          {
+              ["value"] = "dynamitea_missile.m2",
+              ["text"] = "dynamitea_missile.m2",
+              ["fileId"] = "165980",
+          },
+
+          {
+              ["value"] = "dynamitea_spellobject.m2",
+              ["text"] = "dynamitea_spellobject.m2",
+              ["fileId"] = "165981",
+          },
+
+          {
+              ["value"] = "eagleeye_impact_head.m2",
+              ["text"] = "eagleeye_impact_head.m2",
+              ["fileId"] = "165983",
+          },
+
+          {
+              ["value"] = "earthshock_impact_chest.m2",
+              ["text"] = "earthshock_impact_chest.m2",
+              ["fileId"] = "165987",
+          },
+
+          {
+              ["value"] = "enchant_cast_hand.m2",
+              ["text"] = "enchant_cast_hand.m2",
+              ["fileId"] = "165988",
+          },
+
+          {
+              ["value"] = "enchant_precast_hand.m2",
+              ["text"] = "enchant_precast_hand.m2",
+              ["fileId"] = "165989",
+          },
+
+          {
+              ["value"] = "enslavedemon_impact_base.m2",
+              ["text"] = "enslavedemon_impact_base.m2",
+              ["fileId"] = "166039",
+          },
+
+          {
+              ["value"] = "enslavedemon_impact_chest.m2",
+              ["text"] = "enslavedemon_impact_chest.m2",
+              ["fileId"] = "166040",
+          },
+
+          {
+              ["value"] = "enslavedemon_impact_head.m2",
+              ["text"] = "enslavedemon_impact_head.m2",
+              ["fileId"] = "166041",
+          },
+
+          {
+              ["value"] = "entanglingroots_state.m2",
+              ["text"] = "entanglingroots_state.m2",
+              ["fileId"] = "166042",
+          },
+
+          {
+              ["value"] = "errorcube.m2",
+              ["text"] = "errorcube.m2",
+              ["fileId"] = "166046",
+          },
+
+          {
+              ["value"] = "eviscerate_cast_hands.m2",
+              ["text"] = "eviscerate_cast_hands.m2",
+              ["fileId"] = "166047",
+          },
+
+          {
+              ["value"] = "eviscerate_impact_chest.m2",
+              ["text"] = "eviscerate_impact_chest.m2",
+              ["fileId"] = "166048",
+          },
+
+          {
+              ["value"] = "exorcism_impact_chest.m2",
+              ["text"] = "exorcism_impact_chest.m2",
+              ["fileId"] = "166049",
+          },
+
+          {
+              ["value"] = "explodertrail.m2",
+              ["text"] = "explodertrail.m2",
+              ["fileId"] = "166051",
+          },
+
+          {
+              ["value"] = "explosivetrap_recursive.m2",
+              ["text"] = "explosivetrap_recursive.m2",
+              ["fileId"] = "166054",
+          },
+
+          {
+              ["value"] = "exposearmor_head.m2",
+              ["text"] = "exposearmor_head.m2",
+              ["fileId"] = "166055",
+          },
+
+          {
+              ["value"] = "eyesofbeast_impact_head.m2",
+              ["text"] = "eyesofbeast_impact_head.m2",
+              ["fileId"] = "166059",
+          },
+
+          {
+              ["value"] = "faeriefire.m2",
+              ["text"] = "faeriefire.m2",
+              ["fileId"] = "166060",
+          },
+
+          {
+              ["value"] = "faeriefire_impact.m2",
+              ["text"] = "faeriefire_impact.m2",
+              ["fileId"] = "166061",
+          },
+
+          {
+              ["value"] = "farsight_impact_base.m2",
+              ["text"] = "farsight_impact_base.m2",
+              ["fileId"] = "166064",
+          },
+
+          {
+              ["value"] = "fear_impact_chest.m2",
+              ["text"] = "fear_impact_chest.m2",
+              ["fileId"] = "166065",
+          },
+
+          {
+              ["value"] = "fear_state_base.m2",
+              ["text"] = "fear_state_base.m2",
+              ["fileId"] = "166066",
+          },
+
+          {
+              ["value"] = "fear_state_head.m2",
+              ["text"] = "fear_state_head.m2",
+              ["fileId"] = "166067",
+          },
+
+          {
+              ["value"] = "feint_impact_chest.m2",
+              ["text"] = "feint_impact_chest.m2",
+              ["fileId"] = "166068",
+          },
+
+          {
+              ["value"] = "fireball_missile_high.m2",
+              ["text"] = "fireball_missile_high.m2",
+              ["fileId"] = "166128",
+          },
+
+          {
+              ["value"] = "fireball_missile_low.m2",
+              ["text"] = "fireball_missile_low.m2",
+              ["fileId"] = "166129",
+          },
+
+          {
+              ["value"] = "fireblast_impact_chest.m2",
+              ["text"] = "fireblast_impact_chest.m2",
+              ["fileId"] = "166131",
+          },
+
+          {
+              ["value"] = "firebolt_impactdd_med_chest.m2",
+              ["text"] = "firebolt_impactdd_med_chest.m2",
+              ["fileId"] = "166134",
+          },
+
+          {
+              ["value"] = "firebolt_missile_low.m2",
+              ["text"] = "firebolt_missile_low.m2",
+              ["fileId"] = "166135",
+          },
+
+          {
+              ["value"] = "firecrackers_thrown.m2",
+              ["text"] = "firecrackers_thrown.m2",
+              ["fileId"] = "166137",
+          },
+
+          {
+              ["value"] = "firenova_area.m2",
+              ["text"] = "firenova_area.m2",
+              ["fileId"] = "166144",
+          },
+
+          {
+              ["value"] = "firenova_state.m2",
+              ["text"] = "firenova_state.m2",
+              ["fileId"] = "166147",
+          },
+
+          {
+              ["value"] = "firereflect_state_chest.m2",
+              ["text"] = "firereflect_state_chest.m2",
+              ["fileId"] = "166149",
+          },
+
+          {
+              ["value"] = "fireresistance_impact_base.m2",
+              ["text"] = "fireresistance_impact_base.m2",
+              ["fileId"] = "166150",
+          },
+
+          {
+              ["value"] = "fireshieldfinal_impact_head.m2",
+              ["text"] = "fireshieldfinal_impact_head.m2",
+              ["fileId"] = "166157",
+          },
+
+          {
+              ["value"] = "fireshield_impact_head.m2",
+              ["text"] = "fireshield_impact_head.m2",
+              ["fileId"] = "166156",
+          },
+
+          {
+              ["value"] = "fireshot_missile.m2",
+              ["text"] = "fireshot_missile.m2",
+              ["fileId"] = "166158",
+          },
+
+          {
+              ["value"] = "firestrike_missile_low.m2",
+              ["text"] = "firestrike_missile_low.m2",
+              ["fileId"] = "166159",
+          },
+
+          {
+              ["value"] = "fireward_impact_chest.m2",
+              ["text"] = "fireward_impact_chest.m2",
+              ["fileId"] = "166162",
+          },
+
+          {
+              ["value"] = "fireworks_blue_01.m2",
+              ["text"] = "fireworks_blue_01.m2",
+              ["fileId"] = "166165",
+          },
+
+          {
+              ["value"] = "fireworks_green_01.m2",
+              ["text"] = "fireworks_green_01.m2",
+              ["fileId"] = "166166",
+          },
+
+          {
+              ["value"] = "fireworks_redstreaks_01.m2",
+              ["text"] = "fireworks_redstreaks_01.m2",
+              ["fileId"] = "166168",
+          },
+
+          {
+              ["value"] = "fireworks_red_01.m2",
+              ["text"] = "fireworks_red_01.m2",
+              ["fileId"] = "166167",
+          },
+
+          {
+              ["value"] = "fireworks_rwb_01.m2",
+              ["text"] = "fireworks_rwb_01.m2",
+              ["fileId"] = "166169",
+          },
+
+          {
+              ["value"] = "fireworks_yellowrose.m2",
+              ["text"] = "fireworks_yellowrose.m2",
+              ["fileId"] = "166170",
+          },
+
+          {
+              ["value"] = "firework_romancandle_impact_chest_01.m2",
+              ["text"] = "firework_romancandle_impact_chest_01.m2",
+              ["fileId"] = "166163",
+          },
+
+          {
+              ["value"] = "firework_romancandle_missle_01.m2",
+              ["text"] = "firework_romancandle_missle_01.m2",
+              ["fileId"] = "166164",
+          },
+
+          {
+              ["value"] = "fire_cast_hand.m2",
+              ["text"] = "fire_cast_hand.m2",
+              ["fileId"] = "166110",
+          },
+
+          {
+              ["value"] = "fire_dot_state_chest.m2",
+              ["text"] = "fire_dot_state_chest.m2",
+              ["fileId"] = "166111",
+          },
+
+          {
+              ["value"] = "fire_impactdd_chest.m2",
+              ["text"] = "fire_impactdd_chest.m2",
+              ["fileId"] = "166113",
+          },
+
+          {
+              ["value"] = "fire_impactdd_high_base.m2",
+              ["text"] = "fire_impactdd_high_base.m2",
+              ["fileId"] = "166114",
+          },
+
+          {
+              ["value"] = "fire_impactdd_high_chest.m2",
+              ["text"] = "fire_impactdd_high_chest.m2",
+              ["fileId"] = "166115",
+          },
+
+          {
+              ["value"] = "fire_impactdd_low_chest.m2",
+              ["text"] = "fire_impactdd_low_chest.m2",
+              ["fileId"] = "166116",
+          },
+
+          {
+              ["value"] = "fire_impactdd_med_chest.m2",
+              ["text"] = "fire_impactdd_med_chest.m2",
+              ["fileId"] = "166117",
+          },
+
+          {
+              ["value"] = "fire_impactdd_uber_base.m2",
+              ["text"] = "fire_impactdd_uber_base.m2",
+              ["fileId"] = "166118",
+          },
+
+          {
+              ["value"] = "fire_impactdd_uber_chest.m2",
+              ["text"] = "fire_impactdd_uber_chest.m2",
+              ["fileId"] = "166119",
+          },
+
+          {
+              ["value"] = "fire_precast_hand.m2",
+              ["text"] = "fire_precast_hand.m2",
+              ["fileId"] = "166120",
+          },
+
+          {
+              ["value"] = "fire_precast_high_hand.m2",
+              ["text"] = "fire_precast_high_hand.m2",
+              ["fileId"] = "166121",
+          },
+
+          {
+              ["value"] = "fire_precast_low_hand.m2",
+              ["text"] = "fire_precast_low_hand.m2",
+              ["fileId"] = "166122",
+          },
+
+          {
+              ["value"] = "fire_precast_med_hand.m2",
+              ["text"] = "fire_precast_med_hand.m2",
+              ["fileId"] = "166123",
+          },
+
+          {
+              ["value"] = "fire_precast_uber_hand.m2",
+              ["text"] = "fire_precast_uber_hand.m2",
+              ["fileId"] = "166124",
+          },
+
+          {
+              ["value"] = "fire_smoketrail.m2",
+              ["text"] = "fire_smoketrail.m2",
+              ["fileId"] = "166126",
+          },
+
+          {
+              ["value"] = "firstaid_hand.m2",
+              ["text"] = "firstaid_hand.m2",
+              ["fileId"] = "166173",
+          },
+
+          {
+              ["value"] = "firstaid__impact_base.m2",
+              ["text"] = "firstaid__impact_base.m2",
+              ["fileId"] = "166172",
+          },
+
+          {
+              ["value"] = "fistofjustice_cast_base.m2",
+              ["text"] = "fistofjustice_cast_base.m2",
+              ["fileId"] = "166174",
+          },
+
+          {
+              ["value"] = "fistofjustice_impact_chest.m2",
+              ["text"] = "fistofjustice_impact_chest.m2",
+              ["fileId"] = "166175",
+          },
+
+          {
+              ["value"] = "flamebreath.m2",
+              ["text"] = "flamebreath.m2",
+              ["fileId"] = "166176",
+          },
+
+          {
+              ["value"] = "flamebreath180.m2",
+              ["text"] = "flamebreath180.m2",
+              ["fileId"] = "166177",
+          },
+
+          {
+              ["value"] = "flameshock_impact_chest.m2",
+              ["text"] = "flameshock_impact_chest.m2",
+              ["fileId"] = "166186",
+          },
+
+          {
+              ["value"] = "flamestrikesmall_impact_base.m2",
+              ["text"] = "flamestrikesmall_impact_base.m2",
+              ["fileId"] = "166193",
+          },
+
+          {
+              ["value"] = "flamestrike_area.m2",
+              ["text"] = "flamestrike_area.m2",
+              ["fileId"] = "166187",
+          },
+
+          {
+              ["value"] = "flamestrike_impact.m2",
+              ["text"] = "flamestrike_impact.m2",
+              ["fileId"] = "166189",
+          },
+
+          {
+              ["value"] = "flamestrike_impactdd_med_base.m2",
+              ["text"] = "flamestrike_impactdd_med_base.m2",
+              ["fileId"] = "166191",
+          },
+
+          {
+              ["value"] = "flamestrike_impact_base.m2",
+              ["text"] = "flamestrike_impact_base.m2",
+              ["fileId"] = "166190",
+          },
+
+          {
+              ["value"] = "flare_cast_base.m2",
+              ["text"] = "flare_cast_base.m2",
+              ["fileId"] = "166195",
+          },
+
+          {
+              ["value"] = "flare_state_base.m2",
+              ["text"] = "flare_state_base.m2",
+              ["fileId"] = "166196",
+          },
+
+          {
+              ["value"] = "flashheal_base.m2",
+              ["text"] = "flashheal_base.m2",
+              ["fileId"] = "166197",
+          },
+
+          {
+              ["value"] = "focusedcasting_state_chest.m2",
+              ["text"] = "focusedcasting_state_chest.m2",
+              ["fileId"] = "166203",
+          },
+
+          {
+              ["value"] = "food_healeffect_base.m2",
+              ["text"] = "food_healeffect_base.m2",
+              ["fileId"] = "166204",
+          },
+
+          {
+              ["value"] = "frostarmoreffect_impact_chest.m2",
+              ["text"] = "frostarmoreffect_impact_chest.m2",
+              ["fileId"] = "166213",
+          },
+
+          {
+              ["value"] = "frostarmor_low_head.m2",
+              ["text"] = "frostarmor_low_head.m2",
+              ["fileId"] = "166212",
+          },
+
+          {
+              ["value"] = "frostbolt.m2",
+              ["text"] = "frostbolt.m2",
+              ["fileId"] = "166214",
+          },
+
+          {
+              ["value"] = "frostbreath.m2",
+              ["text"] = "frostbreath.m2",
+              ["fileId"] = "166215",
+          },
+
+          {
+              ["value"] = "frostreflect_state_chest.m2",
+              ["text"] = "frostreflect_state_chest.m2",
+              ["fileId"] = "166216",
+          },
+
+          {
+              ["value"] = "frostshot_missile.m2",
+              ["text"] = "frostshot_missile.m2",
+              ["fileId"] = "166217",
+          },
+
+          {
+              ["value"] = "frosttrap_aura.m2",
+              ["text"] = "frosttrap_aura.m2",
+              ["fileId"] = "166219",
+          },
+
+          {
+              ["value"] = "frostward_impact_chest.m2",
+              ["text"] = "frostward_impact_chest.m2",
+              ["fileId"] = "166221",
+          },
+
+          {
+              ["value"] = "frost_nova_area.m2",
+              ["text"] = "frost_nova_area.m2",
+              ["fileId"] = "166210",
+          },
+
+          {
+              ["value"] = "frost_nova_state.m2",
+              ["text"] = "frost_nova_state.m2",
+              ["fileId"] = "166211",
+          },
+
+          {
+              ["value"] = "ghostlystrike_impact_chest.m2",
+              ["text"] = "ghostlystrike_impact_chest.m2",
+              ["fileId"] = "166239",
+          },
+
+          {
+              ["value"] = "ghost_state.m2",
+              ["text"] = "ghost_state.m2",
+              ["fileId"] = "166237",
+          },
+
+          {
+              ["value"] = "giantinsectswarm_state_chest.m2",
+              ["text"] = "giantinsectswarm_state_chest.m2",
+              ["fileId"] = "166240",
+          },
+
+          {
+              ["value"] = "giantinsectswarm_state_ground.m2",
+              ["text"] = "giantinsectswarm_state_ground.m2",
+              ["fileId"] = "166241",
+          },
+
+          {
+              ["value"] = "goobolt_missile_low.m2",
+              ["text"] = "goobolt_missile_low.m2",
+              ["fileId"] = "166254",
+          },
+
+          {
+              ["value"] = "gouge_precast_state_hand.m2",
+              ["text"] = "gouge_precast_state_hand.m2",
+              ["fileId"] = "166255",
+          },
+
+          {
+              ["value"] = "greaterheal_low_base.m2",
+              ["text"] = "greaterheal_low_base.m2",
+              ["fileId"] = "166273",
+          },
+
+          {
+              ["value"] = "greenghost_state.m2",
+              ["text"] = "greenghost_state.m2",
+              ["fileId"] = "166278",
+          },
+
+          {
+              ["value"] = "greenradiationfog.m2",
+              ["text"] = "greenradiationfog.m2",
+              ["fileId"] = "166280",
+          },
+
+          {
+              ["value"] = "grounddust.m2",
+              ["text"] = "grounddust.m2",
+              ["fileId"] = "166285",
+          },
+
+          {
+              ["value"] = "groundingtotem_impact.m2",
+              ["text"] = "groundingtotem_impact.m2",
+              ["fileId"] = "166286",
+          },
+
+          {
+              ["value"] = "harmundeadaura_base.m2",
+              ["text"] = "harmundeadaura_base.m2",
+              ["fileId"] = "166288",
+          },
+
+          {
+              ["value"] = "headsplitter_impact_chest.m2",
+              ["text"] = "headsplitter_impact_chest.m2",
+              ["fileId"] = "166291",
+          },
+
+          {
+              ["value"] = "healingaura_base.m2",
+              ["text"] = "healingaura_base.m2",
+              ["fileId"] = "166293",
+          },
+
+          {
+              ["value"] = "healrag_state_chest.m2",
+              ["text"] = "healrag_state_chest.m2",
+              ["fileId"] = "166294",
+          },
+
+          {
+              ["value"] = "heal_low_base.m2",
+              ["text"] = "heal_low_base.m2",
+              ["fileId"] = "166292",
+          },
+
+          {
+              ["value"] = "hellfire_area_base.m2",
+              ["text"] = "hellfire_area_base.m2",
+              ["fileId"] = "166297",
+          },
+
+          {
+              ["value"] = "hellfire_channel_base.m2",
+              ["text"] = "hellfire_channel_base.m2",
+              ["fileId"] = "166301",
+          },
+
+          {
+              ["value"] = "hellfire_firepuff_caster_base.m2",
+              ["text"] = "hellfire_firepuff_caster_base.m2",
+              ["fileId"] = "166302",
+          },
+
+          {
+              ["value"] = "hellfire_impact_base.m2",
+              ["text"] = "hellfire_impact_base.m2",
+              ["fileId"] = "166303",
+          },
+
+          {
+              ["value"] = "hellfire_impact_caster_base.m2",
+              ["text"] = "hellfire_impact_caster_base.m2",
+              ["fileId"] = "166304",
+          },
+
+          {
+              ["value"] = "hellfire_impact_head.m2",
+              ["text"] = "hellfire_impact_head.m2",
+              ["fileId"] = "166305",
+          },
+
+          {
+              ["value"] = "hitsplatfire.m2",
+              ["text"] = "hitsplatfire.m2",
+              ["fileId"] = "166309",
+          },
+
+          {
+              ["value"] = "holydivineshield_state_base.m2",
+              ["text"] = "holydivineshield_state_base.m2",
+              ["fileId"] = "166342",
+          },
+
+          {
+              ["value"] = "holylight_impact_head.m2",
+              ["text"] = "holylight_impact_head.m2",
+              ["fileId"] = "166348",
+          },
+
+          {
+              ["value"] = "holylight_low_head.m2",
+              ["text"] = "holylight_low_head.m2",
+              ["fileId"] = "166349",
+          },
+
+          {
+              ["value"] = "holynova_impact_base.m2",
+              ["text"] = "holynova_impact_base.m2",
+              ["fileId"] = "166350",
+          },
+
+          {
+              ["value"] = "holyprotection_chest.m2",
+              ["text"] = "holyprotection_chest.m2",
+              ["fileId"] = "166351",
+          },
+
+          {
+              ["value"] = "holysmite_low_chest.m2",
+              ["text"] = "holysmite_low_chest.m2",
+              ["fileId"] = "166354",
+          },
+
+          {
+              ["value"] = "holyward_impact_chest.m2",
+              ["text"] = "holyward_impact_chest.m2",
+              ["fileId"] = "166355",
+          },
+
+          {
+              ["value"] = "holywordheal_base.m2",
+              ["text"] = "holywordheal_base.m2",
+              ["fileId"] = "166357",
+          },
+
+          {
+              ["value"] = "holywordshield_base.m2",
+              ["text"] = "holywordshield_base.m2",
+              ["fileId"] = "166358",
+          },
+
+          {
+              ["value"] = "holywordshield_state_base.m2",
+              ["text"] = "holywordshield_state_base.m2",
+              ["fileId"] = "166359",
+          },
+
+          {
+              ["value"] = "holywordshield_state_chest.m2",
+              ["text"] = "holywordshield_state_chest.m2",
+              ["fileId"] = "166360",
+          },
+
+          {
+              ["value"] = "holyword_fortitude_impact_base.m2",
+              ["text"] = "holyword_fortitude_impact_base.m2",
+              ["fileId"] = "166356",
+          },
+
+          {
+              ["value"] = "holy_hammer_missile.m2",
+              ["text"] = "holy_hammer_missile.m2",
+              ["fileId"] = "166323",
+          },
+
+          {
+              ["value"] = "holy_impactdd_high_base.m2",
+              ["text"] = "holy_impactdd_high_base.m2",
+              ["fileId"] = "166324",
+          },
+
+          {
+              ["value"] = "holy_impactdd_high_chest.m2",
+              ["text"] = "holy_impactdd_high_chest.m2",
+              ["fileId"] = "166325",
+          },
+
+          {
+              ["value"] = "holy_impactdd_low_chest.m2",
+              ["text"] = "holy_impactdd_low_chest.m2",
+              ["fileId"] = "166326",
+          },
+
+          {
+              ["value"] = "holy_impactdd_med_chest.m2",
+              ["text"] = "holy_impactdd_med_chest.m2",
+              ["fileId"] = "166327",
+          },
+
+          {
+              ["value"] = "holy_impactdd_uber_base.m2",
+              ["text"] = "holy_impactdd_uber_base.m2",
+              ["fileId"] = "166328",
+          },
+
+          {
+              ["value"] = "holy_impactdd_uber_chest.m2",
+              ["text"] = "holy_impactdd_uber_chest.m2",
+              ["fileId"] = "166329",
+          },
+
+          {
+              ["value"] = "holy_missile_high.m2",
+              ["text"] = "holy_missile_high.m2",
+              ["fileId"] = "166330",
+          },
+
+          {
+              ["value"] = "holy_missile_low.m2",
+              ["text"] = "holy_missile_low.m2",
+              ["fileId"] = "166331",
+          },
+
+          {
+              ["value"] = "holy_missile_med.m2",
+              ["text"] = "holy_missile_med.m2",
+              ["fileId"] = "166332",
+          },
+
+          {
+              ["value"] = "holy_missile_uber.m2",
+              ["text"] = "holy_missile_uber.m2",
+              ["fileId"] = "166333",
+          },
+
+          {
+              ["value"] = "holy_precast_high_base.m2",
+              ["text"] = "holy_precast_high_base.m2",
+              ["fileId"] = "166334",
+          },
+
+          {
+              ["value"] = "holy_precast_high_hand.m2",
+              ["text"] = "holy_precast_high_hand.m2",
+              ["fileId"] = "166335",
+          },
+
+          {
+              ["value"] = "holy_precast_low_hand.m2",
+              ["text"] = "holy_precast_low_hand.m2",
+              ["fileId"] = "166336",
+          },
+
+          {
+              ["value"] = "holy_precast_med_hand.m2",
+              ["text"] = "holy_precast_med_hand.m2",
+              ["fileId"] = "166337",
+          },
+
+          {
+              ["value"] = "holy_precast_uber_base.m2",
+              ["text"] = "holy_precast_uber_base.m2",
+              ["fileId"] = "166338",
+          },
+
+          {
+              ["value"] = "holy_precast_uber_hand.m2",
+              ["text"] = "holy_precast_uber_hand.m2",
+              ["fileId"] = "166339",
+          },
+
+          {
+              ["value"] = "hordectfflag_spell.m2",
+              ["text"] = "hordectfflag_spell.m2",
+              ["fileId"] = "166361",
+          },
+
+          {
+              ["value"] = "huntersmark_impact_chest.m2",
+              ["text"] = "huntersmark_impact_chest.m2",
+              ["fileId"] = "166362",
+          },
+
+          {
+              ["value"] = "huntersmark_impact_head.m2",
+              ["text"] = "huntersmark_impact_head.m2",
+              ["fileId"] = "166363",
+          },
+
+          {
+              ["value"] = "icearmor_low_head.m2",
+              ["text"] = "icearmor_low_head.m2",
+              ["fileId"] = "166387",
+          },
+
+          {
+              ["value"] = "icebarrier_state.m2",
+              ["text"] = "icebarrier_state.m2",
+              ["fileId"] = "166388",
+          },
+
+          {
+              ["value"] = "icenuke_base_impact.m2",
+              ["text"] = "icenuke_base_impact.m2",
+              ["fileId"] = "166389",
+          },
+
+          {
+              ["value"] = "icenuke_missile.m2",
+              ["text"] = "icenuke_missile.m2",
+              ["fileId"] = "166390",
+          },
+
+          {
+              ["value"] = "iceprison_base.m2",
+              ["text"] = "iceprison_base.m2",
+              ["fileId"] = "166391",
+          },
+
+          {
+              ["value"] = "iceshield_state.m2",
+              ["text"] = "iceshield_state.m2",
+              ["fileId"] = "166392",
+          },
+
+          {
+              ["value"] = "ice_cast_low_hand.m2",
+              ["text"] = "ice_cast_low_hand.m2",
+              ["fileId"] = "166367",
+          },
+
+          {
+              ["value"] = "ice_impactdd_high_chest.m2",
+              ["text"] = "ice_impactdd_high_chest.m2",
+              ["fileId"] = "166368",
+          },
+
+          {
+              ["value"] = "ice_impactdd_low_chest.m2",
+              ["text"] = "ice_impactdd_low_chest.m2",
+              ["fileId"] = "166369",
+          },
+
+          {
+              ["value"] = "ice_impactdd_med_chest.m2",
+              ["text"] = "ice_impactdd_med_chest.m2",
+              ["fileId"] = "166370",
+          },
+
+          {
+              ["value"] = "ice_impactdd_uber_chest.m2",
+              ["text"] = "ice_impactdd_uber_chest.m2",
+              ["fileId"] = "166371",
+          },
+
+          {
+              ["value"] = "ice_missile_high.m2",
+              ["text"] = "ice_missile_high.m2",
+              ["fileId"] = "166374",
+          },
+
+          {
+              ["value"] = "ice_missile_low.m2",
+              ["text"] = "ice_missile_low.m2",
+              ["fileId"] = "166375",
+          },
+
+          {
+              ["value"] = "ice_missile_med.m2",
+              ["text"] = "ice_missile_med.m2",
+              ["fileId"] = "166376",
+          },
+
+          {
+              ["value"] = "ice_missile_uber.m2",
+              ["text"] = "ice_missile_uber.m2",
+              ["fileId"] = "166377",
+          },
+
+          {
+              ["value"] = "ice_precast_high_base.m2",
+              ["text"] = "ice_precast_high_base.m2",
+              ["fileId"] = "166378",
+          },
+
+          {
+              ["value"] = "ice_precast_high_hand.m2",
+              ["text"] = "ice_precast_high_hand.m2",
+              ["fileId"] = "166379",
+          },
+
+          {
+              ["value"] = "ice_precast_high_head.m2",
+              ["text"] = "ice_precast_high_head.m2",
+              ["fileId"] = "166380",
+          },
+
+          {
+              ["value"] = "ice_precast_low_hand.m2",
+              ["text"] = "ice_precast_low_hand.m2",
+              ["fileId"] = "166381",
+          },
+
+          {
+              ["value"] = "ice_precast_med_hand.m2",
+              ["text"] = "ice_precast_med_hand.m2",
+              ["fileId"] = "166382",
+          },
+
+          {
+              ["value"] = "ice_precast_uber_base.m2",
+              ["text"] = "ice_precast_uber_base.m2",
+              ["fileId"] = "166383",
+          },
+
+          {
+              ["value"] = "ice_precast_uber_hand.m2",
+              ["text"] = "ice_precast_uber_hand.m2",
+              ["fileId"] = "166384",
+          },
+
+          {
+              ["value"] = "ice_precast_uber_head.m2",
+              ["text"] = "ice_precast_uber_head.m2",
+              ["fileId"] = "166385",
+          },
+
+          {
+              ["value"] = "immolate_impact_chest.m2",
+              ["text"] = "immolate_impact_chest.m2",
+              ["fileId"] = "166401",
+          },
+
+          {
+              ["value"] = "immolate_state.m2",
+              ["text"] = "immolate_state.m2",
+              ["fileId"] = "166402",
+          },
+
+          {
+              ["value"] = "immolate_state_base.m2",
+              ["text"] = "immolate_state_base.m2",
+              ["fileId"] = "166403",
+          },
+
+          {
+              ["value"] = "immolationtrap_recursive.m2",
+              ["text"] = "immolationtrap_recursive.m2",
+              ["fileId"] = "166404",
+          },
+
+          {
+              ["value"] = "infernal_flare_rec.m2",
+              ["text"] = "infernal_flare_rec.m2",
+              ["fileId"] = "166411",
+          },
+
+          {
+              ["value"] = "infernal_geo.m2",
+              ["text"] = "infernal_geo.m2",
+              ["fileId"] = "166412",
+          },
+
+          {
+              ["value"] = "infernal_impact_base.m2",
+              ["text"] = "infernal_impact_base.m2",
+              ["fileId"] = "166414",
+          },
+
+          {
+              ["value"] = "infernal_smoke_rec.m2",
+              ["text"] = "infernal_smoke_rec.m2",
+              ["fileId"] = "166415",
+          },
+
+          {
+              ["value"] = "innerfire_base.m2",
+              ["text"] = "innerfire_base.m2",
+              ["fileId"] = "166417",
+          },
+
+          {
+              ["value"] = "innerfocus_impact_chest.m2",
+              ["text"] = "innerfocus_impact_chest.m2",
+              ["fileId"] = "166419",
+          },
+
+          {
+              ["value"] = "innerrage_impact_chest.m2",
+              ["text"] = "innerrage_impact_chest.m2",
+              ["fileId"] = "166420",
+          },
+
+          {
+              ["value"] = "insectswarm_state_chest.m2",
+              ["text"] = "insectswarm_state_chest.m2",
+              ["fileId"] = "166421",
+          },
+
+          {
+              ["value"] = "intimidatingshout_cast_base.m2",
+              ["text"] = "intimidatingshout_cast_base.m2",
+              ["fileId"] = "166427",
+          },
+
+          {
+              ["value"] = "intimidatingshout_impact_head.m2",
+              ["text"] = "intimidatingshout_impact_head.m2",
+              ["fileId"] = "166428",
+          },
+
+          {
+              ["value"] = "invisibility_impact_base.m2",
+              ["text"] = "invisibility_impact_base.m2",
+              ["fileId"] = "166430",
+          },
+
+          {
+              ["value"] = "invisibility_impact_chest.m2",
+              ["text"] = "invisibility_impact_chest.m2",
+              ["fileId"] = "166431",
+          },
+
+          {
+              ["value"] = "invisible.m2",
+              ["text"] = "invisible.m2",
+              ["fileId"] = "166432",
+          },
+
+          {
+              ["value"] = "item_bread.m2",
+              ["text"] = "item_bread.m2",
+              ["fileId"] = "166434",
+          },
+
+          {
+              ["value"] = "kick_chest_impact.m2",
+              ["text"] = "kick_chest_impact.m2",
+              ["fileId"] = "166437",
+          },
+
+          {
+              ["value"] = "kidneyshot_base_cast.m2",
+              ["text"] = "kidneyshot_base_cast.m2",
+              ["fileId"] = "166438",
+          },
+
+          {
+              ["value"] = "largebluegreenradiationfog.m2",
+              ["text"] = "largebluegreenradiationfog.m2",
+              ["fileId"] = "166441",
+          },
+
+          {
+              ["value"] = "largegreenradiationfog.m2",
+              ["text"] = "largegreenradiationfog.m2",
+              ["fileId"] = "166442",
+          },
+
+          {
+              ["value"] = "lash_cast_base.m2",
+              ["text"] = "lash_cast_base.m2",
+              ["fileId"] = "166443",
+          },
+
+          {
+              ["value"] = "layonhands_low_chest.m2",
+              ["text"] = "layonhands_low_chest.m2",
+              ["fileId"] = "166452",
+          },
+
+          {
+              ["value"] = "layonhands_low_head.m2",
+              ["text"] = "layonhands_low_head.m2",
+              ["fileId"] = "166453",
+          },
+
+          {
+              ["value"] = "learn_impact_base.m2",
+              ["text"] = "learn_impact_base.m2",
+              ["fileId"] = "166457",
+          },
+
+          {
+              ["value"] = "lesserheal_base.m2",
+              ["text"] = "lesserheal_base.m2",
+              ["fileId"] = "166463",
+          },
+
+          {
+              ["value"] = "levitate_impact_base.m2",
+              ["text"] = "levitate_impact_base.m2",
+              ["fileId"] = "166466",
+          },
+
+          {
+              ["value"] = "lifedrain_missile.m2",
+              ["text"] = "lifedrain_missile.m2",
+              ["fileId"] = "166469",
+          },
+
+          {
+              ["value"] = "lifetap.m2",
+              ["text"] = "lifetap.m2",
+              ["fileId"] = "166470",
+          },
+
+          {
+              ["value"] = "lifetap_state_chest.m2",
+              ["text"] = "lifetap_state_chest.m2",
+              ["fileId"] = "166471",
+          },
+
+          {
+              ["value"] = "lightningboltivus_missile.m2",
+              ["text"] = "lightningboltivus_missile.m2",
+              ["fileId"] = "166498",
+          },
+
+          {
+              ["value"] = "lightningbolt_impact_chest.m2",
+              ["text"] = "lightningbolt_impact_chest.m2",
+              ["fileId"] = "166496",
+          },
+
+          {
+              ["value"] = "lightningbolt_missile.m2",
+              ["text"] = "lightningbolt_missile.m2",
+              ["fileId"] = "166497",
+          },
+
+          {
+              ["value"] = "lightningshield_impact_base.m2",
+              ["text"] = "lightningshield_impact_base.m2",
+              ["fileId"] = "166499",
+          },
+
+          {
+              ["value"] = "lightningshield_state_base.m2",
+              ["text"] = "lightningshield_state_base.m2",
+              ["fileId"] = "166500",
+          },
+
+          {
+              ["value"] = "lightningstorm_cloud_state.m2",
+              ["text"] = "lightningstorm_cloud_state.m2",
+              ["fileId"] = "166502",
+          },
+
+          {
+              ["value"] = "lightningstreak_missile.m2",
+              ["text"] = "lightningstreak_missile.m2",
+              ["fileId"] = "166504",
+          },
+
+          {
+              ["value"] = "lightning_cast_hand.m2",
+              ["text"] = "lightning_cast_hand.m2",
+              ["fileId"] = "166488",
+          },
+
+          {
+              ["value"] = "lightning_precast_low_hand.m2",
+              ["text"] = "lightning_precast_low_hand.m2",
+              ["fileId"] = "166492",
+          },
+
+          {
+              ["value"] = "lighttest.m2",
+              ["text"] = "lighttest.m2",
+              ["fileId"] = "166505",
+          },
+
+          {
+              ["value"] = "loyaltydown_impact_base.m2",
+              ["text"] = "loyaltydown_impact_base.m2",
+              ["fileId"] = "166508",
+          },
+
+          {
+              ["value"] = "loyaltydown_impact_head.m2",
+              ["text"] = "loyaltydown_impact_head.m2",
+              ["fileId"] = "166509",
+          },
+
+          {
+              ["value"] = "loyaltyup_impact_base.m2",
+              ["text"] = "loyaltyup_impact_base.m2",
+              ["fileId"] = "166510",
+          },
+
+          {
+              ["value"] = "loyaltyup_impact_head.m2",
+              ["text"] = "loyaltyup_impact_head.m2",
+              ["fileId"] = "166511",
+          },
+
+          {
+              ["value"] = "magearmor_impact_head.m2",
+              ["text"] = "magearmor_impact_head.m2",
+              ["fileId"] = "166522",
+          },
+
+          {
+              ["value"] = "mageportal_blank.m2",
+              ["text"] = "mageportal_blank.m2",
+              ["fileId"] = "166523",
+          },
+
+          {
+              ["value"] = "magicnet_missile.m2",
+              ["text"] = "magicnet_missile.m2",
+              ["fileId"] = "166527",
+          },
+
+          {
+              ["value"] = "magicnet_state.m2",
+              ["text"] = "magicnet_state.m2",
+              ["fileId"] = "166528",
+          },
+
+          {
+              ["value"] = "magicstonehelmet_green.m2",
+              ["text"] = "magicstonehelmet_green.m2",
+              ["fileId"] = "166529",
+          },
+
+          {
+              ["value"] = "magicstonehelmet_red.m2",
+              ["text"] = "magicstonehelmet_red.m2",
+              ["fileId"] = "166530",
+          },
+
+          {
+              ["value"] = "magicunlock.m2",
+              ["text"] = "magicunlock.m2",
+              ["fileId"] = "166531",
+          },
+
+          {
+              ["value"] = "magic_cast_hand.m2",
+              ["text"] = "magic_cast_hand.m2",
+              ["fileId"] = "166524",
+          },
+
+          {
+              ["value"] = "magic_impact_chest.m2",
+              ["text"] = "magic_impact_chest.m2",
+              ["fileId"] = "166525",
+          },
+
+          {
+              ["value"] = "magic_precast_hand.m2",
+              ["text"] = "magic_precast_hand.m2",
+              ["fileId"] = "166526",
+          },
+
+          {
+              ["value"] = "maim_impact_chest.m2",
+              ["text"] = "maim_impact_chest.m2",
+              ["fileId"] = "166534",
+          },
+
+          {
+              ["value"] = "manaburn_chest.m2",
+              ["text"] = "manaburn_chest.m2",
+              ["fileId"] = "166537",
+          },
+
+          {
+              ["value"] = "manafunnel_impact_chest.m2",
+              ["text"] = "manafunnel_impact_chest.m2",
+              ["fileId"] = "166538",
+          },
+
+          {
+              ["value"] = "manainfuse_base.m2",
+              ["text"] = "manainfuse_base.m2",
+              ["fileId"] = "166539",
+          },
+
+          {
+              ["value"] = "manashield_state_base.m2",
+              ["text"] = "manashield_state_base.m2",
+              ["fileId"] = "166540",
+          },
+
+          {
+              ["value"] = "manashield_state_chest.m2",
+              ["text"] = "manashield_state_chest.m2",
+              ["fileId"] = "166541",
+          },
+
+          {
+              ["value"] = "manashot_missile.m2",
+              ["text"] = "manashot_missile.m2",
+              ["fileId"] = "166542",
+          },
+
+          {
+              ["value"] = "manatideinfuse_base.m2",
+              ["text"] = "manatideinfuse_base.m2",
+              ["fileId"] = "166543",
+          },
+
+          {
+              ["value"] = "mana_impactdot_chest.m2",
+              ["text"] = "mana_impactdot_chest.m2",
+              ["fileId"] = "166536",
+          },
+
+          {
+              ["value"] = "markofbeast_impact_head.m2",
+              ["text"] = "markofbeast_impact_head.m2",
+              ["fileId"] = "166545",
+          },
+
+          {
+              ["value"] = "markofwild_impact_head.m2",
+              ["text"] = "markofwild_impact_head.m2",
+              ["fileId"] = "166546",
+          },
+
+          {
+              ["value"] = "maul.m2",
+              ["text"] = "maul.m2",
+              ["fileId"] = "166549",
+          },
+
+          {
+              ["value"] = "maulcasterbase.m2",
+              ["text"] = "maulcasterbase.m2",
+              ["fileId"] = "166550",
+          },
+
+          {
+              ["value"] = "maulimpact.m2",
+              ["text"] = "maulimpact.m2",
+              ["fileId"] = "166551",
+          },
+
+          {
+              ["value"] = "meteor_impact_base.m2",
+              ["text"] = "meteor_impact_base.m2",
+              ["fileId"] = "166554",
+          },
+
+          {
+              ["value"] = "mightaura_impact_base.m2",
+              ["text"] = "mightaura_impact_base.m2",
+              ["fileId"] = "166557",
+          },
+
+          {
+              ["value"] = "mindblast_head.m2",
+              ["text"] = "mindblast_head.m2",
+              ["fileId"] = "166558",
+          },
+
+          {
+              ["value"] = "mindrot_head.m2",
+              ["text"] = "mindrot_head.m2",
+              ["fileId"] = "166559",
+          },
+
+          {
+              ["value"] = "miningpick_spellobject.m2",
+              ["text"] = "miningpick_spellobject.m2",
+              ["fileId"] = "166560",
+          },
+
+          {
+              ["value"] = "missile_axe_copper.m2",
+              ["text"] = "missile_axe_copper.m2",
+              ["fileId"] = "166563",
+          },
+
+          {
+              ["value"] = "missile_bomb.m2",
+              ["text"] = "missile_bomb.m2",
+              ["fileId"] = "166564",
+          },
+
+          {
+              ["value"] = "missile_boomerang.m2",
+              ["text"] = "missile_boomerang.m2",
+              ["fileId"] = "166565",
+          },
+
+          {
+              ["value"] = "missile_flare.m2",
+              ["text"] = "missile_flare.m2",
+              ["fileId"] = "166566",
+          },
+
+          {
+              ["value"] = "missile_hammer.m2",
+              ["text"] = "missile_hammer.m2",
+              ["fileId"] = "166567",
+          },
+
+          {
+              ["value"] = "missile_leatherball.m2",
+              ["text"] = "missile_leatherball.m2",
+              ["fileId"] = "166568",
+          },
+
+          {
+              ["value"] = "missile_snowball.m2",
+              ["text"] = "missile_snowball.m2",
+              ["fileId"] = "166570",
+          },
+
+          {
+              ["value"] = "missile_thorns.m2",
+              ["text"] = "missile_thorns.m2",
+              ["fileId"] = "166571",
+          },
+
+          {
+              ["value"] = "missile_wrench.m2",
+              ["text"] = "missile_wrench.m2",
+              ["fileId"] = "166579",
+          },
+
+          {
+              ["value"] = "moltenblast_impact_chest.m2",
+              ["text"] = "moltenblast_impact_chest.m2",
+              ["fileId"] = "166583",
+          },
+
+          {
+              ["value"] = "moltenblast_missile.m2",
+              ["text"] = "moltenblast_missile.m2",
+              ["fileId"] = "166584",
+          },
+
+          {
+              ["value"] = "moltenblast_missile_lvl2.m2",
+              ["text"] = "moltenblast_missile_lvl2.m2",
+              ["fileId"] = "166585",
+          },
+
+          {
+              ["value"] = "moltenblast_missile_lvl3.m2",
+              ["text"] = "moltenblast_missile_lvl3.m2",
+              ["fileId"] = "166586",
+          },
+
+          {
+              ["value"] = "moonbeam_impact_base.m2",
+              ["text"] = "moonbeam_impact_base.m2",
+              ["fileId"] = "166590",
+          },
+
+          {
+              ["value"] = "moonfire_impact_base.m2",
+              ["text"] = "moonfire_impact_base.m2",
+              ["fileId"] = "166593",
+          },
+
+          {
+              ["value"] = "movementimmunity_base.m2",
+              ["text"] = "movementimmunity_base.m2",
+              ["fileId"] = "166594",
+          },
+
+          {
+              ["value"] = "mug_missile.m2",
+              ["text"] = "mug_missile.m2",
+              ["fileId"] = "166595",
+          },
+
+          {
+              ["value"] = "multishot_impact.m2",
+              ["text"] = "multishot_impact.m2",
+              ["fileId"] = "166597",
+          },
+
+          {
+              ["value"] = "multishot_missile.m2",
+              ["text"] = "multishot_missile.m2",
+              ["fileId"] = "166598",
+          },
+
+          {
+              ["value"] = "natureresistance_impact_base.m2",
+              ["text"] = "natureresistance_impact_base.m2",
+              ["fileId"] = "166608",
+          },
+
+          {
+              ["value"] = "nature_cast_hand.m2",
+              ["text"] = "nature_cast_hand.m2",
+              ["fileId"] = "166602",
+          },
+
+          {
+              ["value"] = "nature_precast_chest.m2",
+              ["text"] = "nature_precast_chest.m2",
+              ["fileId"] = "166604",
+          },
+
+          {
+              ["value"] = "nature_precast_low_hand.m2",
+              ["text"] = "nature_precast_low_hand.m2",
+              ["fileId"] = "166605",
+          },
+
+          {
+              ["value"] = "naxxramasstrike_impactdd_med_base.m2",
+              ["text"] = "naxxramasstrike_impactdd_med_base.m2",
+              ["fileId"] = "166610",
+          },
+
+          {
+              ["value"] = "nefarianflamebreath.m2",
+              ["text"] = "nefarianflamebreath.m2",
+              ["fileId"] = "166613",
+          },
+
+          {
+              ["value"] = "nefarianflamebreath_impact.m2",
+              ["text"] = "nefarianflamebreath_impact.m2",
+              ["fileId"] = "166614",
+          },
+
+          {
+              ["value"] = "nefarian_impact_base.m2",
+              ["text"] = "nefarian_impact_base.m2",
+              ["fileId"] = "166611",
+          },
+
+          {
+              ["value"] = "nefarian_state_base.m2",
+              ["text"] = "nefarian_state_base.m2",
+              ["fileId"] = "166612",
+          },
+
+          {
+              ["value"] = "net_missile.m2",
+              ["text"] = "net_missile.m2",
+              ["fileId"] = "166615",
+          },
+
+          {
+              ["value"] = "net_state.m2",
+              ["text"] = "net_state.m2",
+              ["fileId"] = "166616",
+          },
+
+          {
+              ["value"] = "nightmare_impact_base.m2",
+              ["text"] = "nightmare_impact_base.m2",
+              ["fileId"] = "166623",
+          },
+
+          {
+              ["value"] = "noname_area.m2",
+              ["text"] = "noname_area.m2",
+              ["fileId"] = "166624",
+          },
+
+          {
+              ["value"] = "nullifydisease_base.m2",
+              ["text"] = "nullifydisease_base.m2",
+              ["fileId"] = "166625",
+          },
+
+          {
+              ["value"] = "nullifypoison_base.m2",
+              ["text"] = "nullifypoison_base.m2",
+              ["fileId"] = "166626",
+          },
+
+          {
+              ["value"] = "onyxia_impact_base.m2",
+              ["text"] = "onyxia_impact_base.m2",
+              ["fileId"] = "166629",
+          },
+
+          {
+              ["value"] = "parachute_wings_head.m2",
+              ["text"] = "parachute_wings_head.m2",
+              ["fileId"] = "166634",
+          },
+
+          {
+              ["value"] = "pathfind_cast_head.m2",
+              ["text"] = "pathfind_cast_head.m2",
+              ["fileId"] = "166636",
+          },
+
+          {
+              ["value"] = "pestilence_impact_chest.m2",
+              ["text"] = "pestilence_impact_chest.m2",
+              ["fileId"] = "166637",
+          },
+
+          {
+              ["value"] = "piercinghowl_impact_head.m2",
+              ["text"] = "piercinghowl_impact_head.m2",
+              ["fileId"] = "166638",
+          },
+
+          {
+              ["value"] = "piercingstrike.m2",
+              ["text"] = "piercingstrike.m2",
+              ["fileId"] = "166639",
+          },
+
+          {
+              ["value"] = "piercingstrike_cast_hand.m2",
+              ["text"] = "piercingstrike_cast_hand.m2",
+              ["fileId"] = "166640",
+          },
+
+          {
+              ["value"] = "poisonshield_state_base.m2",
+              ["text"] = "poisonshield_state_base.m2",
+              ["fileId"] = "166647",
+          },
+
+          {
+              ["value"] = "poisonshot_missile.m2",
+              ["text"] = "poisonshot_missile.m2",
+              ["fileId"] = "166648",
+          },
+
+          {
+              ["value"] = "poison_cloud_grobbulus.m2",
+              ["text"] = "poison_cloud_grobbulus.m2",
+              ["fileId"] = "166642",
+          },
+
+          {
+              ["value"] = "poison_impactdot_med_base.m2",
+              ["text"] = "poison_impactdot_med_base.m2",
+              ["fileId"] = "166644",
+          },
+
+          {
+              ["value"] = "poison_impactdot_med_chest.m2",
+              ["text"] = "poison_impactdot_med_chest.m2",
+              ["fileId"] = "166645",
+          },
+
+          {
+              ["value"] = "poison_impact_chest.m2",
+              ["text"] = "poison_impact_chest.m2",
+              ["fileId"] = "166643",
+          },
+
+          {
+              ["value"] = "polymorph_impact.m2",
+              ["text"] = "polymorph_impact.m2",
+              ["fileId"] = "166649",
+          },
+
+          {
+              ["value"] = "polymorph_impact_base.m2",
+              ["text"] = "polymorph_impact_base.m2",
+              ["fileId"] = "166650",
+          },
+
+          {
+              ["value"] = "potiona_spellobject.m2",
+              ["text"] = "potiona_spellobject.m2",
+              ["fileId"] = "166654",
+          },
+
+          {
+              ["value"] = "potionb_spellobject.m2",
+              ["text"] = "potionb_spellobject.m2",
+              ["fileId"] = "166655",
+          },
+
+          {
+              ["value"] = "prayerofhealing_chest.m2",
+              ["text"] = "prayerofhealing_chest.m2",
+              ["fileId"] = "166656",
+          },
+
+          {
+              ["value"] = "presenceofmind_cast_base.m2",
+              ["text"] = "presenceofmind_cast_base.m2",
+              ["fileId"] = "166658",
+          },
+
+          {
+              ["value"] = "protectionfromfire_chest.m2",
+              ["text"] = "protectionfromfire_chest.m2",
+              ["fileId"] = "166663",
+          },
+
+          {
+              ["value"] = "protectionfromnature_chest.m2",
+              ["text"] = "protectionfromnature_chest.m2",
+              ["fileId"] = "166664",
+          },
+
+          {
+              ["value"] = "purge_impact_chest.m2",
+              ["text"] = "purge_impact_chest.m2",
+              ["fileId"] = "166665",
+          },
+
+          {
+              ["value"] = "purge_new_impact_chest.m2",
+              ["text"] = "purge_new_impact_chest.m2",
+              ["fileId"] = "166666",
+          },
+
+          {
+              ["value"] = "purify_base.m2",
+              ["text"] = "purify_base.m2",
+              ["fileId"] = "166667",
+          },
+
+          {
+              ["value"] = "purpleghost_state.m2",
+              ["text"] = "purpleghost_state.m2",
+              ["fileId"] = "166672",
+          },
+
+          {
+              ["value"] = "pyroblast_missile.m2",
+              ["text"] = "pyroblast_missile.m2",
+              ["fileId"] = "166674",
+          },
+
+          {
+              ["value"] = "rag_firenova_area.m2",
+              ["text"] = "rag_firenova_area.m2",
+              ["fileId"] = "166675",
+          },
+
+          {
+              ["value"] = "rainoffire_impact_base.m2",
+              ["text"] = "rainoffire_impact_base.m2",
+              ["fileId"] = "166677",
+          },
+
+          {
+              ["value"] = "rainoffire_missile.m2",
+              ["text"] = "rainoffire_missile.m2",
+              ["fileId"] = "166678",
+          },
+
+          {
+              ["value"] = "rake.m2",
+              ["text"] = "rake.m2",
+              ["fileId"] = "166679",
+          },
+
+          {
+              ["value"] = "rapidfire_base.m2",
+              ["text"] = "rapidfire_base.m2",
+              ["fileId"] = "166682",
+          },
+
+          {
+              ["value"] = "recklessness_impact_chest.m2",
+              ["text"] = "recklessness_impact_chest.m2",
+              ["fileId"] = "166685",
+          },
+
+          {
+              ["value"] = "reddustcloud.m2",
+              ["text"] = "reddustcloud.m2",
+              ["fileId"] = "166690",
+          },
+
+          {
+              ["value"] = "redemption_base.m2",
+              ["text"] = "redemption_base.m2",
+              ["fileId"] = "166691",
+          },
+
+          {
+              ["value"] = "redghost_state.m2",
+              ["text"] = "redghost_state.m2",
+              ["fileId"] = "166692",
+          },
+
+          {
+              ["value"] = "rejuvenation_impact_base.m2",
+              ["text"] = "rejuvenation_impact_base.m2",
+              ["fileId"] = "166694",
+          },
+
+          {
+              ["value"] = "removecurse_base.m2",
+              ["text"] = "removecurse_base.m2",
+              ["fileId"] = "166695",
+          },
+
+          {
+              ["value"] = "renew_base.m2",
+              ["text"] = "renew_base.m2",
+              ["fileId"] = "166696",
+          },
+
+          {
+              ["value"] = "renew_chest.m2",
+              ["text"] = "renew_chest.m2",
+              ["fileId"] = "166697",
+          },
+
+          {
+              ["value"] = "reputationlevelup.m2",
+              ["text"] = "reputationlevelup.m2",
+              ["fileId"] = "166698",
+          },
+
+          {
+              ["value"] = "resfx.m2",
+              ["text"] = "resfx.m2",
+              ["fileId"] = "166699",
+          },
+
+          {
+              ["value"] = "resistanceaura_base.m2",
+              ["text"] = "resistanceaura_base.m2",
+              ["fileId"] = "166701",
+          },
+
+          {
+              ["value"] = "resistfrost_chest.m2",
+              ["text"] = "resistfrost_chest.m2",
+              ["fileId"] = "166702",
+          },
+
+          {
+              ["value"] = "resist_immune_effect.m2",
+              ["text"] = "resist_immune_effect.m2",
+              ["fileId"] = "166700",
+          },
+
+          {
+              ["value"] = "restoration_impact_base.m2",
+              ["text"] = "restoration_impact_base.m2",
+              ["fileId"] = "166703",
+          },
+
+          {
+              ["value"] = "resurrection_low_base.m2",
+              ["text"] = "resurrection_low_base.m2",
+              ["fileId"] = "166704",
+          },
+
+          {
+              ["value"] = "retaliation_state_chest.m2",
+              ["text"] = "retaliation_state_chest.m2",
+              ["fileId"] = "166705",
+          },
+
+          {
+              ["value"] = "retributionaurared_base.m2",
+              ["text"] = "retributionaurared_base.m2",
+              ["fileId"] = "166708",
+          },
+
+          {
+              ["value"] = "retributionaura_base.m2",
+              ["text"] = "retributionaura_base.m2",
+              ["fileId"] = "166707",
+          },
+
+          {
+              ["value"] = "revivepet_impact_base.m2",
+              ["text"] = "revivepet_impact_base.m2",
+              ["fileId"] = "166709",
+          },
+
+          {
+              ["value"] = "ribbontrail.m2",
+              ["text"] = "ribbontrail.m2",
+              ["fileId"] = "166731",
+          },
+
+          {
+              ["value"] = "righteousfury_chest.m2",
+              ["text"] = "righteousfury_chest.m2",
+              ["fileId"] = "166732",
+          },
+
+          {
+              ["value"] = "righteousnessaura_base.m2",
+              ["text"] = "righteousnessaura_base.m2",
+              ["fileId"] = "166733",
+          },
+
+          {
+              ["value"] = "ritualsummoning_precast_base.m2",
+              ["text"] = "ritualsummoning_precast_base.m2",
+              ["fileId"] = "166737",
+          },
+
+          {
+              ["value"] = "rockyfrost_nova_state.m2",
+              ["text"] = "rockyfrost_nova_state.m2",
+              ["fileId"] = "166743",
+          },
+
+          {
+              ["value"] = "romancandle_a_01.m2",
+              ["text"] = "romancandle_a_01.m2",
+              ["fileId"] = "166744",
+          },
+
+          {
+              ["value"] = "sandvortex_state_base.m2",
+              ["text"] = "sandvortex_state_base.m2",
+              ["fileId"] = "166759",
+          },
+
+          {
+              ["value"] = "sandworm_attackeffects.m2",
+              ["text"] = "sandworm_attackeffects.m2",
+              ["fileId"] = "166760",
+          },
+
+          {
+              ["value"] = "sap_cast_base.m2",
+              ["text"] = "sap_cast_base.m2",
+              ["fileId"] = "166761",
+          },
+
+          {
+              ["value"] = "sap_impact_chest.m2",
+              ["text"] = "sap_impact_chest.m2",
+              ["fileId"] = "166762",
+          },
+
+          {
+              ["value"] = "sap_state_head.m2",
+              ["text"] = "sap_state_head.m2",
+              ["fileId"] = "166763",
+          },
+
+          {
+              ["value"] = "savageblow_impact_chest.m2",
+              ["text"] = "savageblow_impact_chest.m2",
+              ["fileId"] = "166764",
+          },
+
+          {
+              ["value"] = "scorch_low_chest.m2",
+              ["text"] = "scorch_low_chest.m2",
+              ["fileId"] = "166766",
+          },
+
+          {
+              ["value"] = "scorpidshot_missile.m2",
+              ["text"] = "scorpidshot_missile.m2",
+              ["fileId"] = "166767",
+          },
+
+          {
+              ["value"] = "sealoffury_impact_base.m2",
+              ["text"] = "sealoffury_impact_base.m2",
+              ["fileId"] = "166772",
+          },
+
+          {
+              ["value"] = "sealofmight_impact_base.m2",
+              ["text"] = "sealofmight_impact_base.m2",
+              ["fileId"] = "166774",
+          },
+
+          {
+              ["value"] = "sealofmight_low_base.m2",
+              ["text"] = "sealofmight_low_base.m2",
+              ["fileId"] = "166775",
+          },
+
+          {
+              ["value"] = "sealofprotection_impact_base.m2",
+              ["text"] = "sealofprotection_impact_base.m2",
+              ["fileId"] = "166776",
+          },
+
+          {
+              ["value"] = "sealofsacrifice_impact_base.m2",
+              ["text"] = "sealofsacrifice_impact_base.m2",
+              ["fileId"] = "166778",
+          },
+
+          {
+              ["value"] = "sealofsalvation_impact_base.m2",
+              ["text"] = "sealofsalvation_impact_base.m2",
+              ["fileId"] = "166779",
+          },
+
+          {
+              ["value"] = "sealofwisdom_impact_base.m2",
+              ["text"] = "sealofwisdom_impact_base.m2",
+              ["fileId"] = "166781",
+          },
+
+          {
+              ["value"] = "sealofwrath_impact_base.m2",
+              ["text"] = "sealofwrath_impact_base.m2",
+              ["fileId"] = "166782",
+          },
+
+          {
+              ["value"] = "seduction_state_head.m2",
+              ["text"] = "seduction_state_head.m2",
+              ["fileId"] = "166783",
+          },
+
+          {
+              ["value"] = "sensedemons_impact_head.m2",
+              ["text"] = "sensedemons_impact_head.m2",
+              ["fileId"] = "166788",
+          },
+
+          {
+              ["value"] = "shadowprotection_chest.m2",
+              ["text"] = "shadowprotection_chest.m2",
+              ["fileId"] = "166823",
+          },
+
+          {
+              ["value"] = "shadowreflect_state_chest.m2",
+              ["text"] = "shadowreflect_state_chest.m2",
+              ["fileId"] = "166824",
+          },
+
+          {
+              ["value"] = "shadowshield_state_base.m2",
+              ["text"] = "shadowshield_state_base.m2",
+              ["fileId"] = "166827",
+          },
+
+          {
+              ["value"] = "shadowstrike_impact_chest.m2",
+              ["text"] = "shadowstrike_impact_chest.m2",
+              ["fileId"] = "166829",
+          },
+
+          {
+              ["value"] = "shadowward_impact_chest.m2",
+              ["text"] = "shadowward_impact_chest.m2",
+              ["fileId"] = "166830",
+          },
+
+          {
+              ["value"] = "shadowwordbefuddle_head.m2",
+              ["text"] = "shadowwordbefuddle_head.m2",
+              ["fileId"] = "166832",
+          },
+
+          {
+              ["value"] = "shadowworddominate_chest.m2",
+              ["text"] = "shadowworddominate_chest.m2",
+              ["fileId"] = "166833",
+          },
+
+          {
+              ["value"] = "shadowwordfumble_head.m2",
+              ["text"] = "shadowwordfumble_head.m2",
+              ["fileId"] = "166834",
+          },
+
+          {
+              ["value"] = "shadowwordpain_chest.m2",
+              ["text"] = "shadowwordpain_chest.m2",
+              ["fileId"] = "166835",
+          },
+
+          {
+              ["value"] = "shadowwordsilence_breath.m2",
+              ["text"] = "shadowwordsilence_breath.m2",
+              ["fileId"] = "166836",
+          },
+
+          {
+              ["value"] = "shadow_dotparticle.m2",
+              ["text"] = "shadow_dotparticle.m2",
+              ["fileId"] = "166790",
+          },
+
+          {
+              ["value"] = "shadow_fissure_base.m2",
+              ["text"] = "shadow_fissure_base.m2",
+              ["fileId"] = "166791",
+          },
+
+          {
+              ["value"] = "shadow_impactbuff_base.m2",
+              ["text"] = "shadow_impactbuff_base.m2",
+              ["fileId"] = "166794",
+          },
+
+          {
+              ["value"] = "shadow_impactdd_high_chest.m2",
+              ["text"] = "shadow_impactdd_high_chest.m2",
+              ["fileId"] = "166795",
+          },
+
+          {
+              ["value"] = "shadow_impactdd_low_chest.m2",
+              ["text"] = "shadow_impactdd_low_chest.m2",
+              ["fileId"] = "166796",
+          },
+
+          {
+              ["value"] = "shadow_impactdd_med_base.m2",
+              ["text"] = "shadow_impactdd_med_base.m2",
+              ["fileId"] = "166797",
+          },
+
+          {
+              ["value"] = "shadow_impactdd_med_chest.m2",
+              ["text"] = "shadow_impactdd_med_chest.m2",
+              ["fileId"] = "166798",
+          },
+
+          {
+              ["value"] = "shadow_impactdd_uber_chest.m2",
+              ["text"] = "shadow_impactdd_uber_chest.m2",
+              ["fileId"] = "166799",
+          },
+
+          {
+              ["value"] = "shadow_impactdot_med_chest.m2",
+              ["text"] = "shadow_impactdot_med_chest.m2",
+              ["fileId"] = "166800",
+          },
+
+          {
+              ["value"] = "shadow_impactdot_med_head.m2",
+              ["text"] = "shadow_impactdot_med_head.m2",
+              ["fileId"] = "166801",
+          },
+
+          {
+              ["value"] = "shadow_precast_high_base.m2",
+              ["text"] = "shadow_precast_high_base.m2",
+              ["fileId"] = "166805",
+          },
+
+          {
+              ["value"] = "shadow_precast_high_hand.m2",
+              ["text"] = "shadow_precast_high_hand.m2",
+              ["fileId"] = "166806",
+          },
+
+          {
+              ["value"] = "shadow_precast_low_hand.m2",
+              ["text"] = "shadow_precast_low_hand.m2",
+              ["fileId"] = "166807",
+          },
+
+          {
+              ["value"] = "shadow_precast_med_base.m2",
+              ["text"] = "shadow_precast_med_base.m2",
+              ["fileId"] = "166808",
+          },
+
+          {
+              ["value"] = "shadow_precast_med_hand.m2",
+              ["text"] = "shadow_precast_med_hand.m2",
+              ["fileId"] = "166809",
+          },
+
+          {
+              ["value"] = "shadow_precast_uber_base.m2",
+              ["text"] = "shadow_precast_uber_base.m2",
+              ["fileId"] = "166810",
+          },
+
+          {
+              ["value"] = "shadow_precast_uber_hand.m2",
+              ["text"] = "shadow_precast_uber_hand.m2",
+              ["fileId"] = "166811",
+          },
+
+          {
+              ["value"] = "shadow_snare_high_base.m2",
+              ["text"] = "shadow_snare_high_base.m2",
+              ["fileId"] = "166812",
+          },
+
+          {
+              ["value"] = "shieldbash_impact_chest.m2",
+              ["text"] = "shieldbash_impact_chest.m2",
+              ["fileId"] = "166841",
+          },
+
+          {
+              ["value"] = "shieldwallwar_impact_base.m2",
+              ["text"] = "shieldwallwar_impact_base.m2",
+              ["fileId"] = "166843",
+          },
+
+          {
+              ["value"] = "shieldwall_impact_base.m2",
+              ["text"] = "shieldwall_impact_base.m2",
+              ["fileId"] = "166842",
+          },
+
+          {
+              ["value"] = "shock_impact_chest.m2",
+              ["text"] = "shock_impact_chest.m2",
+              ["fileId"] = "166844",
+          },
+
+          {
+              ["value"] = "shock_missile.m2",
+              ["text"] = "shock_missile.m2",
+              ["fileId"] = "166845",
+          },
+
+          {
+              ["value"] = "shout_cast.m2",
+              ["text"] = "shout_cast.m2",
+              ["fileId"] = "166875",
+          },
+
+          {
+              ["value"] = "sinisterstrike_base_cast.m2",
+              ["text"] = "sinisterstrike_base_cast.m2",
+              ["fileId"] = "166877",
+          },
+
+          {
+              ["value"] = "sinisterstrike_impact_chest.m2",
+              ["text"] = "sinisterstrike_impact_chest.m2",
+              ["fileId"] = "166878",
+          },
+
+          {
+              ["value"] = "skull.m2",
+              ["text"] = "skull.m2",
+              ["fileId"] = "166881",
+          },
+
+          {
+              ["value"] = "skull180.m2",
+              ["text"] = "skull180.m2",
+              ["fileId"] = "166882",
+          },
+
+          {
+              ["value"] = "slam_impact_chest.m2",
+              ["text"] = "slam_impact_chest.m2",
+              ["fileId"] = "166890",
+          },
+
+          {
+              ["value"] = "sleep_state_head.m2",
+              ["text"] = "sleep_state_head.m2",
+              ["fileId"] = "166891",
+          },
+
+          {
+              ["value"] = "slicedice_chest.m2",
+              ["text"] = "slicedice_chest.m2",
+              ["fileId"] = "166892",
+          },
+
+          {
+              ["value"] = "slicedice_impact_chest.m2",
+              ["text"] = "slicedice_impact_chest.m2",
+              ["fileId"] = "166893",
+          },
+
+          {
+              ["value"] = "slimelesserexplode_missile.m2",
+              ["text"] = "slimelesserexplode_missile.m2",
+              ["fileId"] = "166897",
+          },
+
+          {
+              ["value"] = "slimelesser_missile.m2",
+              ["text"] = "slimelesser_missile.m2",
+              ["fileId"] = "166896",
+          },
+
+          {
+              ["value"] = "slowingstrike_cast_hand.m2",
+              ["text"] = "slowingstrike_cast_hand.m2",
+              ["fileId"] = "166899",
+          },
+
+          {
+              ["value"] = "slowingstrike_impact_base.m2",
+              ["text"] = "slowingstrike_impact_base.m2",
+              ["fileId"] = "166900",
+          },
+
+          {
+              ["value"] = "slowingstrike_impact_chest.m2",
+              ["text"] = "slowingstrike_impact_chest.m2",
+              ["fileId"] = "166901",
+          },
+
+          {
+              ["value"] = "slow_impact_base.m2",
+              ["text"] = "slow_impact_base.m2",
+              ["fileId"] = "166898",
+          },
+
+          {
+              ["value"] = "smash_impact_chest.m2",
+              ["text"] = "smash_impact_chest.m2",
+              ["fileId"] = "166902",
+          },
+
+          {
+              ["value"] = "snowballpowdery_impact_base.m2",
+              ["text"] = "snowballpowdery_impact_base.m2",
+              ["fileId"] = "166913",
+          },
+
+          {
+              ["value"] = "snowball_impact_chest.m2",
+              ["text"] = "snowball_impact_chest.m2",
+              ["fileId"] = "166912",
+          },
+
+          {
+              ["value"] = "soothingkiss_impact_head.m2",
+              ["text"] = "soothingkiss_impact_head.m2",
+              ["fileId"] = "166922",
+          },
+
+          {
+              ["value"] = "soulfunnel_impact_chest.m2",
+              ["text"] = "soulfunnel_impact_chest.m2",
+              ["fileId"] = "166923",
+          },
+
+          {
+              ["value"] = "soulstoneresurrection_base.m2",
+              ["text"] = "soulstoneresurrection_base.m2",
+              ["fileId"] = "166927",
+          },
+
+          {
+              ["value"] = "sparktrail.m2",
+              ["text"] = "sparktrail.m2",
+              ["fileId"] = "166930",
+          },
+
+          {
+              ["value"] = "spawn_impact_base.m2",
+              ["text"] = "spawn_impact_base.m2",
+              ["fileId"] = "166931",
+          },
+
+          {
+              ["value"] = "spellbreak_cast_base.m2",
+              ["text"] = "spellbreak_cast_base.m2",
+              ["fileId"] = "166932",
+          },
+
+          {
+              ["value"] = "spelllevelup.m2",
+              ["text"] = "spelllevelup.m2",
+              ["fileId"] = "166934",
+          },
+
+          {
+              ["value"] = "spellobject_bomb.m2",
+              ["text"] = "spellobject_bomb.m2",
+              ["fileId"] = "166935",
+          },
+
+          {
+              ["value"] = "spellobject_boomerang.m2",
+              ["text"] = "spellobject_boomerang.m2",
+              ["fileId"] = "166936",
+          },
+
+          {
+              ["value"] = "spellobject_invisibletrap.m2",
+              ["text"] = "spellobject_invisibletrap.m2",
+              ["fileId"] = "2199509",
+          },
+
+          {
+              ["value"] = "spellobject_smithinghammer.m2",
+              ["text"] = "spellobject_smithinghammer.m2",
+              ["fileId"] = "166938",
+          },
+
+          {
+              ["value"] = "spellobject_wrench.m2",
+              ["text"] = "spellobject_wrench.m2",
+              ["fileId"] = "166939",
+          },
+
+          {
+              ["value"] = "spike_impact_base.m2",
+              ["text"] = "spike_impact_base.m2",
+              ["fileId"] = "166944",
+          },
+
+          {
+              ["value"] = "spike_low_base.m2",
+              ["text"] = "spike_low_base.m2",
+              ["fileId"] = "166945",
+          },
+
+          {
+              ["value"] = "spiritarmor_impact_head.m2",
+              ["text"] = "spiritarmor_impact_head.m2",
+              ["fileId"] = "166950",
+          },
+
+          {
+              ["value"] = "sprint_cast_base.m2",
+              ["text"] = "sprint_cast_base.m2",
+              ["fileId"] = "166951",
+          },
+
+          {
+              ["value"] = "sprint_impact_chest.m2",
+              ["text"] = "sprint_impact_chest.m2",
+              ["fileId"] = "166952",
+          },
+
+          {
+              ["value"] = "starfire_area.m2",
+              ["text"] = "starfire_area.m2",
+              ["fileId"] = "166973",
+          },
+
+          {
+              ["value"] = "starshards_impact_base.m2",
+              ["text"] = "starshards_impact_base.m2",
+              ["fileId"] = "166980",
+          },
+
+          {
+              ["value"] = "steam.m2",
+              ["text"] = "steam.m2",
+              ["fileId"] = "166981",
+          },
+
+          {
+              ["value"] = "stoneform_state_base.m2",
+              ["text"] = "stoneform_state_base.m2",
+              ["fileId"] = "166982",
+          },
+
+          {
+              ["value"] = "strike_cast_chest.m2",
+              ["text"] = "strike_cast_chest.m2",
+              ["fileId"] = "166985",
+          },
+
+          {
+              ["value"] = "strike_impact_chest.m2",
+              ["text"] = "strike_impact_chest.m2",
+              ["fileId"] = "166986",
+          },
+
+          {
+              ["value"] = "stunswirl_state_head.m2",
+              ["text"] = "stunswirl_state_head.m2",
+              ["fileId"] = "166988",
+          },
+
+          {
+              ["value"] = "summonpet_cast_impact_base.m2",
+              ["text"] = "summonpet_cast_impact_base.m2",
+              ["fileId"] = "166993",
+          },
+
+          {
+              ["value"] = "summonpet_impact_base.m2",
+              ["text"] = "summonpet_impact_base.m2",
+              ["fileId"] = "166994",
+          },
+
+          {
+              ["value"] = "summonwarhorse_impact_base.m2",
+              ["text"] = "summonwarhorse_impact_base.m2",
+              ["fileId"] = "166995",
+          },
+
+          {
+              ["value"] = "summon_precast_hand.m2",
+              ["text"] = "summon_precast_hand.m2",
+              ["fileId"] = "166991",
+          },
+
+          {
+              ["value"] = "sunder_impact_chest.m2",
+              ["text"] = "sunder_impact_chest.m2",
+              ["fileId"] = "166996",
+          },
+
+          {
+              ["value"] = "sweepingstrike_impact_chest.m2",
+              ["text"] = "sweepingstrike_impact_chest.m2",
+              ["fileId"] = "167003",
+          },
+
+          {
+              ["value"] = "swipecaster.m2",
+              ["text"] = "swipecaster.m2",
+              ["fileId"] = "167004",
+          },
+
+          {
+              ["value"] = "swipeimpact.m2",
+              ["text"] = "swipeimpact.m2",
+              ["fileId"] = "167005",
+          },
+
+          {
+              ["value"] = "tankarda_spellobject.m2",
+              ["text"] = "tankarda_spellobject.m2",
+              ["fileId"] = "167090",
+          },
+
+          {
+              ["value"] = "taunt_cast.m2",
+              ["text"] = "taunt_cast.m2",
+              ["fileId"] = "167092",
+          },
+
+          {
+              ["value"] = "taunt_head.m2",
+              ["text"] = "taunt_head.m2",
+              ["fileId"] = "167093",
+          },
+
+          {
+              ["value"] = "teleport.m2",
+              ["text"] = "teleport.m2",
+              ["fileId"] = "167094",
+          },
+
+          {
+              ["value"] = "thorns_base.m2",
+              ["text"] = "thorns_base.m2",
+              ["fileId"] = "167112",
+          },
+
+          {
+              ["value"] = "thorns_damage_base.m2",
+              ["text"] = "thorns_damage_base.m2",
+              ["fileId"] = "167113",
+          },
+
+          {
+              ["value"] = "thorns_low_chest.m2",
+              ["text"] = "thorns_low_chest.m2",
+              ["fileId"] = "167114",
+          },
+
+          {
+              ["value"] = "thorns_state_base.m2",
+              ["text"] = "thorns_state_base.m2",
+              ["fileId"] = "167115",
+          },
+
+          {
+              ["value"] = "threatreduce_impact_head.m2",
+              ["text"] = "threatreduce_impact_head.m2",
+              ["fileId"] = "167117",
+          },
+
+          {
+              ["value"] = "thunderclap_cast_base.m2",
+              ["text"] = "thunderclap_cast_base.m2",
+              ["fileId"] = "167120",
+          },
+
+          {
+              ["value"] = "torchspell.m2",
+              ["text"] = "torchspell.m2",
+              ["fileId"] = "167130",
+          },
+
+          {
+              ["value"] = "torch_missile.m2",
+              ["text"] = "torch_missile.m2",
+              ["fileId"] = "167128",
+          },
+
+          {
+              ["value"] = "totemb_spellobject.m2",
+              ["text"] = "totemb_spellobject.m2",
+              ["fileId"] = "167132",
+          },
+
+          {
+              ["value"] = "tranquility_area.m2",
+              ["text"] = "tranquility_area.m2",
+              ["fileId"] = "167134",
+          },
+
+          {
+              ["value"] = "tranquility_impact_base.m2",
+              ["text"] = "tranquility_impact_base.m2",
+              ["fileId"] = "167135",
+          },
+
+          {
+              ["value"] = "trickortreat_treat_head.m2",
+              ["text"] = "trickortreat_treat_head.m2",
+              ["fileId"] = "167139",
+          },
+
+          {
+              ["value"] = "trickortreat_trick_head.m2",
+              ["text"] = "trickortreat_trick_head.m2",
+              ["fileId"] = "167140",
+          },
+
+          {
+              ["value"] = "turnundead_impact.m2",
+              ["text"] = "turnundead_impact.m2",
+              ["fileId"] = "167141",
+          },
+
+          {
+              ["value"] = "undying_strength_impact_chest.m2",
+              ["text"] = "undying_strength_impact_chest.m2",
+              ["fileId"] = "167143",
+          },
+
+          {
+              ["value"] = "unholyshackles_state_base.m2",
+              ["text"] = "unholyshackles_state_base.m2",
+              ["fileId"] = "167144",
+          },
+
+          {
+              ["value"] = "unyielding_will_impact_chest.m2",
+              ["text"] = "unyielding_will_impact_chest.m2",
+              ["fileId"] = "167147",
+          },
+
+          {
+              ["value"] = "vampiricembrace_state_base.m2",
+              ["text"] = "vampiricembrace_state_base.m2",
+              ["fileId"] = "167150",
+          },
+
+          {
+              ["value"] = "vanish_cast_base.m2",
+              ["text"] = "vanish_cast_base.m2",
+              ["fileId"] = "167151",
+          },
+
+          {
+              ["value"] = "vengeance_state_hand.m2",
+              ["text"] = "vengeance_state_hand.m2",
+              ["fileId"] = "167152",
+          },
+
+          {
+              ["value"] = "waterbolt_missile_low.m2",
+              ["text"] = "waterbolt_missile_low.m2",
+              ["fileId"] = "167174",
+          },
+
+          {
+              ["value"] = "waterbreathing_impact_base.m2",
+              ["text"] = "waterbreathing_impact_base.m2",
+              ["fileId"] = "167175",
+          },
+
+          {
+              ["value"] = "waterbubble.m2",
+              ["text"] = "waterbubble.m2",
+              ["fileId"] = "167177",
+          },
+
+          {
+              ["value"] = "waterelemental_impact_base.m2",
+              ["text"] = "waterelemental_impact_base.m2",
+              ["fileId"] = "167178",
+          },
+
+          {
+              ["value"] = "waterwalking_impact_head.m2",
+              ["text"] = "waterwalking_impact_head.m2",
+              ["fileId"] = "167189",
+          },
+
+          {
+              ["value"] = "webspin.m2",
+              ["text"] = "webspin.m2",
+              ["fileId"] = "167196",
+          },
+
+          {
+              ["value"] = "web_missile.m2",
+              ["text"] = "web_missile.m2",
+              ["fileId"] = "167194",
+          },
+
+          {
+              ["value"] = "web_state.m2",
+              ["text"] = "web_state.m2",
+              ["fileId"] = "167195",
+          },
+
+          {
+              ["value"] = "whirlwindgeo1.m2",
+              ["text"] = "whirlwindgeo1.m2",
+              ["fileId"] = "167200",
+          },
+
+          {
+              ["value"] = "whirlwindgeo2.m2",
+              ["text"] = "whirlwindgeo2.m2",
+              ["fileId"] = "167201",
+          },
+
+          {
+              ["value"] = "whirlwindgeowhite.m2",
+              ["text"] = "whirlwindgeowhite.m2",
+              ["fileId"] = "167202",
+          },
+
+          {
+              ["value"] = "whirlwind_state_base.m2",
+              ["text"] = "whirlwind_state_base.m2",
+              ["fileId"] = "167199",
+          },
+
+          {
+              ["value"] = "wisdomaura_impact_base.m2",
+              ["text"] = "wisdomaura_impact_base.m2",
+              ["fileId"] = "167211",
+          },
+
+          {
+              ["value"] = "wrath_impact_chest.m2",
+              ["text"] = "wrath_impact_chest.m2",
+              ["fileId"] = "167212",
+          },
+
+          {
+              ["value"] = "wrath_missile.m2",
+              ["text"] = "wrath_missile.m2",
+              ["fileId"] = "167213",
+          },
+
+          {
+              ["value"] = "wrath_precast_hand.m2",
+              ["text"] = "wrath_precast_hand.m2",
+              ["fileId"] = "167214",
+          },
+
+          {
+              ["value"] = "zig_missile.m2",
+              ["text"] = "zig_missile.m2",
+              ["fileId"] = "167229",
+          },
+      },
+  }, -- [8]
+}

--- a/WeakAurasModelPaths/WeakAurasModelPaths.toc
+++ b/WeakAurasModelPaths/WeakAurasModelPaths.toc
@@ -18,4 +18,9 @@
 ## LoadOnDemand: 1
 ## Dependencies: WeakAuras, WeakAurasOptions
 
+#@retail@
 ModelPaths.lua
+#@end-retail@
+#@non-retail@
+# ModelPathsClassic.lua
+#@end-non-retail@

--- a/WeakAurasOptions/OptionsFrames/OptionsFrame.lua
+++ b/WeakAurasOptions/OptionsFrames/OptionsFrame.lua
@@ -283,9 +283,7 @@ function WeakAuras.CreateFrame()
       self.buttonsContainer.frame:Hide()
       self.texturePicker.frame:Hide()
       self.iconPicker.frame:Hide()
-      if not WeakAuras.IsClassic() then
-        self.modelPicker.frame:Hide()
-      end
+      self.modelPicker.frame:Hide()
       self.importexport.frame:Hide()
       self.texteditor.frame:Hide()
       self.codereview.frame:Hide()
@@ -319,12 +317,10 @@ function WeakAuras.CreateFrame()
         self.iconPicker.frame:Hide()
       end
 
-      if not WeakAuras.IsClassic() then
-        if self.window == "model" then
-          self.modelPicker.frame:Show()
-        else
-          self.modelPicker.frame:Hide()
-        end
+      if self.window == "model" then
+        self.modelPicker.frame:Show()
+      else
+        self.modelPicker.frame:Hide()
       end
 
       if self.window == "importexport" then
@@ -445,9 +441,7 @@ function WeakAuras.CreateFrame()
 
   frame.texturePicker = WeakAuras.TexturePicker(frame)
   frame.iconPicker = WeakAuras.IconPicker(frame)
-  if not WeakAuras.IsClassic() then
-    frame.modelPicker = WeakAuras.ModelPicker(frame)
-  end
+  frame.modelPicker = WeakAuras.ModelPicker(frame)
   frame.importexport = WeakAuras.ImportExport(frame)
   frame.texteditor = WeakAuras.TextEditor(frame)
   frame.codereview = WeakAuras.CodeReview(frame)

--- a/WeakAurasOptions/RegionOptions/Model.lua
+++ b/WeakAurasOptions/RegionOptions/Model.lua
@@ -1,7 +1,6 @@
 if not WeakAuras.IsCorrectVersion() then return end
 
 local L = WeakAuras.L;
-if WeakAuras.IsClassic() then return end -- Models disabled for classic
 
 local function createOptions(id, data)
   local options = {
@@ -281,7 +280,7 @@ end
 
 local function createIcon()
   local data = {
-    model_path = "Creature/Arthaslichking/arthaslichking.m2",
+    model_path = "spells/arcanepower_state_chest.m2", -- arthas is not a thing on classic
     model_fileId = "122968", -- Creature/Arthaslichking/arthaslichking.m2
     modelIsUnit = false,
     model_x = 0,

--- a/WeakAurasOptions/SubRegionOptions/BarModel.lua
+++ b/WeakAurasOptions/SubRegionOptions/BarModel.lua
@@ -3,8 +3,6 @@ if not WeakAuras.IsCorrectVersion() then return end
 local SharedMedia = LibStub("LibSharedMedia-3.0");
 local L = WeakAuras.L;
 
-if WeakAuras.IsClassic() then return end -- Models disabled for classic
-
 local function createOptions(parentData, data, index, subIndex)
   local options = {
     __title = L["Model %s"]:format(subIndex),
@@ -39,7 +37,15 @@ local function createOptions(parentData, data, index, subIndex)
       type = "input",
       width = WeakAuras.normalWidth,
       name = L["Model"],
-      order =  10
+      order =  10,
+      hidden = WeakAuras.IsClassic()
+    },
+    model_path = {
+      type = "input",
+      width = WeakAuras.normalWidth,
+      name = L["Model"],
+      order =  10.5,
+      hidden = not WeakAuras.IsClassic()
     },
     chooseModel = {
       type = "execute",

--- a/WeakAurasOptions/WeakAurasOptions.toc
+++ b/WeakAurasOptions/WeakAurasOptions.toc
@@ -29,9 +29,7 @@ RegionOptions\Icon.lua
 RegionOptions\Text.lua
 RegionOptions\Group.lua
 RegionOptions\DynamicGroup.lua
-#@retail@
 RegionOptions\Model.lua
-#@end-retail@
 RegionOptions\ProgressTexture.lua
 
 SubRegionOptions\SubRegionCommon.lua
@@ -39,9 +37,7 @@ SubRegionOptions\SubText.lua
 SubRegionOptions\Border.lua
 SubRegionOptions\Glow.lua
 SubRegionOptions\Tick.lua
-#@retail@
 SubRegionOptions\BarModel.lua
-#@end-retail@
 
 Cache.lua
 
@@ -67,9 +63,7 @@ OptionsFrames\OptionsFrame.lua
 OptionsFrames\CodeReview.lua
 OptionsFrames\IconPicker.lua
 OptionsFrames\ImportExport.lua
-#@retail@
 OptionsFrames\ModelPicker.lua
-#@end-retail@
 OptionsFrames\TextEditor.lua
 OptionsFrames\TexturePicker.lua
 # -- misc Frames


### PR DESCRIPTION
# Description
After seeing WeakAuras was forked on a chinese forum with models support https://bbs.nga.cn/read.php?tid=22060034&rand=116, my tests show that wrong models does not crash the game anymore.


I use the same ModelPaths.lua found on nga.cn forum for classic