### PR TITLE
Add SetTextureOrAtlas to the relevant functions in an Icon region

### DIFF
--- a/WeakAuras/RegionTypes/Icon.lua
+++ b/WeakAuras/RegionTypes/Icon.lua
@@ -404,7 +404,7 @@ local function modify(parent, region, data)
       or data.displayIcon
       or "Interface\\Icons\\INV_Misc_QuestionMark"
       );
-    icon:SetTexture(iconPath);
+    WeakAuras.SetTextureOrAtlas(icon, iconPath)
   end
 
   function region:Scale(scalex, scaley)

--- a/WeakAurasOptions/RegionOptions/Icon.lua
+++ b/WeakAurasOptions/RegionOptions/Icon.lua
@@ -233,10 +233,8 @@ local function modifyThumbnail(parent, frame, data)
   frame:SetParent(parent)
 
   function frame:SetIcon(path)
-    local success = self.icon:SetTexture(data.auto and path or data.displayIcon) and (data.auto and path or data.displayIcon);
-    if not(success) then
-      self.icon:SetTexture("Interface\\Icons\\INV_Misc_QuestionMark");
-    end
+    local iconPath = data.auto and path or data.displayIcon or "Interface\\Icons\\INV_Misc_QuestionMark"
+    WeakAuras.SetTextureOrAtlas(self.icon, iconPath)
   end
 
   if data then


### PR DESCRIPTION
# Description

Small change to allow Icons to use Atlases, as well as display the set atlas in the thumbnail. 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist
<!-- These can be checked off after the pull request is submitted, in case you want discussion before they are completely ready -->

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

<!-- Is there any additional work that needs to be done? If so, add it to the above list -->
