### PR TITLE
add player xp trigger

### DIFF
--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -1720,7 +1720,6 @@ WeakAuras.event_prototypes = {
     },
     automaticrequired = true
   },
-
   ["Faction Reputation"] = {
     type = "status",
     canHaveDuration = false,
@@ -1826,7 +1825,115 @@ WeakAuras.event_prototypes = {
     },
     automaticrequired = true
   },
-
+  ["Experience"] = {
+    type = "status",
+    canHaveDuration = false,
+    events = {
+      ["events"] = {
+        "PLAYER_XP_UPDATE",
+      }
+    },
+    internal_events = {"WA_DELAYED_PLAYER_ENTERING_WORLD"},
+    force_events = "PLAYER_XP_UPDATE",
+    name = L["Player XP"],
+    init = function(trigger)
+      return ""
+    end,
+    statesParameter = "one",
+    args = {
+      {
+        name = "level",
+        display = L["Level"],
+        required = false,
+        type = "number",
+        store = true,
+        init = [[UnitLevel("player")]],
+        conditionType = "number",
+      },
+      {
+        name = "currentXP",
+        display = L["Current XP"],
+        type = "number",
+        store = true,
+        init = [[UnitXP("player")]],
+        conditionType = "number",
+      },
+      {
+        name = "totalXP",
+        display = L["total XP"],
+        type = "number",
+        store = true,
+        init = [[UnitXPMax("player")]],
+        conditionType = "number",
+      },
+      {
+        name = "value",
+        type = "number",
+        store = true,
+        init = "currentXP",
+        hidden = true,
+        test = "true",
+      },
+      {
+        name = "total",
+        type = "number",
+        store = true,
+        init = "totalXP",
+        hidden = true,
+        test = "true",
+      },
+      {
+        name = "progressType",
+        hidden = true,
+        init = "'static'",
+        store = true,
+        test = "true"
+      },
+      {
+        name = "percentXP",
+        display = L["XP (%)"],
+        type = "number",
+        init = "total ~= 0 and (value / total) * 100",
+        store = true,
+        conditionType = "number"
+      },
+      {
+        name = "showRested",
+        display = L["Show Rested Overlay"],
+        type = "toggle",
+        test = "true",
+        reloadOptions = true,
+      },
+      {
+        name = "restedXP",
+        display = L["Rested XP"],
+        init = [[GetXPExhaustion() or 0]],
+        type = "number",
+        store = true,
+        conditionType = "number",
+      },
+      {
+        name = "percentrested",
+        display = "Rested (%)",
+        init = "total ~= 0 and (restedXP / total) * 100",
+        type = "number",
+        store = true,
+        conditionType = "number",
+      },
+    },
+    overlayFuncs = {
+      {
+        name = L["Rested"],
+        func = function(trigger, state)
+          return "forward", state.restedXP
+        end,
+        enable = function(trigger)
+          return trigger.use_showRested
+        end
+      },
+    },
+    automaticrequired = true
+  },
   ["Health"] = {
     type = "status",
     canHaveDuration = true,

--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -1860,7 +1860,7 @@ WeakAuras.event_prototypes = {
       },
       {
         name = "totalXP",
-        display = L["total Experience"],
+        display = L["Total Experience"],
         type = "number",
         store = true,
         init = [[UnitXPMax("player")]],

--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -1835,7 +1835,7 @@ WeakAuras.event_prototypes = {
     },
     internal_events = {"WA_DELAYED_PLAYER_ENTERING_WORLD"},
     force_events = "PLAYER_XP_UPDATE",
-    name = L["Player XP"],
+    name = L["Player Experience"],
     init = function(trigger)
       return ""
     end,
@@ -1852,7 +1852,7 @@ WeakAuras.event_prototypes = {
       },
       {
         name = "currentXP",
-        display = L["Current XP"],
+        display = L["Current Experience"],
         type = "number",
         store = true,
         init = [[UnitXP("player")]],
@@ -1860,7 +1860,7 @@ WeakAuras.event_prototypes = {
       },
       {
         name = "totalXP",
-        display = L["total XP"],
+        display = L["total Experience"],
         type = "number",
         store = true,
         init = [[UnitXPMax("player")]],
@@ -1891,7 +1891,7 @@ WeakAuras.event_prototypes = {
       },
       {
         name = "percentXP",
-        display = L["XP (%)"],
+        display = L["Experience (%)"],
         type = "number",
         init = "total ~= 0 and (value / total) * 100",
         store = true,
@@ -1906,7 +1906,7 @@ WeakAuras.event_prototypes = {
       },
       {
         name = "restedXP",
-        display = L["Rested XP"],
+        display = L["Rested Experience"],
         init = [[GetXPExhaustion() or 0]],
         type = "number",
         store = true,
@@ -1914,7 +1914,7 @@ WeakAuras.event_prototypes = {
       },
       {
         name = "percentrested",
-        display = "Rested (%)",
+        display = L["Rested Experience (%)"],
         init = "total ~= 0 and (restedXP / total) * 100",
         type = "number",
         store = true,


### PR DESCRIPTION
# Description

It doesn't come up super often but it is a display that people occasionally want to make in WA. It also provides a way to trigger based on player level or rested amount, which people might want to use to set activation on Auras displaying other things. 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist
<!-- These can be checked off after the pull request is submitted, in case you want discussion before they are completely ready -->

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

<!-- Is there any additional work that needs to be done? If so, add it to the above list -->
