### PR TITLE
Add combat timer trigger

### DIFF
--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -6016,7 +6016,7 @@ WeakAuras.event_prototypes = {
       },
       {
         name = "timer",
-        display = "Timer",
+        display = L["Timer"],
         type = "number",
         conditionType = "number",
         store = true,
@@ -6028,7 +6028,6 @@ WeakAuras.event_prototypes = {
         name = "duration",
         display = L["Combat Duration"],
         type = "number",
-        conditionType = "number",
         test = "show",
       },
       {

--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -5977,6 +5977,82 @@ WeakAuras.event_prototypes = {
     },
     automaticrequired = true
   },
+  ["Combat Timer"] = {
+    type = "status",
+    name = L["Combat Timer"],
+    events = {
+      ["events"] = {
+        "PLAYER_REGEN_DISABLED",
+        "PLAYER_REGEN_ENABLED",
+        "ENCOUNTER_START",
+        "ENCOUNTER_END",
+        "FRAME_UPDATE",
+      },
+    },
+    init = function(trigger)
+      local ret = [[
+        if event == "PLAYER_REGEN_DISABLED" then
+          WeakAuras.CurrentCombatStart = GetTime()
+        elseif event == "ENCOUNTER_START" then
+          WeakAuras.CurrentEncounterStart = GetTime()
+        elseif event == "PLAYER_REGEN_ENABLED" then
+          WeakAuras.CurrentCombatStart = nil
+        elseif event == "ENCOUNTER_END" then
+          WeakAuras.CurrentEncounterStart = nil
+        end
+        local timerType = %s
+        local duration = %f
+        local start = timerType == "encounter" and WeakAuras.CurrentEncounterStart or WeakAuras.CurrentCombatStart
+        local timer = start and GetTime() - start or 0
+        local show = timer %s duration
+      ]]
+      return ret:format(trigger.timerType or "combat", trigger.duration or "0", trigger.duration_operator or ">")
+    end,
+    args = {
+      {
+        name = "timerType",
+        type = "select",
+        required = true,
+        display = L["Timer Type"],
+        values = "combat_types",
+        test ="true",
+        default = "combat",
+      },
+      {
+        name = "timer",
+        display = "Timer",
+        type = "number",
+        conditionType = "number",
+        store = true,
+        init = "timer",
+        test = "true",
+        hidden = true,
+      },
+      {
+        name = "duration",
+        display = L["Combat Duration"],
+        type = "number",
+        conditionType = "number",
+        test = "show",
+      },
+      {
+        name = "progressType",
+        hidden = true,
+        init = "'static'",
+        test = "true",
+        store = true
+      },
+      {
+        name = "value",
+        init = "timer",
+        hidden = true,
+        test = "true",
+        store = true
+      },
+    },
+    automaticrequired = true,
+    statesParameter = "one",
+  },
   ["Cast"] = {
     type = "status",
     events = function(trigger)

--- a/WeakAuras/Types.lua
+++ b/WeakAuras/Types.lua
@@ -2039,6 +2039,11 @@ WeakAuras.cast_types = {
   channel = L["Channel (Spell)"]
 }
 
+WeakAuras.combat_types = {
+  encounter = L["Encounter"],
+  combat = L["Combat"]
+}
+
 -- register sounds
 LSM:Register("sound", "Batman Punch", "Interface\\AddOns\\WeakAuras\\Media\\Sounds\\BatmanPunch.ogg")
 LSM:Register("sound", "Bike Horn", "Interface\\AddOns\\WeakAuras\\Media\\Sounds\\BikeHorn.ogg")


### PR DESCRIPTION
# Description

Combat Timers are a very frequently requested Aura. There are Custom Options available that will likely remain popular as they provide functionality like tying in to Exorsus Notes and so on. But a generic trigger that provides a simple value the the time spent in combat, and a way to trigger/Condition based on that time would be useful for various applications I think.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist
<!-- These can be checked off after the pull request is submitted, in case you want discussion before they are completely ready -->

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

<!-- Is there any additional work that needs to be done? If so, add it to the above list -->
