### PR TITLE
Fake nameplate anchor fixes  #1896

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ WeakAuras/Libs/*
 format.bat
 **/desktop.ini
 .DS_Store
+.release

--- a/WeakAuras/RegionTypes/DynamicGroup.lua
+++ b/WeakAuras/RegionTypes/DynamicGroup.lua
@@ -354,12 +354,20 @@ local anchorers = {
     return function(frames, activeRegions)
       for _, regionData in ipairs(activeRegions) do
         local unit = regionData.region.state and regionData.region.state.unit
+        local found
         if unit then
           local frame = WeakAuras.GetUnitNameplate(unit)
           if frame then
             frames[frame] = frames[frame] or {}
             tinsert(frames[frame], regionData)
+            found = true
           end
+        end
+        if not found and WeakAuras.IsOptionsOpen() then
+          Private.ensurePRDFrame()
+          Private.personalRessourceDisplayFrame:anchorFrame(regionData.region.state.id, "NAMEPLATE")
+          frames[Private.personalRessourceDisplayFrame] = frames[Private.personalRessourceDisplayFrame] or {}
+          tinsert(frames[Private.personalRessourceDisplayFrame], regionData)
         end
       end
     end

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -4613,7 +4613,7 @@ local function ensureMouseFrame()
 end
 
 local personalRessourceDisplayFrame;
-local function ensurePRDFrame()
+function Private.ensurePRDFrame()
   if (personalRessourceDisplayFrame) then
     return;
   end
@@ -4803,7 +4803,7 @@ local function ensurePRDFrame()
   end
 
   personalRessourceDisplayFrame.anchorFrame = function(self, id, anchorFrameType)
-    if (anchorFrameType == "PRD") then
+    if (anchorFrameType == "PRD" or anchorFrameType == "NAMEPLATE") then
       self.attachedVisibleFrames[id] = true;
     else
       self.attachedVisibleFrames[id] = nil;
@@ -4832,6 +4832,7 @@ local function ensurePRDFrame()
   else
     personalRessourceDisplayFrame.OptionsClosed();
   end
+  Private.personalRessourceDisplayFrame = personalRessourceDisplayFrame
 end
 
 local postPonedAnchors = {};
@@ -4884,7 +4885,7 @@ local function GetAnchorFrame(data, region, parent)
   end
 
   if (anchorFrameType == "PRD") then
-    ensurePRDFrame();
+    Private.ensurePRDFrame();
     personalRessourceDisplayFrame:anchorFrame(id, anchorFrameType);
     return personalRessourceDisplayFrame;
   end
@@ -4897,7 +4898,13 @@ local function GetAnchorFrame(data, region, parent)
 
   if (anchorFrameType == "NAMEPLATE") then
     local unit = region.state.unit
-    return unit and WeakAuras.GetUnitNameplate(unit)
+    local frame = unit and WeakAuras.GetUnitNameplate(unit)
+    if frame then return frame end
+    if WeakAuras.IsOptionsOpen() then
+      Private.ensurePRDFrame()
+      personalRessourceDisplayFrame:anchorFrame(id, anchorFrameType)
+      return personalRessourceDisplayFrame
+    end
   end
 
   if (anchorFrameType == "UNITFRAME") then


### PR DESCRIPTION
# Description

When options are open, this anchor to the fake PRD auras and dynamic groups anchored to nameplates for which the trigger does not return an existing nameplate

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested
- With aura anchored to nameplate
- With a dynamic group with group by frame => nameplate
