### PR TITLE
Update Actions

### DIFF
--- a/.github/workflows/build-beta.yml
+++ b/.github/workflows/build-beta.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
-        fetch-depth: 0
+        fetch-depth: 250
     - name: Install and run Luacheck
       run: |
         sudo apt-get install luarocks
@@ -39,9 +39,9 @@ jobs:
         name: WeakAuras-SL
         path: .release/
 
-    - name: Notify on Failure
+    - name: Send status to Discord
+      uses: nebularg/actions-discord-webhook@v1
+      with:
+        webhook_url: ${{ secrets.WEBHOOK_URL }}
+        status: ${{ job.status }}
       if: failure()
-      env:
-        BUILD_STATUS: ${{ job.status }}
-        WEBHOOK_URL: ${{ secrets.WEBHOOK_URL }}
-      run: curl -s https://raw.githubusercontent.com/nebularg/actions-discord-webhook/master/send.sh | bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,9 +47,9 @@ jobs:
         GITHUB_OAUTH: ${{ secrets.GITHUB_OAUTH }}
         WOWI_API_TOKEN: ${{ secrets.WOWI_API_TOKEN }}
 
-    - name: Notify on Failure
+    - name: Send status to Discord
+      uses: nebularg/actions-discord-webhook@v1
+      with:
+        webhook_url: ${{ secrets.WEBHOOK_URL }}
+        status: ${{ job.status }}
       if: failure()
-      env:
-        BUILD_STATUS: ${{ job.status }}
-        WEBHOOK_URL: ${{ secrets.WEBHOOK_URL }}
-      run: curl -s https://raw.githubusercontent.com/nebularg/actions-discord-webhook/master/send.sh | bash

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -25,9 +25,9 @@ jobs:
         GITHUB_OAUTH: ${{ secrets.GITHUB_OAUTH }}
         WOWI_API_TOKEN: ${{ secrets.WOWI_API_TOKEN }}
 
-    - uses: actions/upload-artifact@master
+    - uses: actions/upload-artifact@v2
       with:
-        name: WeakAuras-PR
+        name: WeakAuras-PR${{ github.event.number }}
         path: .release/
 
     - name: Create Classic Package
@@ -39,13 +39,12 @@ jobs:
 
     - uses: actions/upload-artifact@v2
       with:
-        name: WeakAuras-PR-classic
+        name: WeakAuras-PR${{ github.event.number }}-classic
         path: .release/
 
-    - name: Notify on Failure
+    - name: Send status to Discord
+      uses: nebularg/actions-discord-webhook@v1
+      with:
+        webhook_url: ${{ secrets.WEBHOOK_URL }}
+        status: ${{ job.status }}
       if: failure()
-      env:
-        BUILD_STATUS: ${{ job.status }}
-        WEBHOOK_URL: ${{ secrets.WEBHOOK_URL }}
-      run: curl -s https://raw.githubusercontent.com/nebularg/actions-discord-webhook/master/send.sh | bash
-


### PR DESCRIPTION
- Now uses a GitHub Action for Discord status posts
- Sets git fetch depth to a slightly more sane 250 instead of 0, v2 of the action is still buggy with tags so this can probably be removed in the future
- Try to add the PR number to the name of the archive that is generated