### PR TITLE
Fix ticks not updating properly on size changes.

### DIFF
--- a/WeakAuras/RegionTypes/AuraBar.lua
+++ b/WeakAuras/RegionTypes/AuraBar.lua
@@ -419,6 +419,7 @@ local barPrototype = {
   ["OnSizeChanged"] = function(self, width, height)
     self:UpdateProgress();
     self:UpdateAdditionalBars();
+    self:GetParent().subRegionEvents:Notify("OnRegionSizeChanged")
   end,
 
   -- Blizzard like SetMinMaxValues

--- a/WeakAuras/SubRegionTypes/Tick.lua
+++ b/WeakAuras/SubRegionTypes/Tick.lua
@@ -144,7 +144,7 @@ local funcs = {
     self:UpdateTickPlacement()
     self:UpdateTickSize()
   end,
-  OnSizeChanged = function(self)
+  OnRegionSizeChanged = function(self)
     if self.vertical then
       self.parentMinorSize, self.parentMajorSize = self.parent.bar:GetRealSize()
     else
@@ -395,7 +395,7 @@ local function modify(parent, region, parentData, data, first)
   parent.subRegionEvents:AddSubscriber("Update", region)
   parent.subRegionEvents:AddSubscriber("OrientationChanged", region)
   parent.subRegionEvents:AddSubscriber("InverseChanged", region)
-  parent:SetScript("OnSizeChanged", function() region:OnSizeChanged() end)
+  parent.subRegionEvents:AddSubscriber("OnRegionSizeChanged", region)
 
   region.TimerTick = nil
 end


### PR DESCRIPTION
# Description

My approach was flawed. It worked in testing because I only tested one tick at a time. This adds a new event notifier for all aurabar type regions and utilizes it to properly update ticks.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested

- [x] Tested using an aura that dynamically changed bar size
