### PR TITLE
Fix error with old versions of OmniCC

### DIFF
--- a/WeakAuras/RegionTypes/Icon.lua
+++ b/WeakAuras/RegionTypes/Icon.lua
@@ -357,7 +357,7 @@ local function modify(parent, region, data)
 
   cooldown:SetReverse(not data.inverse);
   cooldown:SetHideCountdownNumbers(data.cooldownTextDisabled);
-  if OmniCC then
+  if OmniCC and OmniCC.Cooldown then
     OmniCC.Cooldown.SetNoCooldownCount(cooldown, data.cooldownTextDisabled)
   end
 


### PR DESCRIPTION
# Description

Users with old versions of omnicc can't use WeakAuras anymore

```
2x WeakAuras\RegionTypes\Icon.lua:361: attempt to index field 'Cooldown' (a nil value)
WeakAuras\RegionTypes\Icon.lua:361: in function `modify'
WeakAuras\WeakAuras-3.0.3.lua:2863: in function `SetRegion'
WeakAuras\WeakAuras.lua:2758: in function <WeakAuras\WeakAuras.lua:2664>
WeakAuras\WeakAuras.lua:2793: in function `Add'
WeakAuras\WeakAuras.lua:2324: in function `load'
WeakAuras\WeakAuras.lua:2331: in function `AddMany'
WeakAuras\WeakAuras.lua:1010: in function <WeakAuras\WeakAuras.lua:982>

WeakAuras\WeakAuras-3.0.3.lua:1132: in function <WeakAuras\WeakAuras.lua:1083>
```

This make the addon more resilient for those who have not updated yet