### PR TITLE
Adding support for Plater personal resource bar anchoring

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -59,6 +59,7 @@ globals = {
 	"IndentationLib",
 	"KuiNameplatesCore",
 	"KuiNameplatesPlayerAnchor",
+	"Plater",
 
 	-- FrameXML misc
 	"BackdropTemplateMixin",

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -4707,8 +4707,8 @@ function Private.ensurePRDFrame()
     local frame = C_NamePlate.GetNamePlateForUnit("player");
     if (frame) then
       if (Plater and frame.Plater and frame.unitFrame.Plater) then
-		personalRessourceDisplayFrame:Attach(frame, frame.unitFrame.healthBar, frame.unitFrame.powerBar);
-	  elseif (frame.kui and frame.kui.bg and frame.kui:IsShown()) then
+        personalRessourceDisplayFrame:Attach(frame, frame.unitFrame.healthBar, frame.unitFrame.powerBar);
+      elseif (frame.kui and frame.kui.bg and frame.kui:IsShown()) then
         personalRessourceDisplayFrame:Attach(frame.kui, frame.kui.bg, frame.kui.bg);
       elseif (ElvUIPlayerNamePlateAnchor) then
         personalRessourceDisplayFrame:Attach(ElvUIPlayerNamePlateAnchor, ElvUIPlayerNamePlateAnchor, ElvUIPlayerNamePlateAnchor);
@@ -4733,7 +4733,7 @@ function Private.ensurePRDFrame()
         local frame = C_NamePlate.GetNamePlateForUnit("player");
         if (frame) then
           if (Plater and frame.Plater and frame.unitFrame.Plater) then
-			personalRessourceDisplayFrame:Attach(frame, frame.unitFrame.healthBar, frame.unitFrame.powerBar);
+            personalRessourceDisplayFrame:Attach(frame, frame.unitFrame.healthBar, frame.unitFrame.powerBar);
           elseif (frame.kui and frame.kui.bg and frame.kui:IsShown()) then
             personalRessourceDisplayFrame:Attach(frame.kui, KuiNameplatesPlayerAnchor, KuiNameplatesPlayerAnchor);
           elseif (ElvUIPlayerNamePlateAnchor) then

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -4706,7 +4706,9 @@ function Private.ensurePRDFrame()
     personalRessourceDisplayFrame:SetScale(1);
     local frame = C_NamePlate.GetNamePlateForUnit("player");
     if (frame) then
-      if (frame.kui and frame.kui.bg and frame.kui:IsShown()) then
+      if (Plater and frame.Plater and frame.unitFrame.Plater) then
+		personalRessourceDisplayFrame:Attach(frame, frame.unitFrame.healthBar, frame.unitFrame.powerBar);
+	  elseif (frame.kui and frame.kui.bg and frame.kui:IsShown()) then
         personalRessourceDisplayFrame:Attach(frame.kui, frame.kui.bg, frame.kui.bg);
       elseif (ElvUIPlayerNamePlateAnchor) then
         personalRessourceDisplayFrame:Attach(ElvUIPlayerNamePlateAnchor, ElvUIPlayerNamePlateAnchor, ElvUIPlayerNamePlateAnchor);
@@ -4730,7 +4732,9 @@ function Private.ensurePRDFrame()
       if (UnitIsUnit(nameplate, "player")) then
         local frame = C_NamePlate.GetNamePlateForUnit("player");
         if (frame) then
-          if (frame.kui and frame.kui.bg and frame.kui:IsShown()) then
+          if (Plater and frame.Plater and frame.unitFrame.Plater) then
+			personalRessourceDisplayFrame:Attach(frame, frame.unitFrame.healthBar, frame.unitFrame.powerBar);
+          elseif (frame.kui and frame.kui.bg and frame.kui:IsShown()) then
             personalRessourceDisplayFrame:Attach(frame.kui, KuiNameplatesPlayerAnchor, KuiNameplatesPlayerAnchor);
           elseif (ElvUIPlayerNamePlateAnchor) then
             personalRessourceDisplayFrame:Attach(ElvUIPlayerNamePlateAnchor, ElvUIPlayerNamePlateAnchor, ElvUIPlayerNamePlateAnchor);


### PR DESCRIPTION
# Description
Adding support for Plater personal resource frame anchoring.
<!-- A #ticketNumber will be sufficient. -->
Fixes https://github.com/Tercioo/Plater-Nameplates/issues/71

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested

- [X] Test with stock Plater personal resource bar and this group of anchored WAs: https://wago.io/n8tDyoqqt
- [X] Test with "moved" Plater personal resource bar with the above group and this Plater mod: https://wago.io/yobXEcUZW

## Checklist
<!-- These can be checked off after the pull request is submitted, in case you want discussion before they are completely ready -->

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

<!-- Is there any additional work that needs to be done? If so, add it to the above list -->
