### PR TITLE
Add "Tooltip on Mouseover" support to Text

### DIFF
--- a/WeakAuras/RegionTypes/Text.lua
+++ b/WeakAuras/RegionTypes/Text.lua
@@ -95,6 +95,21 @@ local function modify(parent, region, data)
   region:SetWidth(region.width);
   region:SetHeight(region.height);
 
+  local tooltipType = Private.CanHaveTooltip(data);
+  if(tooltipType and data.useTooltip) then
+    if not region.tooltipFrame then
+      region.tooltipFrame = CreateFrame("frame", nil, region);
+      region.tooltipFrame:SetAllPoints(region);
+      region.tooltipFrame:SetScript("OnEnter", function()
+        Private.ShowMouseoverTooltip(region, region);
+      end);
+      region.tooltipFrame:SetScript("OnLeave", Private.HideTooltip);
+    end
+    region.tooltipFrame:EnableMouse(true);
+  elseif region.tooltipFrame then
+    region.tooltipFrame:EnableMouse(false);
+  end
+
   text:SetTextHeight(data.fontSize);
   text:SetShadowColor(unpack(data.shadowColor))
   text:SetShadowOffset(data.shadowXOffset, data.shadowYOffset)

--- a/WeakAurasOptions/RegionOptions/Text.lua
+++ b/WeakAurasOptions/RegionOptions/Text.lua
@@ -247,6 +247,14 @@ local function createOptions(id, data)
       }
     },
 
+    useTooltip = {
+      type = "toggle",
+      width = WeakAuras.normalWidth,
+      name = L["Tooltip on Mouseover"],
+      hidden = function() return not OptionsPrivate.Private.CanHaveTooltip(data) end,
+      order = 51
+    },
+
     endHeader = {
       type = "header",
       order = 100,


### PR DESCRIPTION
# Description

Aura and Icon can both display tooltips on mouseover in certain situations.  Add the same feature to Text.

I am trying to create "data text" WeakAuras like the old [SLDataText](https://www.wowinterface.com/downloads/info8539-SLDataText.html).  These are Texts displaying basic information, sometimes with additional information in a tooltip on mouseover.  For example, the "ping" text shows one value returned from `GetNetStats`.  When mousing over the displayed value, all of the values returned from `GetNetStats` are displayed in a tooltip.

The [TSU docs](https://github.com/WeakAuras/WeakAuras2/wiki/Trigger-State-Updater-(TSU)#tooltips) make it seem like they would be an appropriate way to accomplish this by stating: "TSU triggers have the 'Tooltip on Mouseover' option available by default in the Display tab."  However, this is not true for Text.  There does not seem to be a reason why it couldn't be.

This PR copies code and option definitions straight from Icon into Text.

An alternative solution is to use an Icon WA with a fake 0% alpha icon providing the tooltip, overlaid on the text.  However, just supporting tooltips in Text seems like a better solution.

## Type of change

- [x] New feature (non-breaking change which adds functionality

## How Has This Been Tested

https://wago.io/TiTa2ecqo in Classic.

Without my changes, no tooltip on mouseover.  With my changes, there is an option in Display that, when checked, shows a tooltip configured in the TSU on mouseover.


![InkedWoWScrnShot_111520_141445_LI](https://user-images.githubusercontent.com/5225653/99194447-72632f80-274d-11eb-83da-3153a4115669.jpg)

![WoWScrnShot_111420_200703](https://user-images.githubusercontent.com/5225653/99160535-51033480-26b6-11eb-96f9-1d8f1e164edb.jpg)


## Checklist
<!-- These can be checked off after the pull request is submitted, in case you want discussion before they are completely ready -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

<!-- Is there any additional work that needs to be done? If so, add it to the above list -->
