### PR TITLE
Improve Bonus Id trigger.

### DIFF
--- a/WeakAuras/GenericTrigger.lua
+++ b/WeakAuras/GenericTrigger.lua
@@ -3820,6 +3820,23 @@ WeakAuras.CheckForItemBonusId = function(ids)
   return false
 end
 
+WeakAuras.GetBonusIdInfo = function(ids)
+  if WeakAuras.IsClassic() then
+    return
+  end
+  for id in tostring(ids):gmatch('([^,]+)') do
+    local findID = ":" .. tostring(id:trim()) .. ":"
+    for slot in pairs(Private.item_slot_types) do
+      local itemLink = GetInventoryItemLink('player', slot)
+      if itemLink and itemLink:find(findID, 1, true) then
+        local itemID, _, _, _, icon = GetItemInfoInstant(itemLink)
+        local itemName = itemLink:match("%[(.*)%]")
+        return id, itemID, itemName, icon, slot, Private.item_slot_types[slot]
+      end
+    end
+  end
+end
+
 WeakAuras.GetItemSubClassInfo = function(i)
   local subClassId = i % 256
   local classId = (i - subClassId) / 256

--- a/WeakAuras/Legendaries.lua
+++ b/WeakAuras/Legendaries.lua
@@ -1,5 +1,5 @@
 if not WeakAuras.IsCorrectVersion() then return end
-local AddonName, OptionsPrivate = ...
+local AddonName, Private = ...
 
 -- Legendaries based on https://wow.tools/dbc/?dbc=runeforgelegendaryability
 -- mapping legendary id to bonus id
@@ -206,6 +206,11 @@ local legendariesToBonusId = {
   [206] = 7159,
 }
 
+local bonusIdToLegendary = {}
+for k, v in pairs(legendariesToBonusId) do
+  bonusIdToLegendary[v] = k
+end
+
 WeakAuras.GetLegendariesBonusIds = function()
   if WeakAuras.IsClassic() then
     return ""
@@ -232,4 +237,14 @@ WeakAuras.GetLegendariesBonusIds = function()
     result = result .. "|T".. abilities[name][2] .. ":16|t  " ..  name .. ": " .. abilities[name][1] .. "\n"
   end
   return result
+end
+
+WeakAuras.GetLegendaryIcon = function(id)
+  if WeakAuras.IsClassic() then
+    return ""
+  end
+  local legendaryID = bonusIdToLegendary[tonumber(id)]
+  if legendaryID then
+    return C_LegendaryCrafting.GetRuneforgePowerInfo(legendaryID).iconFileID
+  end
 end

--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -6351,17 +6351,75 @@ Private.event_prototypes = {
     internal_events = { "WA_DELAYED_PLAYER_ENTERING_WORLD", },
     force_events = "UNIT_INVENTORY_CHANGED",
     name = L["Item Bonus Id Equipped"],
+    statesParameter = "one",
+    init = function(trigger)
+      local ret = [=[
+        local useLegendaryIcon = %s
+        local itemBonusId, itemId, itemName, itemIcon, itemSlot, itemSlotString = WeakAuras.GetBonusIdInfo(%q)
+        local itemBonusId = tonumber(itemBonusId)
+        local icon = useLegendaryIcon and WeakAuras.GetLegendaryIcon(itemBonusId) or itemIcon
+      ]=]
+      return ret:format(trigger.use_legendaryIcon and "true" or "false", trigger.itemBonusId)
+    end,
     args = {
       {
         name = "itemBonusId",
         display = L["Item Bonus Id"],
         type = "string",
-        test = "WeakAuras.CheckForItemBonusId(%q)",
+        store = "true",
+        test = "itemBonusId",
         required = true,
         desc = function()
           return WeakAuras.GetLegendariesBonusIds()
           .. L["\n\nSupports multiple entries, separated by commas"]
-        end
+        end,
+        conditionType = "number",
+      },
+      {
+        name = "legendaryIcon",
+        display = L["Use Legendary Power Icon"],
+        type = "toggle",
+        test = "true",
+        desc = L["Displays the icon for the Legendary Power that matches this bonus id."],
+      },
+      {
+        name = "name",
+        display = L["Item Name"],
+        hidden = "true",
+        init = "itemName",
+        store = "true",
+        test = "true",
+      },
+      {
+        name = "icon",
+        hidden = "true",
+        init = "icon or 'Interface\\Icons\\INV_Misc_QuestionMark'",
+        store = "true",
+        test = "true",
+      },
+      {
+        name = "itemId",
+        display = L["Item Id"],
+        hidden = "true",
+        store = "true",
+        test = "true",
+        conditionType = "number",
+        operator_types = "only_equal",
+      },
+      {
+        name = "itemSlot",
+        display = L["Item Slot"],
+        type = "select",
+        store = "true",
+        conditionType = "select",
+        values = "item_slot_types",
+      },
+      {
+        name = "itemSlotString",
+        display = L["Item Slot String"],
+        hidden = "true",
+        store = "true",
+        test = "true",
       },
     },
     automaticrequired = true

--- a/WeakAuras/WeakAuras.toc
+++ b/WeakAuras/WeakAuras.toc
@@ -65,3 +65,6 @@ SubRegionTypes\Border.lua
 SubRegionTypes\Glow.lua
 SubRegionTypes\Tick.lua
 SubRegionTypes\BarModel.lua
+
+# misc
+Legendaries.lua

--- a/WeakAurasOptions/WeakAurasOptions.toc
+++ b/WeakAurasOptions/WeakAurasOptions.toc
@@ -72,8 +72,6 @@ OptionsFrames\TexturePicker.lua
 OptionsFrames\MoverSizer.lua
 OptionsFrames\FrameChooser.lua
 
-Legendaries.lua
-
 AceGUI-Widgets\AceGUIWidget-WeakAurasExpand.lua
 AceGUI-Widgets\AceGUIWidget-WeakAurasExpandSmall.lua
 AceGUI-Widgets\AceGUIWidget-WeakAurasIcon.lua


### PR DESCRIPTION
# Description

Changes the following:
* Adds state variables and conditions for bonus id, item id, item name,
icon, and item slot.
* Adds toggle to use Legendary icon instead of item icon. Fallbacks to
item icon.
* Adds option to check for bonus id on specific slot.
* Moves Legendaries.lua from WeakAurasOptions to WeakAuras.

Fixes #(2775)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested

All trigger, display tab, and condition options were tested on a level 60 with a legendary on retail WoW.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings

