### PR TITLE
add tab space setting

### DIFF
--- a/WeakAurasOptions/OptionsFrames/TextEditor.lua
+++ b/WeakAurasOptions/OptionsFrames/TextEditor.lua
@@ -53,6 +53,7 @@ local editor_themes = {
   }
 }
 
+if not WeakAurasSaved.editor_tab_spaces then WeakAurasSaved.editor_tab_spaces = 4 end
 local color_scheme = {[0] = "|r"}
 local function set_scheme()
   if not WeakAurasSaved.editor_theme then
@@ -168,7 +169,7 @@ local function ConstructTextEditor(frame)
   -- display we ned the original, so save it here.
   local originalGetText = editor.editBox.GetText
   set_scheme()
-  IndentationLib.enable(editor.editBox, color_scheme, 4)
+  IndentationLib.enable(editor.editBox, color_scheme, WeakAurasSaved.editor_tab_spaces)
 
   local cancel = CreateFrame("Button", nil, group.frame, "UIPanelButtonTemplate")
   cancel:SetScript(
@@ -229,33 +230,62 @@ local function ConstructTextEditor(frame)
   local dropdown = CreateFrame("Frame", "SettingsMenuFrame", settings_frame, "UIDropDownMenuTemplate")
 
   local function settings_dropdown_initialize(frame, level, menu)
-    for k, v in pairs(editor_themes) do
-      local item = {
-        text = k,
-        isNotRadio = false,
-        checked = function()
-          return WeakAurasSaved.editor_theme == k
-        end,
-        func = function()
-          WeakAurasSaved.editor_theme = k
-          set_scheme()
-          editor.editBox:SetText(editor.editBox:GetText())
-        end
-      }
-      UIDropDownMenu_AddButton(item)
+    if level == 1 then
+      for k, v in pairs(editor_themes) do
+        local item = {
+          text = k,
+          isNotRadio = false,
+          checked = function()
+            return WeakAurasSaved.editor_theme == k
+          end,
+          func = function()
+            WeakAurasSaved.editor_theme = k
+            set_scheme()
+            editor.editBox:SetText(editor.editBox:GetText())
+          end
+        }
+        UIDropDownMenu_AddButton(item, level)
+      end
+      UIDropDownMenu_AddButton(
+        {
+          text = L["Bracket Matching"],
+          isNotRadio = true,
+          checked = function()
+            return WeakAurasSaved.editor_bracket_matching
+          end,
+          func = function()
+            WeakAurasSaved.editor_bracket_matching = not WeakAurasSaved.editor_bracket_matching
+          end
+        },
+      level)
+      UIDropDownMenu_AddButton(
+        {
+          text = L["Tab Spaces"],
+          hasArrow = true,
+          notCheckable = true,
+          menuList = "spaces"
+        },
+      level)
+    elseif menu == "spaces" then
+      local spaces = {2,4,6}
+      for _, i in pairs(spaces) do
+        UIDropDownMenu_AddButton(
+          {
+            text = i,
+            isNotRadio = false,
+            checked = function()
+              return WeakAurasSaved.editor_tab_spaces == i
+            end,
+            func = function()
+              WeakAurasSaved.editor_tab_spaces = i
+              IndentationLib.enable(editor.editBox, color_scheme, WeakAurasSaved.editor_tab_spaces)
+              editor.editBox:SetText(editor.editBox:GetText().."\n")
+              IndentationLib.indentEditbox(editor.editBox)
+            end
+          },
+        level)
+      end
     end
-    UIDropDownMenu_AddButton(
-      {
-        text = L["Bracket Matching"],
-        isNotRadio = true,
-        checked = function()
-          return WeakAurasSaved.editor_bracket_matching
-        end,
-        func = function()
-          WeakAurasSaved.editor_bracket_matching = not WeakAurasSaved.editor_bracket_matching
-        end
-      }
-    )
   end
   UIDropDownMenu_Initialize(dropdown, settings_dropdown_initialize, "MENU")
 

--- a/WeakAurasOptions/OptionsFrames/TextEditor.lua
+++ b/WeakAurasOptions/OptionsFrames/TextEditor.lua
@@ -260,14 +260,14 @@ local function ConstructTextEditor(frame)
       level)
       UIDropDownMenu_AddButton(
         {
-          text = L["Tab Spaces"],
+          text = L["Indent Size"],
           hasArrow = true,
           notCheckable = true,
           menuList = "spaces"
         },
       level)
     elseif menu == "spaces" then
-      local spaces = {2,4,6}
+      local spaces = {2,3,4}
       for _, i in pairs(spaces) do
         UIDropDownMenu_AddButton(
           {

--- a/WeakAurasOptions/OptionsFrames/TextEditor.lua
+++ b/WeakAurasOptions/OptionsFrames/TextEditor.lua
@@ -267,7 +267,7 @@ local function ConstructTextEditor(frame)
         },
       level)
     elseif menu == "spaces" then
-      local spaces = {2,3,4}
+      local spaces = {2,4}
       for _, i in pairs(spaces) do
         UIDropDownMenu_AddButton(
           {


### PR DESCRIPTION
# Description

Adds a menu to the Settings dropdown in the Editor to allow changing the number of tab spaces. 4 is a bit big when people are used to 2, and with Lua indenting so much. 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Checklist
<!-- These can be checked off after the pull request is submitted, in case you want discussion before they are completely ready -->

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

<!-- Is there any additional work that needs to be done? If so, add it to the above list -->
