### PR TITLE
Add talent table to data stub.

### DIFF
--- a/WeakAuras/Types.lua
+++ b/WeakAuras/Types.lua
@@ -2503,6 +2503,9 @@ WeakAuras.data_stub = {
     class = {
       multi = {},
     },
+    talent = {
+      multi = {},
+    },
   },
   actions = {
     init = {},


### PR DESCRIPTION
# Description

With the removal of old modernization data, the old format of talent load data was throwing errors when imported.

This issue was reported twice on discord.

See https://pastebin.com/4J88N5Mb for error.
See https://wago.io/E1ac3_Z9z for aura that when imported, causes issues.

These errors prevent WA from functioning in its entirety.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

- [x] Loaded a broken SV file containing the data.
- [x] Imported the above aura.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] My changes generate no new warnings


It's possible that this isn't the only change necessary, but this is the only occurrence I've seen and I've seen it twice thus far.