### PR TITLE
Spell/Item in Range triggers

### DIFF
--- a/WeakAuras/GenericTrigger.lua
+++ b/WeakAuras/GenericTrigger.lua
@@ -1030,7 +1030,7 @@ function GenericTrigger.LoadDisplays(toLoad, loadEvent, ...)
               if not genericTriggerRegisteredEvents["COMBAT_LOG_EVENT_UNFILTERED"] then
                 eventsToRegister["COMBAT_LOG_EVENT_UNFILTERED"] = true;
               end
-            elseif (event == "FRAME_UPDATE") then
+            elseif (event == "FRAME_UPDATE") or (event == "WA_SPELL_RANGECHECK") then
               register_for_frame_updates = true;
             else
               if (genericTriggerRegisteredEvents[event]) then
@@ -1386,6 +1386,7 @@ do
   local update_frame = nil
   WeakAuras.frames["Custom Trigger Every Frame Updater"] = update_frame;
   local updating = false;
+  local rangeThrottle = 0
 
   function Private.RegisterEveryFrameUpdate(id)
     if not(update_clients[id]) then
@@ -1399,6 +1400,10 @@ do
       update_frame:SetScript("OnUpdate", function()
         if not(WeakAuras.IsPaused()) then
           WeakAuras.ScanEvents("FRAME_UPDATE");
+          if (not rangeThrottle or GetTime() - rangeThrottle > 0.2) then
+            rangeThrottle = GetTime()
+            WeakAuras.ScanEvents("WA_SPELL_RANGECHECK")
+          end
         end
       end);
       updating = true;

--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -7897,6 +7897,129 @@ Private.event_prototypes = {
     automaticrequired = true
   },
 
+  ["Spell in Range"] = {
+    type = "status",
+    events = {
+      ["events"] = {
+        "PLAYER_TARGET_CHANGED",
+        "WA_SPELL_RANGECHECK",
+      }
+    },
+    name = L["Spell in Range"],
+    init = function(trigger)
+      trigger.unit = trigger.unit or "target"
+      trigger.spellName = trigger.spellName or 0
+      local spellName
+      if (trigger.use_exact_spell) then
+        spellName = trigger.spellName
+      else
+        spellName = type(trigger.spellName) == "number" and GetSpellInfo(trigger.spellName) or trigger.spellName
+      end
+      trigger.realSpell = spellName
+      -- IsSpellInRange returns nil for no target, 0 for out of range, and 1 for in range.
+      local ret = [=[
+          local unit = %q
+          local spell = %q
+          local inverse = %s
+          local targetRequired = %s
+
+          local range = WeakAuras.IsSpellInRange(spell, unit)
+          if range then
+            inRange = (range == 1) == not inverse
+          else
+            inRange = inverse and not targetRequired
+          end
+
+          local name, rank, icon, _, minRange, maxRange = GetSpellInfo(spell)
+      ]=]
+      return ret:format(trigger.unit, spellName, trigger.use_inverse and "true" or "false", trigger.use_targetRequired and "true" or "false")
+    end,
+    statesParameter = "one",
+    args = {
+      {
+        name = "unit",
+        display = L["Unit"],
+        required = true,
+        type = "unit",
+        values = "unit_types_range_check",
+        test = "true",
+        store = true
+      },
+      {
+        name = "spellName",
+        display = L["Spell"],
+        required = true,
+        type = "spell",
+        test = "true",
+        showExactOption = true,
+      },
+      {
+        name = "inverse",
+        display = L["Inverse"],
+        type = "toggle",
+        test = "true",
+      },
+      {
+        name = "targetRequired",
+        display = L["Require Valid Target"],
+        type = "toggle",
+        enable = function(trigger)
+          return trigger.use_inverse
+        end,
+        test = "true",
+      },
+      {
+        name = "minRange",
+        display = L["Spell Min Range"],
+        hidden = "true",
+        store = "true",
+        test = "true",
+      },
+      {
+        name = "maxRange",
+        display = L["Spell Max Range"],
+        hidden = "true",
+        store = "true",
+        test = "true",
+      },
+      {
+        name = "unitName",
+        display = L["Unit Name"],
+        hidden = "true",
+        store = "true",
+        test = "true",
+        init = "GetUnitName(unit)",
+      },
+      {
+        name = "icon",
+        hidden = "true",
+        init = "icon or 'Interface/Icons/INV_Misc_QuestionMark'",
+        store = "true",
+        test = "true",
+      },
+      {
+        name = "rank",
+        display = L["Spell Rank"],
+        hidden = "true",
+        store = "true",
+        test = "true",
+      },
+      {
+        name = "name",
+        display = L["Spell Name"],
+        hidden = "true",
+        store = "true",
+        test = "true",
+        init = "name"
+      },
+      {
+        hidden = true,
+        test = "inRange",
+      }
+    },
+    hasSpellID = true,
+    automaticrequired = true
+  },
 };
 
 if WeakAuras.IsClassic() then

--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -8020,6 +8020,105 @@ Private.event_prototypes = {
     hasSpellID = true,
     automaticrequired = true
   },
+
+  ["Item in Range"] = {
+    type = "status",
+    events = {
+      ["events"] = {
+        "PLAYER_TARGET_CHANGED",
+        "WA_SPELL_RANGECHECK",
+      }
+    },
+    name = L["Item in Range"],
+    init = function(trigger)
+      trigger.unit = trigger.unit or "target"
+      trigger.itemName = trigger.itemName or 0
+      local itemName = type(trigger.itemName) == "number" and trigger.itemName or "[["..trigger.itemName.."]]"
+      -- IsItemInRange returns nil for no target, false for out of range, and true for in range.
+      local ret = [=[
+          local unit = %q
+          local item = %q
+          local inverse = %s
+          local targetRequired = %s
+
+          local range = IsItemInRange(item, unit)
+          if range ~= nil then
+            inRange = range == not inverse
+          else
+            inRange = inverse and not targetRequired
+          end
+
+          local name, _, _, _, _, _, _, _, _, icon = GetItemInfo(item);
+          name = name or "Invalid"
+          if not icon then
+            local _, _, _, _, icon = GetItemInfoInstant(item)
+          end
+      ]=]
+      return ret:format(trigger.unit, itemName, trigger.use_inverse and "true" or "false", trigger.use_targetRequired and "true" or "false")
+    end,
+    statesParameter = "one",
+    args = {
+      {
+        name = "unit",
+        display = L["Unit"],
+        required = true,
+        type = "unit",
+        values = "unit_types_range_check",
+        test = "true",
+        store = true
+      },
+      {
+        name = "itemName",
+        display = L["Item"],
+        required = true,
+        type = "item",
+        test = "true",
+      },
+      {
+        name = "inverse",
+        display = L["Inverse"],
+        type = "toggle",
+        test = "true",
+      },
+      {
+        name = "targetRequired",
+        display = L["Require Valid Target"],
+        type = "toggle",
+        enable = function(trigger)
+          return trigger.use_inverse
+        end,
+        test = "true",
+      },
+      {
+        name = "unitName",
+        display = L["Unit Name"],
+        hidden = "true",
+        store = "true",
+        test = "true",
+        init = "GetUnitName(unit)",
+      },
+      {
+        name = "icon",
+        hidden = "true",
+        init = "icon or 'Interface/Icons/INV_Misc_QuestionMark'",
+        store = "true",
+        test = "true",
+      },
+      {
+        name = "name",
+        display = L["Item Name"],
+        hidden = "true",
+        store = "true",
+        test = "true",
+      },
+      {
+        hidden = true,
+        test = "inRange",
+      }
+    },
+    hasItemID = true,
+    automaticrequired = true
+  },
 };
 
 if WeakAuras.IsClassic() then

--- a/WeakAuras/Types.lua
+++ b/WeakAuras/Types.lua
@@ -728,7 +728,8 @@ Private.unit_types_range_check = {
   target = L["Target"],
   focus = L["Focus"],
   pet = L["Pet"],
-  member = L["Specific Unit"]
+  mouseover = L["Mouseover"],
+  member = L["Specific Unit"],
 }
 
 Private.unit_threat_situation_types = {


### PR DESCRIPTION
# Description
Adds triggers for spell and item ranges. These are commonly requested on discord and the current options require the use of the conditions of another trigger.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested

- [x] Tested various spells on allied and enemy targets
- [x] Tested an item on allied targets
- [x] Created a new aura to avoid the mishap from the last PR

## Checklist
<!-- These can be checked off after the pull request is submitted, in case you want discussion before they are completely ready -->

- [ ] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings