### PR TITLE
Bonus Id Trigger fixes and inverse option.

### DIFF
--- a/WeakAuras/Legendaries.lua
+++ b/WeakAuras/Legendaries.lua
@@ -239,12 +239,14 @@ WeakAuras.GetLegendariesBonusIds = function()
   return result
 end
 
-WeakAuras.GetLegendaryIcon = function(id)
+WeakAuras.GetLegendaryData = function(id)
   if WeakAuras.IsClassic() then
     return ""
   end
   local legendaryID = bonusIdToLegendary[tonumber(id)]
   if legendaryID then
-    return C_LegendaryCrafting.GetRuneforgePowerInfo(legendaryID).iconFileID
+    local data = C_LegendaryCrafting.GetRuneforgePowerInfo(legendaryID)
+    return data.name, data.iconFileID
   end
 end
+

--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -6394,7 +6394,7 @@ Private.event_prototypes = {
       {
         name = "icon",
         hidden = "true",
-        init = "icon or 'Interface\\Icons\\INV_Misc_QuestionMark'",
+        init = "icon or 'Interface/Icons/INV_Misc_QuestionMark'",
         store = "true",
         test = "true",
       },

--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -6356,12 +6356,21 @@ Private.event_prototypes = {
     init = function(trigger)
       trigger.itemBonusId = trigger.itemBonusId or ""
       local ret = [=[
-        local useLegendaryIcon = %s
-        local itemBonusId, itemId, itemName, itemIcon, itemSlot, itemSlotString = WeakAuras.GetBonusIdInfo(%q)
+        local fetchLegendaryPower = %s
+        local item = %q
+        local inverse = %s
+        local useItemSlot, slotSelected = %s, %d
+
+        local itemBonusId, itemId, itemName, icon, itemSlot, itemSlotString = WeakAuras.GetBonusIdInfo(item)
         local itemBonusId = tonumber(itemBonusId)
-        local icon = useLegendaryIcon and WeakAuras.GetLegendaryIcon(itemBonusId) or itemIcon
+        if fetchLegendaryPower then
+          itemName, icon = WeakAuras.GetLegendaryData(itemBonusId or item)
+        end
+
+        local slotValidation = (useItemSlot and itemSlot == slotSelected) or (not useItemSlot)
       ]=]
-      return ret:format(trigger.use_legendaryIcon and "true" or "false", trigger.itemBonusId)
+      return ret:format(trigger.use_legendaryIcon and "true" or "false", trigger.itemBonusId, trigger.use_inverse and "true" or "false",
+                        trigger.use_itemSlot and "true" or "false", trigger.itemSlot)
     end,
     args = {
       {
@@ -6369,7 +6378,7 @@ Private.event_prototypes = {
         display = L["Item Bonus Id"],
         type = "string",
         store = "true",
-        test = "itemBonusId",
+        test = "true",
         required = true,
         desc = function()
           return WeakAuras.GetLegendariesBonusIds()
@@ -6379,10 +6388,10 @@ Private.event_prototypes = {
       },
       {
         name = "legendaryIcon",
-        display = L["Use Legendary Power Icon"],
+        display = L["Fetch Legendary Power"],
         type = "toggle",
         test = "true",
-        desc = L["Displays the icon for the Legendary Power that matches this bonus id."],
+        desc = L["Fetches the name and icon of the Legendary Power that matches this bonus id."],
       },
       {
         name = "name",
@@ -6415,6 +6424,13 @@ Private.event_prototypes = {
         store = "true",
         conditionType = "select",
         values = "item_slot_types",
+        test = "true",
+      },
+      {
+        name = "inverse",
+        display = L["Inverse"],
+        type = "toggle",
+        test = "true",
       },
       {
         name = "itemSlotString",
@@ -6423,6 +6439,10 @@ Private.event_prototypes = {
         store = "true",
         test = "true",
       },
+      {
+        hidden = true,
+        test = "not inverse == (itemBonusId and slotValidation or false)",
+      }
     },
     automaticrequired = true
   },

--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -6354,7 +6354,6 @@ Private.event_prototypes = {
     name = L["Item Bonus Id Equipped"],
     statesParameter = "one",
     init = function(trigger)
-      trigger.itemBonusId = trigger.itemBonusId or ""
       local ret = [=[
         local fetchLegendaryPower = %s
         local item = %q
@@ -6369,7 +6368,7 @@ Private.event_prototypes = {
 
         local slotValidation = (useItemSlot and itemSlot == slotSelected) or (not useItemSlot)
       ]=]
-      return ret:format(trigger.use_legendaryIcon and "true" or "false", trigger.itemBonusId, trigger.use_inverse and "true" or "false",
+      return ret:format(trigger.use_legendaryIcon and "true" or "false", trigger.itemBonusId or "", trigger.use_inverse and "true" or "false",
                         trigger.use_itemSlot and "true" or "false", trigger.itemSlot)
     end,
     args = {

--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -6354,13 +6354,14 @@ Private.event_prototypes = {
     name = L["Item Bonus Id Equipped"],
     statesParameter = "one",
     init = function(trigger)
+      trigger.itemBonusId = trigger.itemBonusId or ""
       local ret = [=[
         local useLegendaryIcon = %s
         local itemBonusId, itemId, itemName, itemIcon, itemSlot, itemSlotString = WeakAuras.GetBonusIdInfo(%q)
         local itemBonusId = tonumber(itemBonusId)
         local icon = useLegendaryIcon and WeakAuras.GetLegendaryIcon(itemBonusId) or itemIcon
       ]=]
-      return ret:format(trigger.use_legendaryIcon and "true" or "false", trigger.itemBonusId or "")
+      return ret:format(trigger.use_legendaryIcon and "true" or "false", trigger.itemBonusId)
     end,
     args = {
       {


### PR DESCRIPTION
# Description

Adds an inverse option to the Item Bonus Id trigger. Will show Legendary Power Name and Icon if the option is selected (now renamed to cover both the icon and the fallback name).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested

- [x] Thoroughly tested all bugged behaviors
- [x] Thoroughly tested equipping and unequipping a legendary with inverse toggled both on and off
- [x] Created a brand new aura and selected this trigger to make sure the previous breaking bug no longer exists with this new fix

## Checklist

- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings
