### PR TITLE
Add filters and UnitAura options to TSU tooltips.

### DIFF
--- a/WeakAuras/GenericTrigger.lua
+++ b/WeakAuras/GenericTrigger.lua
@@ -3447,10 +3447,13 @@ function GenericTrigger.SetToolTip(trigger, state)
       GameTooltip:SetHyperlink("item:"..state.itemId..":0:0:0:0:0:0:0");
       return true
     elseif (state.unit and state.unitBuffIndex) then
-      GameTooltip:SetUnitBuff(state.unit, state.unitBuffIndex);
+      GameTooltip:SetUnitBuff(state.unit, state.unitBuffIndex, state.unitBuffFilter);
       return true
     elseif (state.unit and state.unitDebuffIndex) then
-      GameTooltip:SetUnitDebuff(state.unit, state.unitDebuffIndex);
+      GameTooltip:SetUnitDebuff(state.unit, state.unitDebuffIndex, state.unitDebuffFilter);
+      return true
+    elseif (state.unit and state.unitAuraIndex) then
+      GameTooltip:SetUnitAura(state.unit, state.unitAuraIndex, state.unitAuraFilter)
       return true
     end
   end


### PR DESCRIPTION
# Description

Allows TSU tooltips to optionally use filters via `unitBuffFilter` and
`unitDebuffFilter` state variables.
Adds an additional tooltip option for UnitAura with the same Index and
Filter options via `unitAuraIndex` and `unitAuraFilter` state variables.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested

- [x] Tested the new filters for auras/buffs using MAW auras
- [x] Tested not using a filter for buffs, debuffs, and auras to affirm previous behavior stayed intact

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

I particularly noticed this limitation when attempting to display proper tooltips for my stacking Torghast powers.
