### PR TITLE
Bonus Id Fixes

### DIFF
--- a/WeakAuras/GenericTrigger.lua
+++ b/WeakAuras/GenericTrigger.lua
@@ -3831,10 +3831,12 @@ WeakAuras.CheckForItemBonusId = function(ids)
   return false
 end
 
-WeakAuras.GetBonusIdInfo = function(ids)
+
+WeakAuras.GetBonusIdInfo = function(ids, specificSlot)
+  local checkSlots = specificSlot and {[specificSlot] = true} or Private.item_slot_types
   for id in tostring(ids):gmatch('([^,]+)') do
     local findID = ":" .. tostring(id:trim()) .. ":"
-    for slot in pairs(Private.item_slot_types) do
+    for slot in pairs(checkSlots) do
       local itemLink = GetInventoryItemLink('player', slot)
       if itemLink and itemLink:find(findID, 1, true) then
         local itemID, _, _, _, icon = GetItemInfoInstant(itemLink)

--- a/WeakAuras/GenericTrigger.lua
+++ b/WeakAuras/GenericTrigger.lua
@@ -3832,9 +3832,6 @@ WeakAuras.CheckForItemBonusId = function(ids)
 end
 
 WeakAuras.GetBonusIdInfo = function(ids)
-  if WeakAuras.IsClassic() then
-    return
-  end
   for id in tostring(ids):gmatch('([^,]+)') do
     local findID = ":" .. tostring(id:trim()) .. ":"
     for slot in pairs(Private.item_slot_types) do

--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -6349,7 +6349,7 @@ Private.event_prototypes = {
         local inverse = %s
         local useItemSlot, slotSelected = %s, %d
 
-        local itemBonusId, itemId, itemName, icon, itemSlot, itemSlotString = WeakAuras.GetBonusIdInfo(item)
+        local itemBonusId, itemId, itemName, icon, itemSlot, itemSlotString = WeakAuras.GetBonusIdInfo(item, useItemSlot and slotSelected)
         local itemBonusId = tonumber(itemBonusId)
         if fetchLegendaryPower then
           itemName, icon = WeakAuras.GetLegendaryData(itemBonusId or item)

--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -6380,6 +6380,8 @@ Private.event_prototypes = {
         type = "toggle",
         test = "true",
         desc = L["Fetches the name and icon of the Legendary Power that matches this bonus id."],
+        enable = not WeakAuras.IsClassic(),
+        hidden = WeakAuras.IsClassic(),
       },
       {
         name = "name",


### PR DESCRIPTION
# Description

Allows the Bonus Id trigger to work in Classic again. I don't remember doing this originally, but it's fixed now. In addition, prevented the Legendary setting from displaying in Classic.
Fixes bonus IDs on multiple items when using the Item Slot setting.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

- [x] Tested the trigger in Classic
- [x] Thoroughly tested a bonus id that existed on all of my gear with every combination of Inverse and Item Slot settings.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] My changes generate no new warnings