### PR TITLE
Cast trigger: add latency overlay

### DIFF
--- a/WeakAuras/GenericTrigger.lua
+++ b/WeakAuras/GenericTrigger.lua
@@ -729,9 +729,6 @@ function WeakAuras.ScanEventsInternal(event_list, event, arg1, arg2, ... )
     local updateTriggerState = false;
     for triggernum, data in pairs(triggers) do
       local allStates = WeakAuras.GetTriggerStateForTrigger(id, triggernum);
-      if event == "CURRENT_SPELL_CAST_CHANGED" then -- hack for Cast trigger latency
-        arg1 = "player"
-      end
       if (RunTriggerFunc(allStates, data, id, triggernum, event, arg1, arg2, ...)) then
         updateTriggerState = true;
       end
@@ -3175,6 +3172,23 @@ do
       petFrame:SetScript("OnEvent", function(event, unit)
         Private.StartProfileSystem("generictrigger")
         WeakAuras.ScanEvents("PET_UPDATE", "pet")
+        Private.StopProfileSystem("generictrigger")
+      end)
+    end
+  end
+end
+
+-- Cast Latency
+do
+  local castLatencyFrame
+  WeakAuras.frames["Cast Latency Handler"] = castLatencyFrame
+  function WeakAuras.WatchForCastLatency()
+    if not castLatencyFrame then
+      castLatencyFrame = CreateFrame("Frame")
+      castLatencyFrame:RegisterEvent("CURRENT_SPELL_CAST_CHANGED")
+      castLatencyFrame:SetScript("OnEvent", function(event)
+        Private.StartProfileSystem("generictrigger")
+        WeakAuras.ScanEvents("CAST_LATENCY_UPDATE", "player")
         Private.StopProfileSystem("generictrigger")
       end)
     end

--- a/WeakAuras/GenericTrigger.lua
+++ b/WeakAuras/GenericTrigger.lua
@@ -3180,7 +3180,7 @@ end
 
 -- Cast Latency
 do
-  local castLatencyFrame
+  local castLatencyFrame = nil
   WeakAuras.frames["Cast Latency Handler"] = castLatencyFrame
   function WeakAuras.WatchForCastLatency()
     if not castLatencyFrame then

--- a/WeakAuras/GenericTrigger.lua
+++ b/WeakAuras/GenericTrigger.lua
@@ -729,6 +729,9 @@ function WeakAuras.ScanEventsInternal(event_list, event, arg1, arg2, ... )
     local updateTriggerState = false;
     for triggernum, data in pairs(triggers) do
       local allStates = WeakAuras.GetTriggerStateForTrigger(id, triggernum);
+      if event == "CURRENT_SPELL_CAST_CHANGED" then -- hack for Cast trigger latency
+        arg1 = "player"
+      end
       if (RunTriggerFunc(allStates, data, id, triggernum, event, arg1, arg2, ...)) then
         updateTriggerState = true;
       end

--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -6851,8 +6851,9 @@ Private.event_prototypes = {
       end
       AddUnitEventForEvents(result, unit, "UNIT_TARGET")
       if trigger.use_showLatency and unit == "player" then
+        WeakAuras.WatchForCastLatency()
         result.events = result.events or {}
-        tinsert(result.events, "CURRENT_SPELL_CAST_CHANGED")
+        tinsert(result.events, "CAST_LATENCY_UPDATE")
       end
       return result
     end,
@@ -6910,7 +6911,7 @@ Private.event_prototypes = {
 
       if trigger.unit == "player" and trigger.use_showLatency then
         ret = ret .. [[
-          if event == "CURRENT_SPELL_CAST_CHANGED" then
+          if event == "CAST_LATENCY_UPDATE" then
             state.sendTime = GetTime()
           elseif event == "UNIT_SPELLCAST_START" and tonumber(state.sendTime) then
             state.latency = GetTime() - state.sendTime

--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -6851,7 +6851,6 @@ Private.event_prototypes = {
       end
       AddUnitEventForEvents(result, unit, "UNIT_TARGET")
       if trigger.use_showLatency and unit == "player" then
-        WeakAuras.WatchForCastLatency()
         result.events = result.events or {}
         tinsert(result.events, "CAST_LATENCY_UPDATE")
       end
@@ -6868,6 +6867,11 @@ Private.event_prototypes = {
       AddUnitChangeInternalEvents(unit, result)
       AddUnitRoleChangeInternalEvents(unit, result)
       return result
+    end,
+    loadFunc = function(trigger)
+      if trigger.use_showLatency and trigger.unit == "player" then
+        WeakAuras.WatchForCastLatency()
+      end
     end,
     force_events = unitHelperFunctions.UnitChangedForceEvents,
     canHaveDuration = "timed",


### PR DESCRIPTION
# Description

New Overlay Latency option for Cast trigger using delay between CURRENT_SPELL_CAST_CHANGED and UNIT_SPELLCAST_START events

This is the method use by popular cast bar addon Quartz.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested

expected:
- stop casting a self heal before progress reach latency overlay = no heal
- stop casting a self heal after progress reach latency overlay and before full progress = heal

results: seems good :)

![image](https://user-images.githubusercontent.com/189656/105621102-6312f900-5e04-11eb-8713-659b0cdb9269.png)


## Additional comment

I don't like the hack in GenericTrigger.lua to make RunTriggerFunc not return false because of `statesParameter = "unit"` require an arg1, but i have not found a better way to do it