### PR TITLE
Make Time Formats more flexible

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -81,6 +81,8 @@ globals = {
 	"Mixin",
 	"Round",
 	"Saturate",
+	"SecondsFormatter",
+	"SecondsFormatterMixin",
 	"SecureButton_GetModifiedUnit",
 	"SlashCmdList",
 	"SearchBoxTemplate_OnTextChanged",

--- a/WeakAuras/BuffTrigger2.lua
+++ b/WeakAuras/BuffTrigger2.lua
@@ -162,6 +162,20 @@ local function IsSingleMissing(trigger)
   return not IsGroupTrigger(trigger) and trigger.matchesShowOn == "showOnMissing"
 end
 
+local function CanHaveMatchCheck(trigger)
+  if IsGroupTrigger(trigger) then
+    return true
+  end
+  if trigger.matchesShowOn == "showOnMissing" then
+    return false
+  end
+  if trigger.matchesShowOn == "showOnActive" or trigger.matchesShowOn == "showOnMatches" then
+    return true
+  end
+  -- Always: If clones are shown
+  return trigger.showClones
+end
+
 local function HasMatchCount(trigger)
   if IsGroupTrigger(trigger) then
     return trigger.useMatch_count
@@ -1931,22 +1945,22 @@ function BuffTrigger.Rename(oldid, newid)
 end
 
 local function createScanFunc(trigger)
-  local isSingleMissing = IsSingleMissing(trigger)
+  local canHaveMatchCheck = CanHaveMatchCheck(trigger)
   local isMulti = trigger.unit == "multi"
-  local useStacks = not isSingleMissing and not isMulti and trigger.useStacks
+  local useStacks = canHaveMatchCheck and not isMulti and trigger.useStacks
 
   local use_stealable, use_isBossDebuff, use_castByPlayer
-  if not isSingleMissing and not isMulti then
+  if canHaveMatchCheck and not isMulti then
     use_stealable = trigger.use_stealable
     use_isBossDebuff = trigger.use_isBossDebuff
     use_castByPlayer = trigger.use_castByPlayer
   end
-  local use_debuffClass = not isSingleMissing and not isMulti and trigger.use_debuffClass
-  local use_tooltip = not isSingleMissing and not isMulti and trigger.fetchTooltip and trigger.use_tooltip
-  local use_tooltipValue = not isSingleMissing and not isMulti and trigger.fetchTooltip and trigger.use_tooltipValue
-  local use_total = not isSingleMissing and not isMulti and trigger.useTotal and trigger.total
-  local use_ignore_name = not isSingleMissing and not isMulti and trigger.useIgnoreName and trigger.ignoreAuraNames
-  local use_ignore_spellId = not isSingleMissing and not isMulti and trigger.useIgnoreExactSpellId and trigger.ignoreAuraSpellids
+  local use_debuffClass = canHaveMatchCheck and not isMulti and trigger.use_debuffClass
+  local use_tooltip = canHaveMatchCheck and not isMulti and trigger.fetchTooltip and trigger.use_tooltip
+  local use_tooltipValue = canHaveMatchCheck and not isMulti and trigger.fetchTooltip and trigger.use_tooltipValue
+  local use_total = canHaveMatchCheck and not isMulti and trigger.useTotal and trigger.total
+  local use_ignore_name = canHaveMatchCheck and not isMulti and trigger.useIgnoreName and trigger.ignoreAuraNames
+  local use_ignore_spellId = canHaveMatchCheck and not isMulti and trigger.useIgnoreExactSpellId and trigger.ignoreAuraSpellids
 
   if not useStacks and use_stealable == nil and use_isBossDebuff == nil and use_castByPlayer == nil
        and not use_debuffClass and trigger.ownOnly == nil
@@ -2206,7 +2220,7 @@ function BuffTrigger.Add(data)
       local scanFunc = createScanFunc(trigger)
 
       local remFunc
-      if trigger.unit ~= "multi" and not IsSingleMissing(trigger) and trigger.useRem then
+      if trigger.unit ~= "multi" and CanHaveMatchCheck(trigger) and trigger.useRem then
         local remFuncStr = Private.function_strings.count:format(trigger.remOperator or ">=", tonumber(trigger.rem) or 0)
         remFunc = WeakAuras.LoadFunction(remFuncStr)
       end
@@ -2310,7 +2324,7 @@ function BuffTrigger.Add(data)
         perUnitMode = perUnitMode,
         scanFunc = scanFunc,
         remainingFunc = remFunc,
-        remainingCheck = trigger.unit ~= "multi" and not IsSingleMissing(trigger) and trigger.useRem and tonumber(trigger.rem) or 0,
+        remainingCheck = trigger.unit ~= "multi" and CanHaveMatchCheck(trigger) and trigger.useRem and tonumber(trigger.rem) or 0,
         id = id,
         triggernum = triggernum,
         compareFunc = trigger.combineMode == "showHighest" and highestExpirationTime or lowestExpirationTime,

--- a/WeakAuras/Conditions.lua
+++ b/WeakAuras/Conditions.lua
@@ -567,8 +567,8 @@ local function ConstructConditionFunction(data)
       end
     end
   end
-  ret = ret .. "  end\n";
   ret = ret .. recheckCode
+  ret = ret .. "  end\n";
 
   ret = ret .. "  if (recheckTime) then\n"
   ret = ret .. "    WeakAuras.scheduleConditionCheck(recheckTime, uid, cloneId);\n"
@@ -665,17 +665,22 @@ end
 local function runDynamicConditionFunctions(funcs)
   for uid in pairs(funcs) do
     local id = Private.UIDtoID(uid)
+    Private.StartProfileAura(id)
     if (Private.IsAuraActive(uid) and checkConditions[uid]) then
       local activeStates = WeakAuras.GetActiveStates(id)
       for cloneId, state in pairs(activeStates) do
-        local region = WeakAuras.GetRegion(id, cloneId);
-        checkConditions[uid](region, false);
+        local region = WeakAuras.GetRegion(id, cloneId)
+        Private.ActivateAuraEnvironmentForRegion(region)
+        checkConditions[uid](region, false)
+        Private.ActivateAuraEnvironment()
       end
     end
+    Private.StopProfileAura(id)
   end
 end
 
 local function handleDynamicConditions(self, event)
+  Private.StartProfileSystem("dynamic conditions")
   if (globalDynamicConditionFuncs[event]) then
     for i, func in ipairs(globalDynamicConditionFuncs[event]) do
       func(globalConditionState);
@@ -684,6 +689,7 @@ local function handleDynamicConditions(self, event)
   if (dynamicConditions[event]) then
     runDynamicConditionFunctions(dynamicConditions[event]);
   end
+  Private.StopProfileSystem("dynamic conditions")
 end
 
 local lastDynamicConditionsUpdateCheck;

--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -8212,12 +8212,13 @@ Private.dynamic_texts = {
         if not state.expirationTime or not state.duration then
           return nil
         end
-        local remaining  = state.expirationTime - GetTime();
+        local remaining = state.expirationTime - GetTime();
         return remaining >= 0 and remaining or nil
       end
     end,
     func = function(remaining, state, progressPrecision)
       progressPrecision = progressPrecision or 1
+
       if not state or state.progressType ~= "timed" then
         return remaining
       end

--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -5980,10 +5980,12 @@ Private.event_prototypes = {
         end
       ]];
 
+      local showOnActive = trigger.showOn == 'showOnActive' or not trigger.showOn
+
       return ret:format(trigger.weapon or "main",
       trigger.use_enchant and trigger.enchant or "",
-      trigger.use_stack and tonumber(trigger.stack or 0) or "nil",
-      trigger.use_remaining and tonumber(trigger.remaining or 0) or "nil",
+      showOnActive and trigger.use_stack and tonumber(trigger.stack or 0) or "nil",
+      showOnActive and trigger.use_remaining and tonumber(trigger.remaining or 0) or "nil",
       trigger.showOn or "showOnActive",
       trigger.stack_operator or "<",
       trigger.remaining_operator or "<")
@@ -6010,7 +6012,9 @@ Private.event_prototypes = {
         display = L["Stack Count"],
         type = "number",
         test = "true",
-        enable = WeakAuras.IsClassic(),
+        enable = function(trigger)
+          return WeakAuras.IsClassic() and (not trigger.showOn or trigger.showOn == "showOnActive")
+        end,
         hidden = not WeakAuras.IsClassic(),
         store = true
       },
@@ -6065,7 +6069,10 @@ Private.event_prototypes = {
         name = "remaining",
         display = L["Remaining Time"],
         type = "number",
-        test = "true"
+        test = "true",
+        enable = function(trigger)
+          return not trigger.showOn or trigger.showOn == "showOnActive"
+        end
       },
       {
         name = "showOn",

--- a/WeakAuras/RegionTypes/RegionPrototype.lua
+++ b/WeakAuras/RegionTypes/RegionPrototype.lua
@@ -763,6 +763,8 @@ function WeakAuras.regionPrototype.AddExpandFunction(data, region, cloneId, pare
       Private.RunConditions(region, uid, true)
       region.subRegionEvents:Notify("PreHide")
       region:Hide();
+      region.states = nil
+      region.state = nil
       if (cloneId) then
         Private.ReleaseClone(region.id, cloneId, data.regionType);
         parent:RemoveChild(id, cloneId)
@@ -778,6 +780,8 @@ function WeakAuras.regionPrototype.AddExpandFunction(data, region, cloneId, pare
       Private.RunConditions(region, uid, true)
       region.subRegionEvents:Notify("PreHide")
       region:Hide();
+      region.states = nil
+      region.state = nil
       if (cloneId) then
         Private.ReleaseClone(region.id, cloneId, data.regionType);
       end
@@ -831,6 +835,8 @@ function WeakAuras.regionPrototype.AddExpandFunction(data, region, cloneId, pare
         return;
       end
       region.toShow = false;
+      region.states = nil
+      region.state = nil
       region:SetScript("OnUpdate", nil)
 
       Private.PerformActions(data, "finish", region);

--- a/WeakAuras/RegionTypes/RegionPrototype.lua
+++ b/WeakAuras/RegionTypes/RegionPrototype.lua
@@ -814,7 +814,6 @@ function WeakAuras.regionPrototype.AddExpandFunction(data, region, cloneId, pare
 
       region.subRegionEvents:Notify("PreShow")
 
-      region.justCreated = nil;
       Private.ApplyFrameLevel(region)
       region:Show();
       Private.PerformActions(data, "start", region);
@@ -863,7 +862,6 @@ function WeakAuras.regionPrototype.AddExpandFunction(data, region, cloneId, pare
       end
       region.toShow = true;
 
-      region.justCreated = nil;
       if(region.PreShow) then
         region:PreShow();
       end

--- a/WeakAuras/RegionTypes/Text.lua
+++ b/WeakAuras/RegionTypes/Text.lua
@@ -80,10 +80,6 @@ local function modify(parent, region, data)
   if not text:GetFont() then -- Font invalid, set the font but keep the setting
     text:SetFont(STANDARD_TEXT_FONT, data.fontSize, data.outline);
   end
-  if text:GetFont() then
-    text:SetText("")
-    text:SetText(WeakAuras.ReplaceRaidMarkerSymbols(data.displayText));
-  end
   text.displayText = data.displayText;
   text:SetJustifyH(data.justify);
 
@@ -226,7 +222,9 @@ local function modify(parent, region, data)
   region.TimerTick = TimerTick
 
   if not UpdateText then
-    SetText(data.displayText);
+    local textStr = data.displayText
+    textStr = textStr:gsub("\\n", "\n");
+    SetText(textStr)
   end
 
   function region:Color(r, g, b, a)

--- a/WeakAuras/SubRegionTypes/SubText.lua
+++ b/WeakAuras/SubRegionTypes/SubText.lua
@@ -340,7 +340,9 @@ local function modify(parent, region, parentData, data, first)
 
   if not UpdateText then
     if text:GetFont() then
-      text:SetText(WeakAuras.ReplaceRaidMarkerSymbols(data.text_text))
+      local textStr = data.text_text
+      textStr = textStr:gsub("\\n", "\n");
+      text:SetText(WeakAuras.ReplaceRaidMarkerSymbols(textStr))
     end
   end
 

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -2914,7 +2914,6 @@ local function EnsureClone(id, cloneId)
   if not(clones[id][cloneId]) then
     local data = WeakAuras.GetData(id);
     WeakAuras.SetRegion(data, cloneId);
-    clones[id][cloneId].justCreated = true;
   end
   return clones[id][cloneId];
 end

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -1,6 +1,6 @@
 local AddonName, Private = ...
 
-local internalVersion = 43
+local internalVersion = 44
 
 -- Lua APIs
 local insert = table.insert

--- a/WeakAurasOptions/BuffTrigger2.lua
+++ b/WeakAurasOptions/BuffTrigger2.lua
@@ -62,6 +62,20 @@ local function IsSingleMissing(trigger)
   return not IsGroupTrigger(trigger) and trigger.matchesShowOn == "showOnMissing"
 end
 
+local function CanHaveMatchCheck(trigger)
+  if IsGroupTrigger(trigger) then
+    return true
+  end
+  if trigger.matchesShowOn == "showOnMissing" then
+    return false
+  end
+  if trigger.matchesShowOn == "showOnActive" or trigger.matchesShowOn == "showOnMatches" then
+    return true
+  end
+  -- Always: If clones are shown
+  return trigger.showClones
+end
+
 local function CreateNameOptions(aura_options, data, trigger, size, isExactSpellId, isIgnoreList, prefix, baseOrder, useKey, optionKey, name, desc)
   local spellCache = WeakAuras.spellCache
 
@@ -69,7 +83,7 @@ local function CreateNameOptions(aura_options, data, trigger, size, isExactSpell
     local hiddenFunction
     if isIgnoreList then
       hiddenFunction = function()
-        return not (trigger.type == "aura2" and trigger[useKey] and (i == 1 or trigger[optionKey] and trigger[optionKey][i - 1]) and trigger.unit ~= "multi" and not IsSingleMissing(trigger))
+        return not (trigger.type == "aura2" and trigger[useKey] and (i == 1 or trigger[optionKey] and trigger[optionKey][i - 1]) and trigger.unit ~= "multi" and CanHaveMatchCheck(trigger))
       end
     else
       hiddenFunction = function()
@@ -263,7 +277,7 @@ local function GetBuffTriggerOptions(data, triggernum)
       width = WeakAuras.normalWidth,
       name = L["Debuff Type"],
       order = 11.2,
-      hidden = function() return not (trigger.type == "aura2" and trigger.unit ~= "multi" and not IsSingleMissing(trigger)) end
+      hidden = function() return not (trigger.type == "aura2" and trigger.unit ~= "multi" and CanHaveMatchCheck(trigger)) end
     },
     debuffClass = {
       type = "multiselect",
@@ -272,7 +286,7 @@ local function GetBuffTriggerOptions(data, triggernum)
       order = 11.3,
       hidden = function()
         return not (trigger.type == "aura2" and trigger.unit ~= "multi"
-          and not IsSingleMissing(trigger)
+          and CanHaveMatchCheck(trigger)
           and trigger.use_debuffClass)
       end,
       values = OptionsPrivate.Private.debuff_class_types,
@@ -284,7 +298,7 @@ local function GetBuffTriggerOptions(data, triggernum)
       order = 11.4,
       hidden = function()
         return not (trigger.type == "aura2" and trigger.unit ~= "multi"
-          and not IsSingleMissing(trigger)
+          and CanHaveMatchCheck(trigger)
           and not trigger.use_debuffClass)
       end
     },
@@ -321,28 +335,28 @@ local function GetBuffTriggerOptions(data, triggernum)
       name = L["Ignored Name(s)"],
       order = 32,
       width = WeakAuras.normalWidth - 0.2,
-      hidden = function() return not (trigger.type == "aura2" and trigger.unit ~= "multi" and not IsSingleMissing(trigger)) end
+      hidden = function() return not (trigger.type == "aura2" and trigger.unit ~= "multi" and CanHaveMatchCheck(trigger)) end
     },
     useIgnoreNameSpace = {
       type = "description",
       name = "",
       order = 32.1,
       width = WeakAuras.normalWidth,
-      hidden = function() return not (trigger.type == "aura2" and not trigger.useIgnoreName and trigger.unit ~= "multi" and not IsSingleMissing(trigger)) end
+      hidden = function() return not (trigger.type == "aura2" and not trigger.useIgnoreName and trigger.unit ~= "multi" and CanHaveMatchCheck(trigger)) end
     },
     useIgnoreExactSpellId = {
       type = "toggle",
       name = L["Ignored Exact Spell ID(s)"],
       width = WeakAuras.normalWidth - 0.2,
       order = 42,
-      hidden = function() return not (trigger.type == "aura2" and trigger.unit ~= "multi" and not IsSingleMissing(trigger)) end
+      hidden = function() return not (trigger.type == "aura2" and trigger.unit ~= "multi" and CanHaveMatchCheck(trigger)) end
     },
     useIgnoreExactSpellIddSpace = {
       type = "description",
       name = "",
       order = 42.1,
       width = WeakAuras.normalWidth,
-      hidden = function() return not (trigger.type == "aura2" and not trigger.useIgnoreExactSpellId and trigger.unit ~= "multi" and not IsSingleMissing(trigger)) end
+      hidden = function() return not (trigger.type == "aura2" and not trigger.useIgnoreExactSpellId and trigger.unit ~= "multi" and CanHaveMatchCheck(trigger)) end
     },
 
     useNamePattern = {
@@ -378,7 +392,7 @@ local function GetBuffTriggerOptions(data, triggernum)
       type = "toggle",
       width = WeakAuras.normalWidth,
       name = L["Stack Count"],
-      hidden = function() return not (trigger.type == "aura2" and trigger.unit ~= "multi" and not IsSingleMissing(trigger)) end,
+      hidden = function() return not (trigger.type == "aura2" and trigger.unit ~= "multi" and CanHaveMatchCheck(trigger)) end,
       order = 60
     },
     stacksOperator = {
@@ -388,7 +402,7 @@ local function GetBuffTriggerOptions(data, triggernum)
       width = WeakAuras.halfWidth,
       values = OptionsPrivate.Private.operator_types,
       disabled = function() return not trigger.useStacks end,
-      hidden = function() return not (trigger.type == "aura2" and trigger.unit ~= "multi" and not IsSingleMissing(trigger) and trigger.useStacks) end,
+      hidden = function() return not (trigger.type == "aura2" and trigger.unit ~= "multi" and CanHaveMatchCheck(trigger) and trigger.useStacks) end,
       get = function() return trigger.useStacks and trigger.stacksOperator or nil end
     },
     stacks = {
@@ -397,7 +411,7 @@ local function GetBuffTriggerOptions(data, triggernum)
       validate = ValidateNumeric,
       order = 60.2,
       width = WeakAuras.halfWidth,
-      hidden = function() return not (trigger.type == "aura2" and trigger.unit ~= "multi" and not IsSingleMissing(trigger) and trigger.useStacks) end,
+      hidden = function() return not (trigger.type == "aura2" and trigger.unit ~= "multi" and CanHaveMatchCheck(trigger) and trigger.useStacks) end,
       get = function() return trigger.useStacks and trigger.stacks or nil end
     },
     useStacksSpace = {
@@ -405,13 +419,13 @@ local function GetBuffTriggerOptions(data, triggernum)
       width = WeakAuras.normalWidth,
       name = "",
       order = 60.3,
-      hidden = function() return not (trigger.type == "aura2" and trigger.unit ~= "multi" and not IsSingleMissing(trigger) and not trigger.useStacks) end
+      hidden = function() return not (trigger.type == "aura2" and trigger.unit ~= "multi" and CanHaveMatchCheck(trigger) and not trigger.useStacks) end
     },
     useRem = {
       type = "toggle",
       width = WeakAuras.normalWidth,
       name = L["Remaining Time"],
-      hidden = function() return not (trigger.type == "aura2" and trigger.unit ~= "multi" and not IsSingleMissing(trigger)) end,
+      hidden = function() return not (trigger.type == "aura2" and trigger.unit ~= "multi" and CanHaveMatchCheck(trigger)) end,
       order = 61
     },
     remOperator = {
@@ -421,7 +435,7 @@ local function GetBuffTriggerOptions(data, triggernum)
       width = WeakAuras.halfWidth,
       values = OptionsPrivate.Private.operator_types,
       disabled = function() return not trigger.useRem end,
-      hidden = function() return not (trigger.type == "aura2" and trigger.unit ~= "multi" and not IsSingleMissing(trigger) and trigger.useRem) end,
+      hidden = function() return not (trigger.type == "aura2" and trigger.unit ~= "multi" and CanHaveMatchCheck(trigger) and trigger.useRem) end,
       get = function() return trigger.useRem and trigger.remOperator or nil end
     },
     rem = {
@@ -430,7 +444,7 @@ local function GetBuffTriggerOptions(data, triggernum)
       validate = ValidateNumeric,
       order = 61.2,
       width = WeakAuras.halfWidth,
-      hidden = function() return not (trigger.type == "aura2" and trigger.unit ~= "multi" and not IsSingleMissing(trigger) and trigger.useRem) end,
+      hidden = function() return not (trigger.type == "aura2" and trigger.unit ~= "multi" and CanHaveMatchCheck(trigger) and trigger.useRem) end,
       get = function() return trigger.useRem and trigger.rem or nil end
     },
     useRemSpace = {
@@ -438,13 +452,13 @@ local function GetBuffTriggerOptions(data, triggernum)
       width = WeakAuras.normalWidth,
       name = "",
       order = 61.3,
-      hidden = function() return not (trigger.type == "aura2" and trigger.unit ~= "multi" and not IsSingleMissing(trigger) and not trigger.useRem) end
+      hidden = function() return not (trigger.type == "aura2" and trigger.unit ~= "multi" and CanHaveMatchCheck(trigger) and not trigger.useRem) end
     },
     useTotal = {
       type = "toggle",
       width = WeakAuras.normalWidth,
       name = L["Total Time"],
-      hidden = function() return not (trigger.type == "aura2" and trigger.unit ~= "multi" and not IsSingleMissing(trigger)) end,
+      hidden = function() return not (trigger.type == "aura2" and trigger.unit ~= "multi" and CanHaveMatchCheck(trigger)) end,
       order = 61.4
     },
     totalOperator = {
@@ -454,7 +468,7 @@ local function GetBuffTriggerOptions(data, triggernum)
       width = WeakAuras.halfWidth,
       values = OptionsPrivate.Private.operator_types,
       disabled = function() return not trigger.useTotal end,
-      hidden = function() return not (trigger.type == "aura2" and trigger.unit ~= "multi" and not IsSingleMissing(trigger) and trigger.useTotal) end,
+      hidden = function() return not (trigger.type == "aura2" and trigger.unit ~= "multi" and CanHaveMatchCheck(trigger) and trigger.useTotal) end,
       get = function() return trigger.useTotal and trigger.totalOperator or nil end
     },
     total = {
@@ -463,7 +477,7 @@ local function GetBuffTriggerOptions(data, triggernum)
       validate = ValidateNumeric,
       order = 61.6,
       width = WeakAuras.halfWidth,
-      hidden = function() return not (trigger.type == "aura2" and trigger.unit ~= "multi" and not IsSingleMissing(trigger) and trigger.useTotal) end,
+      hidden = function() return not (trigger.type == "aura2" and trigger.unit ~= "multi" and CanHaveMatchCheck(trigger) and trigger.useTotal) end,
       get = function() return trigger.useTotal and trigger.total or nil end
     },
     useTotalSpace = {
@@ -471,7 +485,7 @@ local function GetBuffTriggerOptions(data, triggernum)
       width = WeakAuras.normalWidth,
       name = "",
       order = 61.7,
-      hidden = function() return not (trigger.type == "aura2" and trigger.unit ~= "multi" and not IsSingleMissing(trigger) and not trigger.useTotal) end
+      hidden = function() return not (trigger.type == "aura2" and trigger.unit ~= "multi" and CanHaveMatchCheck(trigger) and not trigger.useTotal) end
     },
     fetchTooltip = {
       type = "toggle",
@@ -486,14 +500,14 @@ local function GetBuffTriggerOptions(data, triggernum)
       width = WeakAuras.normalWidth,
       name = L["Tooltip Pattern Match"],
       order = 62.1,
-      hidden = function() return not (trigger.type == "aura2" and trigger.unit ~= "multi" and not IsSingleMissing(trigger) and trigger.fetchTooltip) end
+      hidden = function() return not (trigger.type == "aura2" and trigger.unit ~= "multi" and CanHaveMatchCheck(trigger) and trigger.fetchTooltip) end
     },
     use_tooltipSpace = {
       type = "description",
       name = "",
       order = 62.2,
       width = WeakAuras.normalWidth,
-      hidden = function() return not (trigger.type == "aura2" and trigger.unit ~= "multi" and not IsSingleMissing(trigger) and not trigger.use_tooltip and trigger.fetchTooltip) end
+      hidden = function() return not (trigger.type == "aura2" and trigger.unit ~= "multi" and CanHaveMatchCheck(trigger) and not trigger.use_tooltip and trigger.fetchTooltip) end
     },
     tooltip_operator = {
       type = "select",
@@ -501,7 +515,7 @@ local function GetBuffTriggerOptions(data, triggernum)
       name = L["Operator"],
       order = 62.3,
       disabled = function() return not trigger.use_tooltip end,
-      hidden = function() return not (trigger.type == "aura2" and trigger.unit ~= "multi" and not IsSingleMissing(trigger) and trigger.use_tooltip and trigger.fetchTooltip) end,
+      hidden = function() return not (trigger.type == "aura2" and trigger.unit ~= "multi" and CanHaveMatchCheck(trigger) and trigger.use_tooltip and trigger.fetchTooltip) end,
       values = OptionsPrivate.Private.string_operator_types
     },
     tooltip = {
@@ -510,21 +524,21 @@ local function GetBuffTriggerOptions(data, triggernum)
       width = WeakAuras.doubleWidth,
       order = 62.4,
       disabled = function() return not trigger.use_tooltip end,
-      hidden = function() return not (trigger.type == "aura2" and trigger.unit ~= "multi" and not IsSingleMissing(trigger) and trigger.use_tooltip and trigger.fetchTooltip) end
+      hidden = function() return not (trigger.type == "aura2" and trigger.unit ~= "multi" and CanHaveMatchCheck(trigger) and trigger.use_tooltip and trigger.fetchTooltip) end
     },
     use_tooltipValue = {
       type = "toggle",
       width = WeakAuras.normalWidth,
       name = L["Tooltip Value"],
       order = 63.1,
-      hidden = function() return not (trigger.type == "aura2" and trigger.unit ~= "multi" and not IsSingleMissing(trigger) and trigger.fetchTooltip) end
+      hidden = function() return not (trigger.type == "aura2" and trigger.unit ~= "multi" and CanHaveMatchCheck(trigger) and trigger.fetchTooltip) end
     },
     tooltipValueNumber = {
       type = "select",
       width = WeakAuras.normalWidth,
       name = L["Tooltip Value #"],
       order = 63.2,
-      hidden = function() return not (trigger.type == "aura2" and trigger.unit ~= "multi" and not IsSingleMissing(trigger) and trigger.use_tooltipValue and trigger.fetchTooltip) end,
+      hidden = function() return not (trigger.type == "aura2" and trigger.unit ~= "multi" and CanHaveMatchCheck(trigger) and trigger.use_tooltipValue and trigger.fetchTooltip) end,
       values = OptionsPrivate.Private.tooltip_count
     },
     use_tooltipValueSpace = {
@@ -532,14 +546,14 @@ local function GetBuffTriggerOptions(data, triggernum)
       name = "",
       order = 63.2,
       width = WeakAuras.normalWidth,
-      hidden = function() return not (trigger.type == "aura2" and trigger.unit ~= "multi" and not IsSingleMissing(trigger) and not trigger.use_tooltipValue and trigger.fetchTooltip) end
+      hidden = function() return not (trigger.type == "aura2" and trigger.unit ~= "multi" and CanHaveMatchCheck(trigger) and not trigger.use_tooltipValue and trigger.fetchTooltip) end
     },
     tooltipValue_operator = {
       type = "select",
       width = WeakAuras.normalWidth,
       name = L["Operator"],
       order = 63.3,
-      hidden = function() return not (trigger.type == "aura2" and trigger.unit ~= "multi" and not IsSingleMissing(trigger) and trigger.use_tooltipValue and trigger.fetchTooltip) end,
+      hidden = function() return not (trigger.type == "aura2" and trigger.unit ~= "multi" and CanHaveMatchCheck(trigger) and trigger.use_tooltipValue and trigger.fetchTooltip) end,
       values = OptionsPrivate.Private.operator_types
     },
     tooltipValue = {
@@ -548,7 +562,7 @@ local function GetBuffTriggerOptions(data, triggernum)
       width = WeakAuras.normalWidth,
       validate = ValidateNumeric,
       order = 63.4,
-      hidden = function() return not (trigger.type == "aura2" and trigger.unit ~= "multi" and not IsSingleMissing(trigger) and trigger.use_tooltipValue and trigger.fetchTooltip) end
+      hidden = function() return not (trigger.type == "aura2" and trigger.unit ~= "multi" and CanHaveMatchCheck(trigger) and trigger.use_tooltipValue and trigger.fetchTooltip) end
     },
     use_stealable = {
       type = "toggle",
@@ -560,7 +574,7 @@ local function GetBuffTriggerOptions(data, triggernum)
       end,
       width = WeakAuras.doubleWidth,
       order = 64,
-      hidden = function() return not (trigger.type == "aura2" and trigger.unit ~= "multi" and not IsSingleMissing(trigger)) end,
+      hidden = function() return not (trigger.type == "aura2" and trigger.unit ~= "multi" and CanHaveMatchCheck(trigger)) end,
       get = function()
         local value = trigger.use_stealable
         if value == nil then return false
@@ -588,7 +602,7 @@ local function GetBuffTriggerOptions(data, triggernum)
       end,
       width = WeakAuras.doubleWidth,
       order = 64.1,
-      hidden = function() return not (trigger.type == "aura2" and trigger.unit ~= "multi" and not IsSingleMissing(trigger)) end,
+      hidden = function() return not (trigger.type == "aura2" and trigger.unit ~= "multi" and CanHaveMatchCheck(trigger)) end,
       get = function()
         local value = trigger.use_isBossDebuff
         if value == nil then return false
@@ -617,7 +631,7 @@ local function GetBuffTriggerOptions(data, triggernum)
       desc = L["Only Match auras cast by a player (not an npc)"],
       width = WeakAuras.doubleWidth,
       order = 64.2,
-      hidden = function() return not (trigger.type == "aura2" and trigger.unit ~= "multi" and not IsSingleMissing(trigger)) end,
+      hidden = function() return not (trigger.type == "aura2" and trigger.unit ~= "multi" and CanHaveMatchCheck(trigger)) end,
       get = function()
         local value = trigger.use_castByPlayer
         if value == nil then return false

--- a/WeakAurasOptions/ConditionOptions.lua
+++ b/WeakAurasOptions/ConditionOptions.lua
@@ -866,7 +866,7 @@ local function addControlsForChange(args, order, data, conditionVariable, condit
         if (not message) then
           return true;
         end
-        if (not OptionsPrivate.Private.ContainsPlaceHolders(message, "c")) then
+        if (not OptionsPrivate.Private.ContainsCustomPlaceHolder(message)) then
           return true;
         end
 

--- a/WeakAurasTemplates/TriggerTemplatesData.lua
+++ b/WeakAurasTemplates/TriggerTemplatesData.lua
@@ -38,13 +38,20 @@ local templates =
     },
   }
 
+local manaIcon = WeakAuras.IsClassic() and "Interface\\Icons\\spell_frost_manarecharge.blp"
+                                        or "Interface\\Icons\\inv_elemental_mote_mana"
+local rageIcon = WeakAuras.IsClassic() and "Interface\\Icons\\ability_racial_bloodrage.blp"
+                                        or "Interface\\Icons\\spell_misc_emotionangry"
+local comboPointsIcon = WeakAuras.IsClassic() and "Interface\\Icons\\ability_backstab"
+                                        or "Interface\\Icons\\inv_mace_2h_pvp410_c_01"
+
 local powerTypes =
   {
-    [0] = { name = POWER_TYPE_MANA, icon = "Interface\\Icons\\inv_elemental_mote_mana" },
-    [1] = { name = POWER_TYPE_RED_POWER, icon = "Interface\\Icons\\spell_misc_emotionangry"},
+    [0] = { name = POWER_TYPE_MANA, icon = manaIcon },
+    [1] = { name = POWER_TYPE_RED_POWER, icon = rageIcon},
     [2] = { name = POWER_TYPE_FOCUS, icon = "Interface\\Icons\\ability_hunter_focusfire"},
     [3] = { name = POWER_TYPE_ENERGY, icon = "Interface\\Icons\\spell_shadow_shadowworddominate"},
-    [4] = { name = COMBO_POINTS, icon = "Interface\\Icons\\inv_mace_2h_pvp410_c_01"},
+    [4] = { name = COMBO_POINTS, icon = comboPointsIcon},
     [6] = { name = RUNIC_POWER, icon = "Interface\\Icons\\inv_sword_62"},
     [7] = { name = SOUL_SHARDS_POWER, icon = "Interface\\Icons\\inv_misc_gem_amethyst_02"},
     [8] = { name = POWER_TYPE_LUNAR_POWER, icon = "Interface\\Icons\\ability_druid_eclipseorange"},
@@ -147,7 +154,7 @@ if WeakAuras.IsClassic() then
         title = L["Resources"],
         args = {
         },
-        icon = "Interface\\Icons\\spell_misc_emotionangry",
+        icon = rageIcon,
       }
     }
   }
@@ -182,7 +189,7 @@ if WeakAuras.IsClassic() then
           { spell = 879, type = "ability", requiresTarget = true, usable = true}, -- Exorcism
           { spell = 1022, type = "ability", buff = true}, -- Blessing of Protection
           { spell = 1044, type = "ability", buff = true}, -- Blessing of Freedom
-          { spell = 1052, type = "ability"}, -- Purify
+          { spell = 1152, type = "ability"}, -- Purify
           { spell = 2812, type = "ability"}, -- Holy Wrath
           { spell = 4987, type = "ability"}, -- Cleanse
           { spell = 6940, type = "ability"}, -- Blessing of Sacrifice
@@ -211,7 +218,7 @@ if WeakAuras.IsClassic() then
         title = L["Resources"],
         args = {
         },
-        icon = "Interface\\Icons\\inv_elemental_mote_mana",
+        icon = manaIcon,
       },
     }
   }
@@ -291,7 +298,7 @@ if WeakAuras.IsClassic() then
         title = L["Resources"],
         args = {
         },
-        icon = "Interface\\Icons\\ability_hunter_focusfire",
+        icon = manaIcon,
       },
     }
   }
@@ -362,7 +369,7 @@ if WeakAuras.IsClassic() then
         title = L["Resources"],
         args = {
         },
-        icon = "Interface\\Icons\\inv_mace_2h_pvp410_c_01",
+        icon = comboPointsIcon,
       },
     }
   }
@@ -423,7 +430,7 @@ if WeakAuras.IsClassic() then
         title = L["Resources"],
         args = {
         },
-        icon = "Interface\\Icons\\inv_elemental_mote_mana",
+        icon = manaIcon,
       },
     }
   }
@@ -434,7 +441,6 @@ if WeakAuras.IsClassic() then
         title = L["Buffs"],
         args = {
           { spell = 546, type = "buff", unit = "player"}, -- Water Walking
-          { spell = 974, type = "buff", unit = "player", talent = 8}, -- Earth Shield
           { spell = 16256, type = "buff", unit = "player", talent = 30}, -- Flurry
         },
         icon = 135863
@@ -520,9 +526,9 @@ if WeakAuras.IsClassic() then
           { spell = 1459, type = "buff", unit = "player"}, -- Arcane Intellect
           { spell = 1463, type = "buff", unit = "player"}, -- Mana Shield
           { spell = 6143, type = "buff", unit = "player"}, -- Frost Ward
+          { spell = 11958, type = "buff", unit = "player"}, -- Ice Block
           { spell = 12042, type = "buff", unit = "player"}, -- Arcane Power
           { spell = 12536, type = "buff", unit = "player"}, -- Clearcasting
-          { spell = 45438, type = "buff", unit = "player"}, -- Ice Block
         },
         icon = 136096
       },
@@ -578,7 +584,7 @@ if WeakAuras.IsClassic() then
         title = L["Resources"],
         args = {
         },
-        icon = "Interface\\Icons\\spell_arcane_arcane01",
+        icon = manaIcon,
       },
     }
   }
@@ -749,7 +755,7 @@ if WeakAuras.IsClassic() then
         title = L["Resources and Shapeshift Form"],
         args = {
         },
-        icon = "Interface\\Icons\\ability_druid_eclipseorange",
+        icon = manaIcon,
       },
     }
   }
@@ -874,7 +880,7 @@ else
         title = L["Resources"],
         args = {
         },
-        icon = "Interface\\Icons\\spell_misc_emotionangry",
+        icon = rageIcon,
       },
     },
     [2] = { -- Fury
@@ -982,7 +988,7 @@ else
         title = L["Resources"],
         args = {
         },
-        icon = "Interface\\Icons\\spell_misc_emotionangry",
+        icon = rageIcon,
       },
     },
     [3] = { -- Protection
@@ -1091,7 +1097,7 @@ else
         title = L["Resources"],
         args = {
         },
-        icon = "Interface\\Icons\\spell_misc_emotionangry",
+        icon = rageIcon,
       }
     }
   }
@@ -1200,7 +1206,7 @@ else
         title = L["Resources"],
         args = {
         },
-        icon = "Interface\\Icons\\inv_elemental_mote_mana",
+        icon = manaIcon,
       },
     },
     [2] = { -- Protection
@@ -1305,7 +1311,7 @@ else
         title = L["Resources"],
         args = {
         },
-        icon = "Interface\\Icons\\inv_elemental_mote_mana",
+        icon = manaIcon,
       },
     },
     [3] = { -- Retribution
@@ -1916,7 +1922,7 @@ else
         title = L["Resources"],
         args = {
         },
-        icon = "Interface\\Icons\\inv_mace_2h_pvp410_c_01",
+        icon = comboPointsIcon,
       },
     },
     [2] = { -- Outlaw
@@ -2045,7 +2051,7 @@ else
         title = L["Resources"],
         args = {
         },
-        icon = "Interface\\Icons\\inv_mace_2h_pvp410_c_01",
+        icon = comboPointsIcon,
       },
     },
     [3] = { -- Subtlety
@@ -2166,7 +2172,7 @@ else
         title = L["Resources"],
         args = {
         },
-        icon = "Interface\\Icons\\inv_mace_2h_pvp410_c_01",
+        icon = comboPointsIcon,
       },
     },
   }
@@ -2278,7 +2284,7 @@ else
         title = L["Resources"],
         args = {
         },
-        icon = "Interface\\Icons\\inv_elemental_mote_mana",
+        icon = manaIcon,
       },
     },
     [2] = { -- Holy
@@ -2399,7 +2405,7 @@ else
         title = L["Resources"],
         args = {
         },
-        icon = "Interface\\Icons\\inv_elemental_mote_mana",
+        icon = manaIcon,
       },
     },
     [3] = { -- Shadow
@@ -2892,7 +2898,7 @@ else
         title = L["Resources"],
         args = {
         },
-        icon = "Interface\\Icons\\inv_elemental_mote_mana",
+        icon = manaIcon,
       },
     },
   }
@@ -3103,7 +3109,7 @@ else
         title = L["Resources"],
         args = {
         },
-        icon = "Interface\\Icons\\inv_elemental_mote_mana",
+        icon = manaIcon,
       },
     },
     [3] = { -- Frost
@@ -3212,7 +3218,7 @@ else
         title = L["Resources"],
         args = {
         },
-        icon = "Interface\\Icons\\inv_elemental_mote_mana",
+        icon = manaIcon,
       },
     },
   }
@@ -3861,7 +3867,7 @@ else
         title = L["Resources"],
         args = {
         },
-        icon = "Interface\\Icons\\inv_elemental_mote_mana",
+        icon = manaIcon,
       },
     },
     [3] = { -- Windwalker
@@ -4261,7 +4267,7 @@ else
         title = L["Resources and Shapeshift Form"],
         args = {
         },
-        icon = "Interface\\Icons\\inv_mace_2h_pvp410_c_01",
+        icon = comboPointsIcon,
       },
     },
     [3] = { -- Guardian
@@ -4405,7 +4411,7 @@ else
         title = L["Resources and Shapeshift Form"],
         args = {
         },
-        icon = "Interface\\Icons\\spell_misc_emotionangry",
+        icon = rageIcon,
       },
     },
     [4] = { -- Restoration
@@ -4550,7 +4556,7 @@ else
         title = L["Resources and Shapeshift Form"],
         args = {
         },
-        icon = "Interface\\Icons\\inv_elemental_mote_mana",
+        icon = manaIcon,
       },
     },
   }
@@ -5106,7 +5112,7 @@ end
 -- General Section
 tinsert(templates.general.args, {
   title = L["Health"],
-  icon = "Interface\\Icons\\inv_alchemy_70_red",
+  icon = WeakAuras.IsClassic() and "Interface\\Icons\\inv_potion_54" or "Interface\\Icons\\inv_alchemy_70_red",
   type = "health"
 });
 tinsert(templates.general.args, {
@@ -5134,7 +5140,7 @@ tinsert(templates.general.args, {
 
 tinsert(templates.general.args, {
   title = L["Pet Behavior"],
-  icon = "Interface\\Icons\\Ability_hunter_pet_assist",
+  icon = WeakAuras.IsClassic() and "Interface\\Icons\\ability_defend.blp" or "Interface\\Icons\\Ability_hunter_pet_assist",
   triggers = {[1] = { trigger = {
     type = WeakAuras.GetTriggerCategoryFor("Pet Behavior"),
     event = "Pet Behavior",
@@ -5142,13 +5148,15 @@ tinsert(templates.general.args, {
     behavior = "assist"}}}
 });
 
-tinsert(templates.general.args, {
-  spell = 2825, type = "buff", unit = "player",
-  forceOwnOnly = true,
-  ownOnly = nil,
-  overideTitle = L["Bloodlust/Heroism"],
-  spellIds = {2825, 32182, 80353, 264667}}
-);
+if not WeakAuras.IsClassic() then
+  tinsert(templates.general.args, {
+    spell = 2825, type = "buff", unit = "player",
+    forceOwnOnly = true,
+    ownOnly = nil,
+    overideTitle = L["Bloodlust/Heroism"],
+    spellIds = {2825, 32182, 80353, 264667}}
+  );
+end
 
 -- Meta template for Power triggers
 local function createSimplePowerTemplate(powertype)
@@ -5922,86 +5930,117 @@ end
 ------------------------------
 -- Hardcoded race templates
 -------------------------------
+if WeakAuras.IsClassic() then
+  -- Every Man for Himself
+  tinsert(templates.race.Human, { spell = 20600, type = "ability" });
+  -- Stoneform
+  tinsert(templates.race.Dwarf, { spell = 20594, type = "ability", titleSuffix = L["cooldown"]});
+  tinsert(templates.race.Dwarf, { spell = 20594, type = "buff", unit = "player", titleSuffix = L["buff"]});
+  -- Shadow Meld
+  tinsert(templates.race.NightElf, { spell = 20580, type = "ability", titleSuffix = L["cooldown"]});
+  tinsert(templates.race.NightElf, { spell = 20580, type = "buff", titleSuffix = L["buff"]});
+  -- Escape Artist
+  tinsert(templates.race.Gnome, { spell = 20589, type = "ability" });
 
--- Every Man for Himself
-tinsert(templates.race.Human, { spell = 59752, type = "ability" });
--- Stoneform
-tinsert(templates.race.Dwarf, { spell = 20594, type = "ability", titleSuffix = L["cooldown"]});
-tinsert(templates.race.Dwarf, { spell = 65116, type = "buff", unit = "player", titleSuffix = L["buff"]});
--- Shadow Meld
-tinsert(templates.race.NightElf, { spell = 58984, type = "ability", titleSuffix = L["cooldown"]});
-tinsert(templates.race.NightElf, { spell = 58984, type = "buff", titleSuffix = L["buff"]});
--- Escape Artist
-tinsert(templates.race.Gnome, { spell = 20589, type = "ability" });
--- Gift of the Naaru
-tinsert(templates.race.Draenei, { spell = 28880, type = "ability", titleSuffix = L["cooldown"]});
-tinsert(templates.race.Draenei, { spell = 28880, type = "buff", unit = "player", titleSuffix = L["buff"]});
--- Dark Flight
-tinsert(templates.race.Worgen, { spell = 68992, type = "ability", titleSuffix = L["cooldown"]});
-tinsert(templates.race.Worgen, { spell = 68992, type = "buff", unit = "player", titleSuffix = L["buff"]});
--- Quaking Palm
-tinsert(templates.race.Pandaren, { spell = 107079, type = "ability", titleSuffix = L["cooldown"]});
-tinsert(templates.race.Pandaren, { spell = 107079, type = "buff", titleSuffix = L["buff"]});
--- Blood Fury
-tinsert(templates.race.Orc, { spell = 20572, type = "ability", titleSuffix = L["cooldown"]});
-tinsert(templates.race.Orc, { spell = 20572, type = "buff", unit = "player", titleSuffix = L["buff"]});
---Cannibalize
-tinsert(templates.race.Scourge, { spell = 20577, type = "ability", titleSuffix = L["cooldown"]});
-tinsert(templates.race.Scourge, { spell = 20578, type = "buff", unit = "player", titleSuffix = L["buff"]});
--- War Stomp
-tinsert(templates.race.Tauren, { spell = 20549, type = "ability", titleSuffix = L["cooldown"]});
-tinsert(templates.race.Tauren, { spell = 20549, type = "buff", titleSuffix = L["buff"]});
---Beserking
-tinsert(templates.race.Troll, { spell = 26297, type = "ability", titleSuffix = L["cooldown"]});
-tinsert(templates.race.Troll, { spell = 26297, type = "buff", unit = "player", titleSuffix = L["buff"]});
--- Arcane Torment
-tinsert(templates.race.BloodElf, { spell = 69179, type = "ability", titleSuffix = L["cooldown"]});
-tinsert(templates.race.BloodElf, { spell = 69179, type = "buff", titleSuffix = L["buff"]});
--- Pack Hobgoblin
-tinsert(templates.race.Goblin, { spell = 69046, type = "ability" });
--- Rocket Barrage
-tinsert(templates.race.Goblin, { spell = 69041, type = "ability" });
+  -- Blood Fury
+  tinsert(templates.race.Orc, { spell = 20572, type = "ability", titleSuffix = L["cooldown"]});
+  tinsert(templates.race.Orc, { spell = 20572, type = "buff", unit = "player", titleSuffix = L["buff"]});
+  --Cannibalize
+  tinsert(templates.race.Scourge, { spell = 20577, type = "ability", titleSuffix = L["cooldown"]});
+  tinsert(templates.race.Scourge, { spell = 20578, type = "buff", unit = "player", titleSuffix = L["buff"]});
+  -- Will of the Forsaken
+  tinsert(templates.race.Scourge, { spell = 7744, type = "ability", titleSuffix = L["cooldown"]});
+  tinsert(templates.race.Scourge, { spell = 7744, type = "buff", unit = "player", titleSuffix = L["buff"]});
+  -- War Stomp
+  tinsert(templates.race.Tauren, { spell = 20549, type = "ability", titleSuffix = L["cooldown"]});
+  tinsert(templates.race.Tauren, { spell = 20549, type = "debuff", titleSuffix = L["debuff"]});
+  --Beserking
+  tinsert(templates.race.Troll, { spell = 26927, type = "ability", titleSuffix = L["Rogue cooldown"]});
+  tinsert(templates.race.Troll, { spell = 26926, type = "ability", titleSuffix = L["Warrior cooldown"]});
+  tinsert(templates.race.Troll, { spell = 20554, type = "ability", titleSuffix = L["Other cooldown"]});
+  tinsert(templates.race.Troll, { spell = 26635, type = "buff", unit = "player", titleSuffix = L["buff"]});
+else
+  -- Every Man for Himself
+  tinsert(templates.race.Human, { spell = 59752, type = "ability" });
+  -- Stoneform
+  tinsert(templates.race.Dwarf, { spell = 20594, type = "ability", titleSuffix = L["cooldown"]});
+  tinsert(templates.race.Dwarf, { spell = 65116, type = "buff", unit = "player", titleSuffix = L["buff"]});
+  -- Shadow Meld
+  tinsert(templates.race.NightElf, { spell = 58984, type = "ability", titleSuffix = L["cooldown"]});
+  tinsert(templates.race.NightElf, { spell = 58984, type = "buff", titleSuffix = L["buff"]});
+  -- Escape Artist
+  tinsert(templates.race.Gnome, { spell = 20589, type = "ability" });
+  -- Gift of the Naaru
+  tinsert(templates.race.Draenei, { spell = 28880, type = "ability", titleSuffix = L["cooldown"]});
+  tinsert(templates.race.Draenei, { spell = 28880, type = "buff", unit = "player", titleSuffix = L["buff"]});
+  -- Dark Flight
+  tinsert(templates.race.Worgen, { spell = 68992, type = "ability", titleSuffix = L["cooldown"]});
+  tinsert(templates.race.Worgen, { spell = 68992, type = "buff", unit = "player", titleSuffix = L["buff"]});
+  -- Quaking Palm
+  tinsert(templates.race.Pandaren, { spell = 107079, type = "ability", titleSuffix = L["cooldown"]});
+  tinsert(templates.race.Pandaren, { spell = 107079, type = "buff", titleSuffix = L["buff"]});
+  -- Blood Fury
+  tinsert(templates.race.Orc, { spell = 20572, type = "ability", titleSuffix = L["cooldown"]});
+  tinsert(templates.race.Orc, { spell = 20572, type = "buff", unit = "player", titleSuffix = L["buff"]});
+  --Cannibalize
+  tinsert(templates.race.Scourge, { spell = 20577, type = "ability", titleSuffix = L["cooldown"]});
+  tinsert(templates.race.Scourge, { spell = 20578, type = "buff", unit = "player", titleSuffix = L["buff"]});
+  -- War Stomp
+  tinsert(templates.race.Tauren, { spell = 20549, type = "ability", titleSuffix = L["cooldown"]});
+  tinsert(templates.race.Tauren, { spell = 20549, type = "debuff", titleSuffix = L["debuff"]});
+  --Beserking
+  tinsert(templates.race.Troll, { spell = 26297, type = "ability", titleSuffix = L["cooldown"]});
+  tinsert(templates.race.Troll, { spell = 26297, type = "buff", unit = "player", titleSuffix = L["buff"]});
+  -- Arcane Torrent
+  tinsert(templates.race.BloodElf, { spell = 69179, type = "ability", titleSuffix = L["cooldown"]});
+  -- Pack Hobgoblin
+  tinsert(templates.race.Goblin, { spell = 69046, type = "ability" });
+  -- Rocket Barrage
+  tinsert(templates.race.Goblin, { spell = 69041, type = "ability" });
 
--- Arcane Pulse
-tinsert(templates.race.Nightborne, { spell = 260364, type = "ability" });
--- Cantrips
-tinsert(templates.race.Nightborne, { spell = 255661, type = "ability" });
--- Light's Judgment
-tinsert(templates.race.LightforgedDraenei, { spell = 255647, type = "ability" });
--- Forge of Light
-tinsert(templates.race.LightforgedDraenei, { spell = 259930, type = "ability" });
--- Bull Rush
-tinsert(templates.race.HighmountainTauren, { spell = 255654, type = "ability" });
---Spatial Rift
-tinsert(templates.race.VoidElf, { spell = 256948, type = "ability" });
--- Fireblood
-tinsert(templates.race.DarkIronDwarf, { spell = 265221, type = "ability" });
--- Mole Machine
-tinsert(templates.race.DarkIronDwarf, { spell = 265225, type = "ability" });
---Haymaker
-tinsert(templates.race.KulTiran, { spell = 287712, type = "ability", requiresTarget = true });
--- Brush it Off
-tinsert(templates.race.KulTiran, { spell = 291843, type = "buff"});
--- Hyper Organic Light Originator
-tinsert(templates.race.Mechagnome, { spell = 312924, type = "ability" });
--- Combat Anlysis
-tinsert(templates.race.Mechagnome, { spell = 313424, type = "buff" });
--- Recently Failed
-tinsert(templates.race.Mechagnome, { spell = 313015, type = "debuff" });
--- Ancestral Call
-tinsert(templates.race.MagharOrc, { spell = 274738, type = "ability" });
--- ZandalariTroll = {}
--- Pterrordax Swoop
-tinsert(templates.race.ZandalariTroll, { spell = 281954, type = "ability" });
--- Regenratin'
-tinsert(templates.race.ZandalariTroll, { spell = 291944, type = "ability" });
--- Embrace of the Loa
-tinsert(templates.race.ZandalariTroll, { spell = 292752, type = "ability" });
--- Vulpera = {}
--- Bag of Tricks
-tinsert(templates.race.Vulpera, { spell = 312411, type = "ability" });
--- Make Camp
-tinsert(templates.race.Vulpera, { spell = 312370, type = "ability" });
+  -- Arcane Pulse
+  tinsert(templates.race.Nightborne, { spell = 260364, type = "ability" });
+  -- Cantrips
+  tinsert(templates.race.Nightborne, { spell = 255661, type = "ability" });
+  -- Light's Judgment
+  tinsert(templates.race.LightforgedDraenei, { spell = 255647, type = "ability" });
+  -- Forge of Light
+  tinsert(templates.race.LightforgedDraenei, { spell = 259930, type = "ability" });
+  -- Bull Rush
+  tinsert(templates.race.HighmountainTauren, { spell = 255654, type = "ability" });
+  --Spatial Rift
+  tinsert(templates.race.VoidElf, { spell = 256948, type = "ability" });
+  -- Fireblood
+  tinsert(templates.race.DarkIronDwarf, { spell = 265221, type = "ability" });
+  -- Mole Machine
+  tinsert(templates.race.DarkIronDwarf, { spell = 265225, type = "ability" });
+  --Haymaker
+  tinsert(templates.race.KulTiran, { spell = 287712, type = "ability", requiresTarget = true });
+  -- Brush it Off
+  tinsert(templates.race.KulTiran, { spell = 291843, type = "buff"});
+  -- Hyper Organic Light Originator
+  tinsert(templates.race.Mechagnome, { spell = 312924, type = "ability" });
+  -- Combat Anlysis
+  tinsert(templates.race.Mechagnome, { spell = 313424, type = "buff" });
+  -- Recently Failed
+  tinsert(templates.race.Mechagnome, { spell = 313015, type = "debuff" });
+  -- Ancestral Call
+  tinsert(templates.race.MagharOrc, { spell = 274738, type = "ability" });
+  -- ZandalariTroll = {}
+  -- Pterrordax Swoop
+  tinsert(templates.race.ZandalariTroll, { spell = 281954, type = "ability" });
+  -- Regenratin'
+  tinsert(templates.race.ZandalariTroll, { spell = 291944, type = "ability" });
+  -- Embrace of the Loa
+  tinsert(templates.race.ZandalariTroll, { spell = 292752, type = "ability" });
+  -- Vulpera = {}
+  -- Bag of Tricks
+  tinsert(templates.race.Vulpera, { spell = 312411, type = "ability" });
+  -- Make Camp
+  tinsert(templates.race.Vulpera, { spell = 312370, type = "ability" });
+end
+
+
 
 ------------------------------
 -- Helper code for options


### PR DESCRIPTION
By making the dynamic threshold configurable.

And by using Blizzard's time formatting functions, as proposed by
Elvador in #2173. This patch offers basically the same functionality,
though quite differently presented to the user.

There's now a top-level option to choose between:
* Built-in:            63:42   3:07    10    2.4
* Old Blizzard         2h      3m 7s   10s   2.4
* Modern Blizzard      1h 3m   3m 7s   10s   2.4

All formats support (and default to) increased precision below a
threshold. The default threshold remains at 3s.

The threshold setting is also the off-switch for the additional
precision. Setting it to 0, disables that behaviour. This isn't the most
obvious user interface, but creating a special control for it is too
much work and a additional checkbox destroys the layout.

Fixes: #2707

