### PR TITLE
Fix target type check to compare against a string

### DIFF
--- a/WeakAuras/Transmission.lua
+++ b/WeakAuras/Transmission.lua
@@ -1684,7 +1684,7 @@ function WeakAuras.Import(inData, target)
     return nil, "Invalid import data."
   end
   local status, msg = true, ""
-  if type(target) ~= nil then
+  if type(target) ~= 'nil' then
     local targetData
     local uid = type(target) == 'table' and target.uid or target
     if type(uid) == 'string' then


### PR DESCRIPTION
# Description

This is a fix for the issue submitted in #2943, it simply changes the following check:
```lua
if type(target) ~= nil then
```

to:
```lua
if type(target) ~= 'nil' then
```

<!-- A #ticketNumber will be sufficient. -->
Fixes #2943

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested

I ran the reproduction steps listed in #2943:

1. Add a print statement at the end of the Import function, or at the place where .Import is being called logging the status and message.
2. Open the aura import popup
3. Enter a valid import string
4. ~See the import info popup appear and a message in the chat frame with false "Invalid update target. Importing as an unknown payload."~

and confirmed that step 4 is no longer the case and the function properly returns `true, ""` if the import was successful.

## Checklist
<!-- These can be checked off after the pull request is submitted, in case you want discussion before they are completely ready -->

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings

<!-- Is there any additional work that needs to be done? If so, add it to the above list -->
