### PR TITLE
Fix Modernize for time format with non-dynamic decimal precision

### DIFF
--- a/WeakAuras/Modernize.lua
+++ b/WeakAuras/Modernize.lua
@@ -1183,11 +1183,12 @@ function Private.Modernize(data)
             data[prefix .. symbol .. "_time_format"] = 0
 
             local oldDynamic = data[prefix .. symbol .. "_time_dynamic"]
-            data[prefix .. symbol .. "_time_dynamic_threshold"] = oldDynamic and 3 or 0
+            data[prefix .. symbol .. "_time_dynamic_threshold"] = oldDynamic and 3 or 60
           end
           data[prefix .. symbol .. "_time_dynamic"] = nil
           if data[prefix .. symbol .. "_time_precision"] == 0 then
             data[prefix .. symbol .. "_time_precision"] = 1
+            data[prefix .. symbol .. "_time_dynamic_threshold"] = 0
           end
         end
       end


### PR DESCRIPTION
# Description

After updating from 3.1.9-28-g99622d5 to 3.1.9-37-g62029a4 I noticed that my auras that used to show remaining time with one decimal now show it with no decimals.

https://github.com/WeakAuras/WeakAuras2/commit/4ea2b0024cd67cb1c05db728f97e935a5f66a7d0 (+ fix in https://github.com/WeakAuras/WeakAuras2/commit/62029a44722018a5c48cb36dec1178d366cd7b87) refactors time formatting to introduce new formatting options. However the Modernize step incorrectly disables decimals for time texts that have dynamic precision disable. Also, time texts that have decimals disabled but had dynamic previously enabled and still set to true in their data now show one decimal below 3 seconds.

Decimals for times higher than 3 seconds were achieved with `_time_dynamic = false`, showing selected precision for values below 60 instead of just below 3. To maintain that, set `_time_dynamic_threshold = 60` instead of `_time_dynamic_threshold = 0` which disables decimals altogether.

For time formats without decimals, still set `_time_dynamic_threshold = 0` to keep decimals disabled as `_time_precision = 0` is no longer a valid precision setting.

I don't believe it's possible to properly repair damage from the bug, as both `precision = 1` and `precision = 0` have been mapped to `precision = 1` with no way to tell them apart. My guess is that these two are the most common options, making the value of repairing just `dynamic_threshold` rather limited.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested

```
!WA:2!vBz3sTTXByC7XtAA00jfCtttiF58rtttkuWeiqA7)ccSdqnGJSadzMwZATRT3ezj1vR4RJ6W0PtMEixcCqpkh5RGo5k4Dy6vqUeYvqFxj5e(WUzA(NzA7jYYR3177ZVNN3vk5YP996D4bgAGX7p7y9xF8XhnBw6iPBMMMM(0lTFvI1tOcxVPCTDfZLkvQIPgCGrErvxbLj0J)rVE0T5BVnrqZy66Al5E7jDTwNj85UoNlzLDfBUyTA(mzYQrlSHyR4b2tWQJtYClpMrDHBG3ErZOeFB2jAfDF0ENmzYug(weBwQQwUo1411eeljUy)rn8LeHuRAnUd3VHMo(HuBhPGxVowe9Dtr8T)YEuw1GA1uBNyMCfkMFPc6s1EtceKS747XSTNL6R9c)GQS1zoYs4S5B2QYutwYSsjZjnm1dW)8QE2KTycdhstMVMr4uRodJylB8QLwuWWLAuQyUcf2nWjUe0IfyoADMxVL(XaIGLjFGTDMYn4s2l5osMWHyVCe9k3I4y1Wvu0f)HQtLBbZCg7sC4njkLpk0t(NZi(SssbZPUSXjHpr3X1HTpf1JAgvuQt4ZqIr93rnvL2H7O3KWDYd3gxaCh4lG(HbWp79OJCno17msEtMO)MUyv7G2s)sMVSf3PMRiQk0AvtGCaRbIKK6LrfCE1qQ9QAPPmYLBH9jbsC4f9cDmTyRDwhmeK65rFjksCQ9qaAeMk8121Nzxlu7WT2tPbE0Y1TDj08vLyAWrEwJMbyOtthTpRZcFJMHLnX3xDNUpwWQBYgWPTgNT9yMLNx3FOG0w)6tVbM3K2ChCNxYSWSlKRfL7Rmwt2MYR9PEW7N07QhyOkrkUIxffrQq3cDFUvdVESc8LUnvtzjpkrYGR8cuTUk6yvMtLn0Ne)k8HODPb9QbP1Gp603eoZVjc8zlGCATDv5VWWuFE9Ae43G7upZCekltzUdfUcKbUkCn48AqFWfGlcxcUSg6tNd(y4SW1186v1jSoZmkJnpAvplH3f6yThDJHscu4ML3zdK9LfeVDkhFJEnxhPxp5f8TZ8Wacv5QzmnHX0GVkp81kAc)VWRFB41jux3rTivt7533VbH6UXkrUzk4u6sC)nSAFaskVR3DM6jywCvUpj85QW9rdOF5BoYcVxs4(AIhJEcV2w6fYL3eoH6qimlBiBk7Fq40Aq2uWWWDHr0GjBrKpCW8lm8ynNEO4IF1OI)IjGpdUvROXE9Pq7HT1mAOX(ZFamKgmEv9fnnxC(NEdykyAvbKlm(mZe3orImjsKaYVg8a0fNbMnofKomieLcG5wl0wpGlRCyL9IU831hui2MH5Fwcybyr02IXJs3O8paEoYi9ESrmGsXw5ehZkJmxZZdlH(gSScpRKeghwdkhADqfuWRcp6vaTAiqPkm1gPFpsTtRW6dQxFJLgCZ5xMvc(HqWH(IcxfHhECsD)2KQX)zjvQ)ksfg9gQJGA1AC5Y8L8lS(cDduTP0u)uIZPOK6V5Wy6GhRecK2CsbiKtkCfcieuifpoMu1(RvCxAZpGIJ1jQASmF77wrLESa1quKkJT(G551N2EQYt3MyyCbbMIBy)umPQe1coI2ri1CX5P)frQt8oLuHbQSiOSNLV6Ow37UKY17aOA0nqfxvT5vXjsCMoZRd1aQ4viCocWqqD5OhoDCEPu9FNEjS6rwHDukq3XtCYsvjGd0hnzRPFIpNTX9A(4H2uP9d1h92EcqNjvPU2d(pcPoz3ivyazyvc4qGsSAUnMVWYu8PxVRbvBcT8VN4ID8PEhQ1dbrN4JImh6LB6oGEZTEkUGe6)V3L445VHPh4DiIJh4d8E8Kt)OGvk6o40HSwfqoAZx61)Jv(Z)
```
Compared 3.1.9-28-g99622d5, 3.1.9-37-g62029a4, and 3.1.9-37-g62029a4 with the changes manually applied.

## Checklist
<!-- These can be checked off after the pull request is submitted, in case you want discussion before they are completely ready -->

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

<!-- Is there any additional work that needs to be done? If so, add it to the above list -->
