### PR TITLE
handle DBM & BW pause/resume callbacks

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -54,6 +54,7 @@ globals = {
 	"BigWigsLoader",
 	"CUSTOM_CLASS_COLORS",
 	"DBM",
+	"DBT",
 	"ElvUIPlayerNamePlateAnchor",
 	"GTFO",
 	"IndentationLib",

--- a/WeakAuras/GenericTrigger.lua
+++ b/WeakAuras/GenericTrigger.lua
@@ -2639,7 +2639,7 @@ do
       bar.count = msg:match("(%d+)") or "0"
       bar.dbmType = dbmType
 
-      local barOptions = DBM.Bars.options
+      local barOptions = DBT.Options or DBM.Bars.options
       local r, g, b = 0, 0, 0
       if dbmType == 1 then
         r, g, b = barOptions.StartColorAR, barOptions.StartColorAG, barOptions.StartColorAB

--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -4791,7 +4791,7 @@ Private.event_prototypes = {
     type = "addons",
     events = {},
     internal_events = {
-      "BigWigs_StartBar", "BigWigs_StopBar", "BigWigs_Timer_Update",
+      "BigWigs_StartBar", "BigWigs_StopBar", "BigWigs_Timer_Update", "BigWigs_PauseBar", "BigWigs_ResumeBar"
     },
     force_events = "BigWigs_Timer_Force",
     name = L["BigWigs Timer"],
@@ -4833,7 +4833,10 @@ Private.event_prototypes = {
           end
 
           if useClone then
-            if event == "BigWigs_StartBar" then
+            if event == "BigWigs_StartBar"
+            or event == "BigWigs_PauseBar"
+            or event == "BigWigs_ResumeBar"
+            then
               if WeakAuras.BigWigsTimerMatches(id, triggerText, triggerTextOperator, triggerSpellId, triggerCount, triggerCast) then
                 local bar = WeakAuras.GetBigWigsTimerById(id)
                 if bar then

--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -8216,6 +8216,10 @@ Private.dynamic_texts = {
         return state.value or nil
       end
       if state.progressType == "timed" then
+        if state.paused then
+          return state.remaining and state.remaining >= 0 and state.remaining or nil
+        end
+
         if not state.expirationTime or not state.duration then
           return nil
         end

--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -4460,7 +4460,12 @@ Private.event_prototypes = {
       }
     },
     nameFunc = function(trigger)
-      return "";
+      local item = GetInventoryItemID("player", trigger.itemSlot or 0);
+      if (item) then
+        return GetItemInfo(item)
+      else
+        return ""
+      end
     end,
     iconFunc = function(trigger)
       return GetInventoryItemTexture("player", trigger.itemSlot or 0) or "Interface\\Icons\\INV_Misc_QuestionMark";

--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -4539,7 +4539,7 @@ Private.event_prototypes = {
     type = "addons",
     events = {},
     internal_events = {
-      "DBM_TimerStart", "DBM_TimerStop", "DBM_TimerStopAll", "DBM_TimerUpdate", "DBM_TimerForce"
+      "DBM_TimerStart", "DBM_TimerStop", "DBM_TimerStopAll", "DBM_TimerUpdate", "DBM_TimerForce", "DBM_TimerResume", "DBM_TimerPause"
     },
     force_events = "DBM_TimerForce",
     name = L["DBM Timer"],
@@ -4547,6 +4547,8 @@ Private.event_prototypes = {
     triggerFunction = function(trigger)
       WeakAuras.RegisterDBMCallback("DBM_TimerStart")
       WeakAuras.RegisterDBMCallback("DBM_TimerStop")
+      WeakAuras.RegisterDBMCallback("DBM_TimerPause")
+      WeakAuras.RegisterDBMCallback("DBM_TimerResume")
       WeakAuras.RegisterDBMCallback("DBM_TimerUpdate")
       WeakAuras.RegisterDBMCallback("wipe")
       WeakAuras.RegisterDBMCallback("kill")
@@ -4587,7 +4589,10 @@ Private.event_prototypes = {
           end
 
           if useClone then
-            if event == "DBM_TimerStart" then
+            if event == "DBM_TimerStart"
+            or event == "DBM_TimerPause"
+            or event == "DBM_TimerResume"
+            then
               if WeakAuras.DBMTimerMatches(id, triggerId, triggerText, triggerTextOperator, triggerSpellId, triggerDbmType, triggerCount) then
                 local bar = WeakAuras.GetDBMTimerById(id)
                 if bar then

--- a/WeakAuras/RegionTypes/Icon.lua
+++ b/WeakAuras/RegionTypes/Icon.lua
@@ -537,7 +537,21 @@ local function modify(parent, region, data)
     function region:Update()
       local state = region.state
       if state.progressType == "timed" then
-        local expirationTime = state.expirationTime and state.expirationTime > 0 and state.expirationTime or math.huge;
+        local expirationTime
+        if state.paused == true then
+          if not region.paused then
+            region:Pause()
+            cooldown:Pause()
+          end
+          expirationTime = GetTime() + (state.remaining or 0)
+        else
+          if region.paused then
+            region:Resume()
+            cooldown:Resume()
+          end
+          expirationTime = state.expirationTime and state.expirationTime > 0 and state.expirationTime or math.huge;
+        end
+
         local duration = state.duration or 0
         if region.adjustedMinRelPercent then
           region.adjustedMinRel = region.adjustedMinRelPercent * duration
@@ -557,7 +571,6 @@ local function modify(parent, region, data)
         end
 
         region:SetTime(max - adjustMin, expirationTime - adjustMin, state.inverse);
-        cooldown:Resume()
       elseif state.progressType == "static" then
         local value = state.value or 0;
         local total = state.total or 0;

--- a/WeakAuras/RegionTypes/ProgressTexture.lua
+++ b/WeakAuras/RegionTypes/ProgressTexture.lua
@@ -1259,7 +1259,27 @@ local function modify(parent, region, data)
 
     local max
     if state.progressType == "timed" then
-      local expirationTime = state.expirationTime and state.expirationTime > 0 and state.expirationTime or math.huge;
+      local expirationTime
+      if state.paused == true then
+        if not region.paused then
+          region:Pause()
+        end
+        if region.TimerTick then
+          region.TimerTick = nil
+          region:UpdateRegionHasTimerTick()
+        end
+        expirationTime = GetTime() + (state.remaining or 0)
+      else
+        if region.paused then
+          region:Resume()
+        end
+        if not region.TimerTick then
+          region.TimerTick = TimerTick
+          region:UpdateRegionHasTimerTick()
+        end
+        expirationTime = state.expirationTime and state.expirationTime > 0 and state.expirationTime or math.huge;
+      end
+
       local duration = state.duration or 0
       if region.adjustedMinRelPercent then
         region.adjustedMinRel = region.adjustedMinRelPercent * duration
@@ -1277,11 +1297,11 @@ local function modify(parent, region, data)
       end
 
       region:SetTime(max - adjustMin, expirationTime - adjustMin, state.inverse);
-      if not region.TimerTick then
-        region.TimerTick = TimerTick
-        region:UpdateRegionHasTimerTick()
-      end
     elseif state.progressType == "static" then
+      if region.paused then
+        region:Resume()
+      end
+
       local value = state.value or 0;
       local total = state.total or 0;
       if region.adjustedMinRelPercent then
@@ -1304,6 +1324,9 @@ local function modify(parent, region, data)
         region:UpdateRegionHasTimerTick()
       end
     else
+      if region.paused then
+        region:Resume()
+      end
       region:SetTime(0, math.huge)
       if region.TimerTick then
         region.TimerTick = nil

--- a/WeakAuras/RegionTypes/RegionPrototype.lua
+++ b/WeakAuras/RegionTypes/RegionPrototype.lua
@@ -894,6 +894,16 @@ function WeakAuras.regionPrototype.AddExpandFunction(data, region, cloneId, pare
   if not region.Expand then
     function region:Expand() end
   end
+  if not region.Pause then
+    function region:Pause()
+      self.paused = true
+    end
+  end
+  if not region.Resume then
+    function region:Resume()
+      self.paused = nil
+    end
+  end
 end
 
 function WeakAuras.SetTextureOrAtlas(texture, path, wrapModeH, wrapModeV)

--- a/WeakAuras/RegionTypes/stopmotion.lua
+++ b/WeakAuras/RegionTypes/stopmotion.lua
@@ -339,7 +339,12 @@ local function modify(parent, region, data)
           local total = region.state.total ~= 0 and region.state.total or 1
           frame = floor((frames - 1) * value / total) + startFrame;
         else
-          local remaining = region.state.expirationTime and (region.state.expirationTime - GetTime()) or 0;
+          local remaining
+          if region.state.paused then
+            remaining = region.state.remaining or 0;
+          else
+            remaining = region.state.expirationTime and (region.state.expirationTime - GetTime()) or 0;
+          end
           local progress = region.state.duration and region.state.duration > 0 and (1 - (remaining / region.state.duration)) or 0;
           frame = floor( (frames - 1) * progress) + startFrame;
         end
@@ -364,6 +369,15 @@ local function modify(parent, region, data)
     region.FrameTick = onUpdate;
 
     function region:Update()
+      if region.state.paused then
+        if not region.paused then
+          region:Pause()
+        end
+      else
+        if region.paused then
+          region:Resume()
+        end
+      end
       onUpdate();
     end
 

--- a/WeakAuras/SubRegionTypes/Tick.lua
+++ b/WeakAuras/SubRegionTypes/Tick.lua
@@ -190,7 +190,7 @@ local funcs = {
     end
   end,
   UpdateTimerTick = function(self)
-    if self.tick_placement_mode == "ValueOffset" and self.state and self.state.progressType == "timed" then
+    if self.tick_placement_mode == "ValueOffset" and self.state and self.state.progressType == "timed" and not self.paused then
       if not self.TimerTick then
         self.TimerTick = self.UpdateTickPlacement
         self.parent:UpdateRegionHasTimerTick()
@@ -230,7 +230,13 @@ local funcs = {
     elseif self.tick_placement_mode == "ValueOffset" then
       if self.trigger_total and self.trigger_total ~= 0 then
         if self.state.progressType == "timed" then
-          tick_placement = self.state.expirationTime - GetTime() + self.tick_placement
+          if self.state.paused then
+            if self.state.remaining then
+              tick_placement = self.state.remaining + self.tick_placement
+            end
+          else
+            tick_placement = self.state.expirationTime - GetTime() + self.tick_placement
+          end
         else
           tick_placement = self.state.value + self.tick_placement
         end

--- a/WeakAuras/Types.lua
+++ b/WeakAuras/Types.lua
@@ -2675,6 +2675,7 @@ Private.internal_fields = {
   uid = true,
   internalVersion = true,
   sortHybridTable = true,
+  tocversion = true,
 }
 
 -- fields that are not included in exported data

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -3816,7 +3816,7 @@ end
 
 local function startStopTimers(id, cloneId, triggernum, state)
   if (state.show) then
-    if (state.autoHide and state.duration and state.duration > 0) then -- autohide, update timer
+    if (state.autoHide and state.duration and state.duration > 0 and not state.paused) then -- autohide, update timer
       timers[id] = timers[id] or {};
       timers[id][triggernum] = timers[id][triggernum] or {};
       timers[id][triggernum][cloneId] = timers[id][triggernum][cloneId] or {};


### PR DESCRIPTION
# Description
As I don't think we have a way to pause a timed aura, this will handle DBM_TimerPause like a DBM_TimerStop event, and DBM_TimerResume like a DBM_TimerStart event
and same for BigWigs_PauseBar and BigWigs_ResumeBar events

fixes #2951

I have not tested the change since it seems dbm will only fire them for a mythic boss i won't do