### PR TITLE
Add WeakAuras Import UI

### DIFF
--- a/WeakAuras/Transmission.lua
+++ b/WeakAuras/Transmission.lua
@@ -742,6 +742,7 @@ function StringToTable(inString, fromChat)
   end
   return deserialized
 end
+Private.StringToTable = StringToTable
 
 function WeakAuras.DisplayToString(id, forChat)
   local data = WeakAuras.GetData(id);

--- a/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasPendingUpdateButton.lua
+++ b/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasPendingUpdateButton.lua
@@ -109,6 +109,9 @@ local methods = {
     self.titletext = title;
     self.title:SetText(title);
   end,
+  ["SetClick"] = function(self, func)
+    self.frame:SetScript("OnClick", func);
+  end,
   ["UpdateThumbnail"] = function(self)
     if not self.hasThumbnail then
       return
@@ -244,7 +247,7 @@ Constructor
 
 local function Constructor()
   local name = "WeakAurasPendingUpdateButton"..AceGUI:GetNextWidgetNum(Type);
-  local button = CreateFrame("BUTTON", name, UIParent, "OptionsListButtonTemplate");
+  local button = CreateFrame("BUTTON", name, UIParent);
   button:SetHeight(32);
   button:SetWidth(1000);
   button.dgroup = nil;

--- a/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasPendingUpdateButton.lua
+++ b/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasPendingUpdateButton.lua
@@ -81,6 +81,13 @@ local methods = {
     self:Enable()
     self.frame:Hide()
   end,
+  ["SetLogo"] = function(self, path)
+    ViragDevTool_AddData(self.frame, "SetLogo")
+    self.frame.updateLogo.tex:SetTexture(path)
+  end,
+  ["SetRefreshLogo"] = function(self, path)
+    self.frame.update:SetNormalTexture(path)
+  end,
   ["Disable"] = function(self)
     self.background:Hide()
     self.frame:Disable()
@@ -296,6 +303,7 @@ local function Constructor()
   local tex = updateLogo:CreateTexture(nil, "OVERLAY")
   tex:SetTexture([[Interface\AddOns\WeakAuras\Media\Textures\wagoupdate_logo.tga]])
   tex:SetAllPoints()
+  updateLogo.tex = tex
   updateLogo:SetSize(24, 24)
   updateLogo:SetPoint("CENTER", update)
 

--- a/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasPendingUpdateButton.lua
+++ b/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasPendingUpdateButton.lua
@@ -27,34 +27,6 @@ local function Show_Tooltip(owner, line1, line2)
   GameTooltip:Show()
 end
 
-local function Show_Long_Tooltip(owner, description)
-  GameTooltip:SetOwner(owner, "ANCHOR_NONE")
-  GameTooltip:SetPoint("LEFT", owner, "RIGHT")
-  GameTooltip:ClearLines()
-  local line = 1
-  for i, v in pairs(description) do
-    if (type(v) == "string") then
-      if (line > 1) then
-        GameTooltip:AddLine(v, 1, 1, 1, 1)
-      else
-        GameTooltip:AddLine(v)
-      end
-    elseif (type(v) == "table") then
-      if (i == 1) then
-        GameTooltip:AddDoubleLine(v[1], v[2] .. (v[3] and (" |T" .. v[3] .. ":12:12:0:0:64:64:4:60:4:60|t") or ""))
-      else
-        GameTooltip:AddDoubleLine(v[1], v[2] .. (v[3] and (" |T" .. v[3] .. ":12:12:0:0:64:64:4:60:4:60|t") or ""), 1, 1, 1, 1, 1, 1, 1, 1)
-      end
-    end
-    line = line + 1
-  end
-  GameTooltip:Show()
-end
-
-local function ensure(t, k, v)
-  return t and k and v and t[k] == v
-end
-
 --[[-----------------------------------------------------------------------------
 Methods
 -------------------------------------------------------------------------------]]
@@ -82,7 +54,6 @@ local methods = {
     self.frame:Hide()
   end,
   ["SetLogo"] = function(self, path)
-    ViragDevTool_AddData(self.frame, "SetLogo")
     self.frame.updateLogo.tex:SetTexture(path)
   end,
   ["SetRefreshLogo"] = function(self, path)
@@ -257,7 +228,6 @@ local function Constructor()
   local button = CreateFrame("BUTTON", name, UIParent)
   button:SetHeight(32)
   button:SetWidth(1000)
-  button.dgroup = nil
   button.data = {}
 
   local background = button:CreateTexture(nil, "BACKGROUND")

--- a/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasPendingUpdateButton.lua
+++ b/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasPendingUpdateButton.lua
@@ -1,0 +1,339 @@
+if not WeakAuras.IsCorrectVersion() then return end
+local AddonName, OptionsPrivate = ...
+
+local tinsert, tconcat, tremove, wipe = table.insert, table.concat, table.remove, wipe
+local select, pairs, next, type, unpack = select, pairs, next, type, unpack
+local tostring, error = tostring, error
+
+local Type, Version = "WeakAurasPendingUpdateButton", 1
+local AceGUI = LibStub and LibStub("AceGUI-3.0", true)
+if not AceGUI or (AceGUI:GetWidgetVersion(Type) or 0) >= Version then return end
+
+local L = WeakAuras.L;
+local fullName;
+
+local function Hide_Tooltip()
+  GameTooltip:Hide();
+end
+
+local function Show_Tooltip(owner, line1, line2)
+  GameTooltip:SetOwner(owner, "ANCHOR_NONE");
+  GameTooltip:SetPoint("LEFT", owner, "RIGHT");
+  GameTooltip:ClearLines();
+  GameTooltip:AddLine(line1);
+  GameTooltip:AddLine(line2, 1, 1, 1, 1);
+  GameTooltip:Show();
+end
+
+local function Show_Long_Tooltip(owner, description)
+  GameTooltip:SetOwner(owner, "ANCHOR_NONE");
+  GameTooltip:SetPoint("LEFT", owner, "RIGHT");
+  GameTooltip:ClearLines();
+  local line = 1;
+  for i,v in pairs(description) do
+    if(type(v) == "string") then
+      if(line > 1) then
+        GameTooltip:AddLine(v, 1, 1, 1, 1);
+      else
+        GameTooltip:AddLine(v);
+      end
+    elseif(type(v) == "table") then
+      if(i == 1) then
+        GameTooltip:AddDoubleLine(v[1], v[2]..(v[3] and (" |T"..v[3]..":12:12:0:0:64:64:4:60:4:60|t") or ""));
+      else
+        GameTooltip:AddDoubleLine(v[1], v[2]..(v[3] and (" |T"..v[3]..":12:12:0:0:64:64:4:60:4:60|t") or ""), 1, 1, 1, 1, 1, 1, 1, 1);
+      end
+    end
+    line = line + 1;
+  end
+  GameTooltip:Show();
+end
+
+local function ensure(t, k, v)
+  return t and k and v and t[k] == v
+end
+
+--[[-----------------------------------------------------------------------------
+Methods
+-------------------------------------------------------------------------------]]
+local methods = {
+  ["OnAcquire"] = function(self)
+    self:SetWidth(1000);
+    self:SetHeight(32);
+    self.hasThumbnail = false
+  end,
+  ["Initialize"] = function(self, id, companionData)
+    self.callbacks = {};
+    self.id = id
+    self.companionData = companionData
+
+    function self.callbacks.OnUpdateClick()
+      WeakAuras.Import(self.companionData.encoded)
+    end
+
+    self:SetTitle(self.companionData.name);
+    self.update:SetScript("OnClick", self.callbacks.OnUpdateClick);
+    local data = OptionsPrivate.Private.StringToTable(self.companionData.encoded, true)
+    self.data = data.d
+    -- self:SetNormalTooltip();
+    self.frame:EnableKeyboard(false);
+    self:Enable();
+    self.frame:Hide()
+  end,
+  ["Disable"] = function(self)
+    self.background:Hide();
+    self.frame:Disable();
+  end,
+  ["Enable"] = function(self)
+    self.background:Show();
+    self.frame:Enable();
+    self.update:Show()
+    self.update:Enable()
+    self.updateLogo:Show()
+    self:UpdateThumbnail()
+  end,
+  ["OnRelease"] = function(self)
+    self:ReleaseThumbnail()
+    self:Enable();
+    self.title:Show();
+    self.frame:SetScript("OnEnter", nil);
+    self.frame:SetScript("OnLeave", nil);
+    self.frame:SetScript("OnClick", nil);
+    --self.frame:EnableMouse(false);
+    self.frame:ClearAllPoints();
+    self.frame:Hide();
+    self.frame = nil;
+    self.data = nil;
+  end,
+  ["SetTitle"] = function(self, title)
+    self.titletext = title;
+    self.title:SetText(title);
+  end,
+  ["UpdateThumbnail"] = function(self)
+    if not self.hasThumbnail then
+      return
+    end
+
+    if self.data.regionType ~= self.thumbnailType then
+      self:ReleaseThumbnail()
+      self:AcquireThumbnail()
+    else
+      local option = WeakAuras.regionOptions[self.thumbnailType]
+      if option and option.modifyThumbnail then
+        option.modifyThumbnail(self.frame, self.thumbnail, self.data)
+      end
+    end
+  end,
+  ["ReleaseThumbnail"] = function(self)
+    if not self.hasThumbnail then
+      return
+    end
+    self.hasThumbnail = false
+
+    if self.thumbnail then
+      local regionType = self.thumbnailType
+      local option = WeakAuras.regionOptions[regionType]
+      option.releaseThumbnail(self.thumbnail)
+      self.thumbnail = nil
+    end
+  end,
+  ["AcquireThumbnail"] = function(self)
+    if self.hasThumbnail then
+      return
+    end
+
+    if not self.data then
+      return
+    end
+
+    self.hasThumbnail = true
+
+    local button = self.frame
+    local regionType = self.data.regionType
+    self.thumbnailType = regionType
+
+    local option = WeakAuras.regionOptions[regionType]
+    if option and option.acquireThumbnail then
+      self.thumbnail = option.acquireThumbnail(button, self.data)
+      self:SetIcon(self.thumbnail)
+    else
+      self:SetIcon("Interface\\Icons\\INV_Misc_QuestionMark")
+    end
+  end,
+  ["SetIcon"] = function(self, icon)
+    self.orgIcon = icon;
+    if(type(icon) == "string" or type(icon) == "number") then
+      self.icon:SetTexture(icon);
+      self.icon:Show();
+      if(self.iconRegion and self.iconRegion.Hide) then
+        self.iconRegion:Hide();
+      end
+    else
+      self.iconRegion = icon;
+      icon:SetAllPoints(self.icon);
+      icon:SetParent(self.frame);
+      icon:Show()
+      self.iconRegion:Show();
+      self.icon:Hide();
+    end
+  end,
+  ["OverrideIcon"] = function(self)
+    self.icon:SetTexture("Interface\\Addons\\WeakAuras\\Media\\Textures\\icon.blp")
+    self.icon:Show()
+    if(self.iconRegion and self.iconRegion.Hide) then
+      self.iconRegion:Hide();
+    end
+  end,
+  ["RestoreIcon"] = function(self)
+    self:SetIcon(self.orgIcon);
+  end,
+  ["Expand"] = function(self, reloadTooltip)
+    self.expand:Enable();
+    OptionsPrivate.SetCollapsed(self.data.id, "displayButton", "", false)
+    self.expand:SetNormalTexture("Interface\\BUTTONS\\UI-MinusButton-Up.blp");
+    self.expand:SetPushedTexture("Interface\\BUTTONS\\UI-MinusButton-Down.blp");
+    self.expand.title = L["Collapse"];
+    self.expand.desc = L["Hide this group's children"];
+    self.expand:SetScript("OnClick", function() self:Collapse(true) end);
+    self.expand.func();
+    if(reloadTooltip) then
+      Hide_Tooltip();
+      Show_Tooltip(self.frame, self.expand.title, self.expand.desc);
+    end
+  end,
+  ["Collapse"] = function(self, reloadTooltip)
+    self.expand:Enable();
+    OptionsPrivate.SetCollapsed(self.data.id, "displayButton", "", true)
+    self.expand:SetNormalTexture("Interface\\BUTTONS\\UI-PlusButton-Up.blp");
+    self.expand:SetPushedTexture("Interface\\BUTTONS\\UI-PlusButton-Down.blp");
+    self.expand.title = L["Expand"];
+    self.expand.desc = L["Show this group's children"];
+    self.expand:SetScript("OnClick", function() self:Expand(true) end);
+    self.expand.func();
+    --if(reloadTooltip) then
+    --  Hide_Tooltip();
+    --  Show_Tooltip(self.frame, self.expand.title, self.expand.desc);
+    --end
+  end,
+  ["SetOnExpandCollapse"] = function(self, func)
+    self.expand.func = func;
+  end,
+  ["GetExpanded"] = function(self)
+    return not OptionsPrivate.IsCollapsed(self.id, "displayButton", "", true)
+  end,
+  ["DisableExpand"] = function(self)
+    self.expand:Disable();
+    self.expand.disabled = true;
+    self.expand.expanded = false;
+    self.expand:SetNormalTexture("Interface\\BUTTONS\\UI-PlusButton-Disabled.blp");
+  end,
+  ["EnableExpand"] = function(self)
+    self.expand.disabled = false;
+    if(self:GetExpanded()) then
+      self:Expand();
+    else
+      self:Collapse();
+    end
+  end,
+}
+
+--[[-----------------------------------------------------------------------------
+Constructor
+-------------------------------------------------------------------------------]]
+
+local function Constructor()
+  local name = "WeakAurasPendingUpdateButton"..AceGUI:GetNextWidgetNum(Type);
+  local button = CreateFrame("BUTTON", name, UIParent, "OptionsListButtonTemplate");
+  button:SetHeight(32);
+  button:SetWidth(1000);
+  button.dgroup = nil;
+  button.data = {};
+
+  local background = button:CreateTexture(nil, "BACKGROUND");
+  button.background = background;
+  background:SetTexture("Interface\\BUTTONS\\UI-Listbox-Highlight2.blp");
+  background:SetBlendMode("ADD");
+  background:SetVertexColor(0.5, 0.5, 0.5, 0.25);
+  background:SetPoint("TOP", button, "TOP");
+  background:SetPoint("BOTTOM", button, "BOTTOM");
+  background:SetPoint("LEFT", button, "LEFT");
+  background:SetPoint("RIGHT", button, "RIGHT");
+
+  local icon = button:CreateTexture(nil, "OVERLAY");
+  button.icon = icon;
+  icon:SetWidth(32);
+  icon:SetHeight(32);
+  icon:SetPoint("LEFT", button, "LEFT");
+
+  local title = button:CreateFontString(nil, "OVERLAY", "GameFontNormal");
+  button.title = title;
+  title:SetHeight(14);
+  title:SetJustifyH("LEFT");
+  title:SetPoint("TOPLEFT", icon, "TOPRIGHT", 2, 0);
+  title:SetPoint("BOTTOMRIGHT", button, "BOTTOMRIGHT");
+  title:SetVertexColor(0.6, 0.6, 0.6)
+
+  button.description = {};
+
+  --[[
+  button:SetScript("OnEnter", function()
+      Show_Long_Tooltip(button, button.description);
+  end);
+  button:SetScript("OnLeave", Hide_Tooltip);
+  ]]--
+
+  local update, updateLogo
+  if WeakAurasCompanion then
+    update = CreateFrame("BUTTON", nil, button);
+    button.update = update
+    update.disabled = true
+    update.func = function() end
+    update:SetNormalTexture([[Interface\AddOns\WeakAuras\Media\Textures\wagoupdate_refresh.tga]])
+    update:Disable()
+    update:SetWidth(24)
+    update:SetHeight(24)
+    update:SetPoint("RIGHT", button, "RIGHT", -35, 0)
+
+    -- Add logo
+    updateLogo = CreateFrame("Frame", nil, button)
+    button.updateLogo = updateLogo
+    local tex = updateLogo:CreateTexture(nil, "OVERLAY")
+    tex:SetTexture([[Interface\AddOns\WeakAuras\Media\Textures\wagoupdate_logo.tga]])
+    tex:SetAllPoints()
+    updateLogo:SetSize(24,24)
+    updateLogo:SetPoint("CENTER",update)
+
+    -- Animation On Hover
+    local animGroup = update:CreateAnimationGroup()
+    update.animGroup = animGroup
+    local animRotate = animGroup:CreateAnimation("rotation")
+    animRotate:SetDegrees(-360)
+    animRotate:SetDuration(1)
+    animRotate:SetSmoothing("OUT")
+    animGroup:SetScript("OnFinished",function() if (MouseIsOver(update)) then animGroup:Play() end end)
+    update:SetScript("OnEnter", function()
+      animGroup:Play()
+      --Show_Tooltip(button, update.title, update.desc)
+    end);
+    -- update:SetScript("OnLeave", Hide_Tooltip)
+    update:Hide()
+    updateLogo:Hide()
+  end
+
+  local widget = {
+    frame = button,
+    title = title,
+    icon = icon,
+    background = background,
+    update = update,
+    updateLogo = updateLogo,
+    type = Type
+  }
+  for method, func in pairs(methods) do
+    widget[method] = func
+  end
+
+  return AceGUI:RegisterAsWidget(widget);
+end
+
+AceGUI:RegisterWidgetType(Type, Constructor, Version)

--- a/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasPendingUpdateButton.lua
+++ b/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasPendingUpdateButton.lua
@@ -1,52 +1,54 @@
-if not WeakAuras.IsCorrectVersion() then return end
-local AddonName, OptionsPrivate = ...
+if not WeakAuras.IsCorrectVersion() then
+  return
+end
 
-local tinsert, tconcat, tremove, wipe = table.insert, table.concat, table.remove, wipe
-local select, pairs, next, type, unpack = select, pairs, next, type, unpack
-local tostring, error = tostring, error
+local AddonName, OptionsPrivate = ...
+local L = WeakAuras.L
+
+local pairs, next, type, unpack = pairs, next, type, unpack
 
 local Type, Version = "WeakAurasPendingUpdateButton", 1
 local AceGUI = LibStub and LibStub("AceGUI-3.0", true)
-if not AceGUI or (AceGUI:GetWidgetVersion(Type) or 0) >= Version then return end
 
-local L = WeakAuras.L;
-local fullName;
+if not AceGUI or (AceGUI:GetWidgetVersion(Type) or 0) >= Version then
+  return
+end
 
 local function Hide_Tooltip()
-  GameTooltip:Hide();
+  GameTooltip:Hide()
 end
 
 local function Show_Tooltip(owner, line1, line2)
-  GameTooltip:SetOwner(owner, "ANCHOR_NONE");
-  GameTooltip:SetPoint("LEFT", owner, "RIGHT");
-  GameTooltip:ClearLines();
-  GameTooltip:AddLine(line1);
-  GameTooltip:AddLine(line2, 1, 1, 1, 1);
-  GameTooltip:Show();
+  GameTooltip:SetOwner(owner, "ANCHOR_NONE")
+  GameTooltip:SetPoint("LEFT", owner, "RIGHT")
+  GameTooltip:ClearLines()
+  GameTooltip:AddLine(line1)
+  GameTooltip:AddLine(line2, 1, 1, 1, 1)
+  GameTooltip:Show()
 end
 
 local function Show_Long_Tooltip(owner, description)
-  GameTooltip:SetOwner(owner, "ANCHOR_NONE");
-  GameTooltip:SetPoint("LEFT", owner, "RIGHT");
-  GameTooltip:ClearLines();
-  local line = 1;
-  for i,v in pairs(description) do
-    if(type(v) == "string") then
-      if(line > 1) then
-        GameTooltip:AddLine(v, 1, 1, 1, 1);
+  GameTooltip:SetOwner(owner, "ANCHOR_NONE")
+  GameTooltip:SetPoint("LEFT", owner, "RIGHT")
+  GameTooltip:ClearLines()
+  local line = 1
+  for i, v in pairs(description) do
+    if (type(v) == "string") then
+      if (line > 1) then
+        GameTooltip:AddLine(v, 1, 1, 1, 1)
       else
-        GameTooltip:AddLine(v);
+        GameTooltip:AddLine(v)
       end
-    elseif(type(v) == "table") then
-      if(i == 1) then
-        GameTooltip:AddDoubleLine(v[1], v[2]..(v[3] and (" |T"..v[3]..":12:12:0:0:64:64:4:60:4:60|t") or ""));
+    elseif (type(v) == "table") then
+      if (i == 1) then
+        GameTooltip:AddDoubleLine(v[1], v[2] .. (v[3] and (" |T" .. v[3] .. ":12:12:0:0:64:64:4:60:4:60|t") or ""))
       else
-        GameTooltip:AddDoubleLine(v[1], v[2]..(v[3] and (" |T"..v[3]..":12:12:0:0:64:64:4:60:4:60|t") or ""), 1, 1, 1, 1, 1, 1, 1, 1);
+        GameTooltip:AddDoubleLine(v[1], v[2] .. (v[3] and (" |T" .. v[3] .. ":12:12:0:0:64:64:4:60:4:60|t") or ""), 1, 1, 1, 1, 1, 1, 1, 1)
       end
     end
-    line = line + 1;
+    line = line + 1
   end
-  GameTooltip:Show();
+  GameTooltip:Show()
 end
 
 local function ensure(t, k, v)
@@ -58,12 +60,12 @@ Methods
 -------------------------------------------------------------------------------]]
 local methods = {
   ["OnAcquire"] = function(self)
-    self:SetWidth(1000);
-    self:SetHeight(32);
+    self:SetWidth(1000)
+    self:SetHeight(32)
     self.hasThumbnail = false
   end,
   ["Initialize"] = function(self, id, companionData)
-    self.callbacks = {};
+    self.callbacks = {}
     self.id = id
     self.companionData = companionData
 
@@ -71,22 +73,21 @@ local methods = {
       WeakAuras.Import(self.companionData.encoded)
     end
 
-    self:SetTitle(self.companionData.name);
-    self.update:SetScript("OnClick", self.callbacks.OnUpdateClick);
+    self:SetTitle(self.companionData.name)
+    self.update:SetScript("OnClick", self.callbacks.OnUpdateClick)
     local data = OptionsPrivate.Private.StringToTable(self.companionData.encoded, true)
     self.data = data.d
-    -- self:SetNormalTooltip();
-    self.frame:EnableKeyboard(false);
-    self:Enable();
+    self.frame:EnableKeyboard(false)
+    self:Enable()
     self.frame:Hide()
   end,
   ["Disable"] = function(self)
-    self.background:Hide();
-    self.frame:Disable();
+    self.background:Hide()
+    self.frame:Disable()
   end,
   ["Enable"] = function(self)
-    self.background:Show();
-    self.frame:Enable();
+    self.background:Show()
+    self.frame:Enable()
     self.update:Show()
     self.update:Enable()
     self.updateLogo:Show()
@@ -94,23 +95,22 @@ local methods = {
   end,
   ["OnRelease"] = function(self)
     self:ReleaseThumbnail()
-    self:Enable();
-    self.title:Show();
-    self.frame:SetScript("OnEnter", nil);
-    self.frame:SetScript("OnLeave", nil);
-    self.frame:SetScript("OnClick", nil);
-    --self.frame:EnableMouse(false);
-    self.frame:ClearAllPoints();
-    self.frame:Hide();
-    self.frame = nil;
-    self.data = nil;
+    self:Enable()
+    self.title:Show()
+    self.frame:SetScript("OnEnter", nil)
+    self.frame:SetScript("OnLeave", nil)
+    self.frame:SetScript("OnClick", nil)
+    self.frame:ClearAllPoints()
+    self.frame:Hide()
+    self.frame = nil
+    self.data = nil
   end,
   ["SetTitle"] = function(self, title)
-    self.titletext = title;
-    self.title:SetText(title);
+    self.titletext = title
+    self.title:SetText(title)
   end,
   ["SetClick"] = function(self, func)
-    self.frame:SetScript("OnClick", func);
+    self.frame:SetScript("OnClick", func)
   end,
   ["UpdateThumbnail"] = function(self)
     if not self.hasThumbnail then
@@ -164,79 +164,79 @@ local methods = {
     end
   end,
   ["SetIcon"] = function(self, icon)
-    self.orgIcon = icon;
-    if(type(icon) == "string" or type(icon) == "number") then
-      self.icon:SetTexture(icon);
-      self.icon:Show();
-      if(self.iconRegion and self.iconRegion.Hide) then
-        self.iconRegion:Hide();
+    self.orgIcon = icon
+    if (type(icon) == "string" or type(icon) == "number") then
+      self.icon:SetTexture(icon)
+      self.icon:Show()
+      if (self.iconRegion and self.iconRegion.Hide) then
+        self.iconRegion:Hide()
       end
     else
-      self.iconRegion = icon;
-      icon:SetAllPoints(self.icon);
-      icon:SetParent(self.frame);
+      self.iconRegion = icon
+      icon:SetAllPoints(self.icon)
+      icon:SetParent(self.frame)
       icon:Show()
-      self.iconRegion:Show();
-      self.icon:Hide();
+      self.iconRegion:Show()
+      self.icon:Hide()
     end
     self.thumbnail.icon:SetDesaturated(true)
   end,
   ["OverrideIcon"] = function(self)
     self.icon:SetTexture("Interface\\Addons\\WeakAuras\\Media\\Textures\\icon.blp")
     self.icon:Show()
-    if(self.iconRegion and self.iconRegion.Hide) then
-      self.iconRegion:Hide();
+    if (self.iconRegion and self.iconRegion.Hide) then
+      self.iconRegion:Hide()
     end
   end,
   ["RestoreIcon"] = function(self)
-    self:SetIcon(self.orgIcon);
+    self:SetIcon(self.orgIcon)
   end,
   ["Expand"] = function(self, reloadTooltip)
-    self.expand:Enable();
+    self.expand:Enable()
     OptionsPrivate.SetCollapsed(self.data.id, "displayButton", "", false)
-    self.expand:SetNormalTexture("Interface\\BUTTONS\\UI-MinusButton-Up.blp");
-    self.expand:SetPushedTexture("Interface\\BUTTONS\\UI-MinusButton-Down.blp");
-    self.expand.title = L["Collapse"];
-    self.expand.desc = L["Hide this group's children"];
-    self.expand:SetScript("OnClick", function() self:Collapse(true) end);
-    self.expand.func();
-    if(reloadTooltip) then
-      Hide_Tooltip();
-      Show_Tooltip(self.frame, self.expand.title, self.expand.desc);
+    self.expand:SetNormalTexture("Interface\\BUTTONS\\UI-MinusButton-Up.blp")
+    self.expand:SetPushedTexture("Interface\\BUTTONS\\UI-MinusButton-Down.blp")
+    self.expand.title = L["Collapse"]
+    self.expand.desc = L["Hide this group's children"]
+    self.expand:SetScript("OnClick", function()
+      self:Collapse(true)
+    end)
+    self.expand.func()
+    if reloadTooltip then
+      Hide_Tooltip()
+      Show_Tooltip(self.frame, self.expand.title, self.expand.desc)
     end
   end,
   ["Collapse"] = function(self, reloadTooltip)
-    self.expand:Enable();
+    self.expand:Enable()
     OptionsPrivate.SetCollapsed(self.data.id, "displayButton", "", true)
-    self.expand:SetNormalTexture("Interface\\BUTTONS\\UI-PlusButton-Up.blp");
-    self.expand:SetPushedTexture("Interface\\BUTTONS\\UI-PlusButton-Down.blp");
-    self.expand.title = L["Expand"];
-    self.expand.desc = L["Show this group's children"];
-    self.expand:SetScript("OnClick", function() self:Expand(true) end);
-    self.expand.func();
-    --if(reloadTooltip) then
-    --  Hide_Tooltip();
-    --  Show_Tooltip(self.frame, self.expand.title, self.expand.desc);
-    --end
+    self.expand:SetNormalTexture("Interface\\BUTTONS\\UI-PlusButton-Up.blp")
+    self.expand:SetPushedTexture("Interface\\BUTTONS\\UI-PlusButton-Down.blp")
+    self.expand.title = L["Expand"]
+    self.expand.desc = L["Show this group's children"]
+    self.expand:SetScript("OnClick", function()
+      self:Expand(true)
+    end)
+    self.expand.func()
   end,
   ["SetOnExpandCollapse"] = function(self, func)
-    self.expand.func = func;
+    self.expand.func = func
   end,
   ["GetExpanded"] = function(self)
     return not OptionsPrivate.IsCollapsed(self.id, "displayButton", "", true)
   end,
   ["DisableExpand"] = function(self)
-    self.expand:Disable();
-    self.expand.disabled = true;
-    self.expand.expanded = false;
-    self.expand:SetNormalTexture("Interface\\BUTTONS\\UI-PlusButton-Disabled.blp");
+    self.expand:Disable()
+    self.expand.disabled = true
+    self.expand.expanded = false
+    self.expand:SetNormalTexture("Interface\\BUTTONS\\UI-PlusButton-Disabled.blp")
   end,
   ["EnableExpand"] = function(self)
-    self.expand.disabled = false;
-    if(self:GetExpanded()) then
-      self:Expand();
+    self.expand.disabled = false
+    if (self:GetExpanded()) then
+      self:Expand()
     else
-      self:Collapse();
+      self:Collapse()
     end
   end,
 }
@@ -246,50 +246,44 @@ Constructor
 -------------------------------------------------------------------------------]]
 
 local function Constructor()
-  local name = "WeakAurasPendingUpdateButton"..AceGUI:GetNextWidgetNum(Type);
-  local button = CreateFrame("BUTTON", name, UIParent);
-  button:SetHeight(32);
-  button:SetWidth(1000);
-  button.dgroup = nil;
-  button.data = {};
+  local name = "WeakAurasPendingUpdateButton" .. AceGUI:GetNextWidgetNum(Type)
+  local button = CreateFrame("BUTTON", name, UIParent)
+  button:SetHeight(32)
+  button:SetWidth(1000)
+  button.dgroup = nil
+  button.data = {}
 
-  local background = button:CreateTexture(nil, "BACKGROUND");
-  button.background = background;
-  background:SetTexture("Interface\\BUTTONS\\UI-Listbox-Highlight2.blp");
-  background:SetBlendMode("ADD");
-  background:SetVertexColor(0.5, 1, 0.5, 0.3);
-  background:SetPoint("TOP", button, "TOP");
-  background:SetPoint("BOTTOM", button, "BOTTOM");
-  background:SetPoint("LEFT", button, "LEFT");
-  background:SetPoint("RIGHT", button, "RIGHT");
+  local background = button:CreateTexture(nil, "BACKGROUND")
+  button.background = background
+  background:SetTexture("Interface\\BUTTONS\\UI-Listbox-Highlight2.blp")
+  background:SetBlendMode("ADD")
+  background:SetVertexColor(0.5, 1, 0.5, 0.3)
+  background:SetPoint("TOP", button, "TOP")
+  background:SetPoint("BOTTOM", button, "BOTTOM")
+  background:SetPoint("LEFT", button, "LEFT")
+  background:SetPoint("RIGHT", button, "RIGHT")
 
-  local icon = button:CreateTexture(nil, "OVERLAY");
-  button.icon = icon;
-  icon:SetWidth(32);
-  icon:SetHeight(32);
-  icon:SetPoint("LEFT", button, "LEFT");
+  local icon = button:CreateTexture(nil, "OVERLAY")
+  button.icon = icon
+  icon:SetWidth(32)
+  icon:SetHeight(32)
+  icon:SetPoint("LEFT", button, "LEFT")
 
-  local title = button:CreateFontString(nil, "OVERLAY", "GameFontNormal");
-  button.title = title;
-  title:SetHeight(14);
-  title:SetJustifyH("LEFT");
-  title:SetPoint("TOPLEFT", icon, "TOPRIGHT", 2, 0);
-  title:SetPoint("BOTTOMRIGHT", button, "BOTTOMRIGHT");
+  local title = button:CreateFontString(nil, "OVERLAY", "GameFontNormal")
+  button.title = title
+  title:SetHeight(14)
+  title:SetJustifyH("LEFT")
+  title:SetPoint("TOPLEFT", icon, "TOPRIGHT", 2, 0)
+  title:SetPoint("BOTTOMRIGHT", button, "BOTTOMRIGHT")
   title:SetVertexColor(0.6, 0.6, 0.6)
 
-  button.description = {};
+  button.description = {}
 
-  --[[
-  button:SetScript("OnEnter", function()
-      Show_Long_Tooltip(button, button.description);
-  end);
-  button:SetScript("OnLeave", Hide_Tooltip);
-  ]]--
-
-  local update = CreateFrame("BUTTON", nil, button);
+  local update = CreateFrame("BUTTON", nil, button)
   button.update = update
   update.disabled = true
-  update.func = function() end
+  update.func = function()
+  end
   update:SetNormalTexture([[Interface\AddOns\WeakAuras\Media\Textures\wagoupdate_refresh.tga]])
   update:Disable()
   update:SetWidth(24)
@@ -302,22 +296,25 @@ local function Constructor()
   local tex = updateLogo:CreateTexture(nil, "OVERLAY")
   tex:SetTexture([[Interface\AddOns\WeakAuras\Media\Textures\wagoupdate_logo.tga]])
   tex:SetAllPoints()
-  updateLogo:SetSize(24,24)
-  updateLogo:SetPoint("CENTER",update)
+  updateLogo:SetSize(24, 24)
+  updateLogo:SetPoint("CENTER", update)
 
   -- Animation On Hover
   local animGroup = update:CreateAnimationGroup()
   update.animGroup = animGroup
+
   local animRotate = animGroup:CreateAnimation("rotation")
   animRotate:SetDegrees(-360)
   animRotate:SetDuration(1)
   animRotate:SetSmoothing("OUT")
-  animGroup:SetScript("OnFinished",function() if (MouseIsOver(update)) then animGroup:Play() end end)
+  animGroup:SetScript("OnFinished", function()
+    if (MouseIsOver(update)) then
+      animGroup:Play()
+    end
+  end)
   update:SetScript("OnEnter", function()
     animGroup:Play()
-    --Show_Tooltip(button, update.title, update.desc)
-  end);
-  -- update:SetScript("OnLeave", Hide_Tooltip)
+  end)
   update:Hide()
   updateLogo:Hide()
 
@@ -328,13 +325,14 @@ local function Constructor()
     background = background,
     update = update,
     updateLogo = updateLogo,
-    type = Type
+    type = Type,
   }
+
   for method, func in pairs(methods) do
     widget[method] = func
   end
 
-  return AceGUI:RegisterAsWidget(widget);
+  return AceGUI:RegisterAsWidget(widget)
 end
 
 AceGUI:RegisterWidgetType(Type, Constructor, Version)

--- a/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasPendingUpdateButton.lua
+++ b/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasPendingUpdateButton.lua
@@ -253,7 +253,7 @@ local function Constructor()
   button.background = background;
   background:SetTexture("Interface\\BUTTONS\\UI-Listbox-Highlight2.blp");
   background:SetBlendMode("ADD");
-  background:SetVertexColor(0.5, 0.5, 0.5, 0.25);
+  background:SetVertexColor(0.5, 0.5, 0.5, 0.1);
   background:SetPoint("TOP", button, "TOP");
   background:SetPoint("BOTTOM", button, "BOTTOM");
   background:SetPoint("LEFT", button, "LEFT");

--- a/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasPendingUpdateButton.lua
+++ b/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasPendingUpdateButton.lua
@@ -176,6 +176,7 @@ local methods = {
       self.iconRegion:Show();
       self.icon:Hide();
     end
+    self.thumbnail.icon:SetDesaturated(true)
   end,
   ["OverrideIcon"] = function(self)
     self.icon:SetTexture("Interface\\Addons\\WeakAuras\\Media\\Textures\\icon.blp")

--- a/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasPendingUpdateButton.lua
+++ b/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasPendingUpdateButton.lua
@@ -282,43 +282,40 @@ local function Constructor()
   button:SetScript("OnLeave", Hide_Tooltip);
   ]]--
 
-  local update, updateLogo
-  if WeakAurasCompanion then
-    update = CreateFrame("BUTTON", nil, button);
-    button.update = update
-    update.disabled = true
-    update.func = function() end
-    update:SetNormalTexture([[Interface\AddOns\WeakAuras\Media\Textures\wagoupdate_refresh.tga]])
-    update:Disable()
-    update:SetWidth(24)
-    update:SetHeight(24)
-    update:SetPoint("RIGHT", button, "RIGHT", -35, 0)
+  local update = CreateFrame("BUTTON", nil, button);
+  button.update = update
+  update.disabled = true
+  update.func = function() end
+  update:SetNormalTexture([[Interface\AddOns\WeakAuras\Media\Textures\wagoupdate_refresh.tga]])
+  update:Disable()
+  update:SetWidth(24)
+  update:SetHeight(24)
+  update:SetPoint("RIGHT", button, "RIGHT", -2, 0)
 
-    -- Add logo
-    updateLogo = CreateFrame("Frame", nil, button)
-    button.updateLogo = updateLogo
-    local tex = updateLogo:CreateTexture(nil, "OVERLAY")
-    tex:SetTexture([[Interface\AddOns\WeakAuras\Media\Textures\wagoupdate_logo.tga]])
-    tex:SetAllPoints()
-    updateLogo:SetSize(24,24)
-    updateLogo:SetPoint("CENTER",update)
+  -- Add logo
+  local updateLogo = CreateFrame("Frame", nil, button)
+  button.updateLogo = updateLogo
+  local tex = updateLogo:CreateTexture(nil, "OVERLAY")
+  tex:SetTexture([[Interface\AddOns\WeakAuras\Media\Textures\wagoupdate_logo.tga]])
+  tex:SetAllPoints()
+  updateLogo:SetSize(24,24)
+  updateLogo:SetPoint("CENTER",update)
 
-    -- Animation On Hover
-    local animGroup = update:CreateAnimationGroup()
-    update.animGroup = animGroup
-    local animRotate = animGroup:CreateAnimation("rotation")
-    animRotate:SetDegrees(-360)
-    animRotate:SetDuration(1)
-    animRotate:SetSmoothing("OUT")
-    animGroup:SetScript("OnFinished",function() if (MouseIsOver(update)) then animGroup:Play() end end)
-    update:SetScript("OnEnter", function()
-      animGroup:Play()
-      --Show_Tooltip(button, update.title, update.desc)
-    end);
-    -- update:SetScript("OnLeave", Hide_Tooltip)
-    update:Hide()
-    updateLogo:Hide()
-  end
+  -- Animation On Hover
+  local animGroup = update:CreateAnimationGroup()
+  update.animGroup = animGroup
+  local animRotate = animGroup:CreateAnimation("rotation")
+  animRotate:SetDegrees(-360)
+  animRotate:SetDuration(1)
+  animRotate:SetSmoothing("OUT")
+  animGroup:SetScript("OnFinished",function() if (MouseIsOver(update)) then animGroup:Play() end end)
+  update:SetScript("OnEnter", function()
+    animGroup:Play()
+    --Show_Tooltip(button, update.title, update.desc)
+  end);
+  -- update:SetScript("OnLeave", Hide_Tooltip)
+  update:Hide()
+  updateLogo:Hide()
 
   local widget = {
     frame = button,

--- a/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasPendingUpdateButton.lua
+++ b/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasPendingUpdateButton.lua
@@ -257,7 +257,7 @@ local function Constructor()
   button.background = background;
   background:SetTexture("Interface\\BUTTONS\\UI-Listbox-Highlight2.blp");
   background:SetBlendMode("ADD");
-  background:SetVertexColor(0.5, 0.5, 0.5, 0.1);
+  background:SetVertexColor(0.5, 1, 0.5, 0.3);
   background:SetPoint("TOP", button, "TOP");
   background:SetPoint("BOTTOM", button, "BOTTOM");
   background:SetPoint("LEFT", button, "LEFT");

--- a/WeakAurasOptions/OptionsFrames/OptionsFrame.lua
+++ b/WeakAurasOptions/OptionsFrames/OptionsFrame.lua
@@ -707,6 +707,27 @@ function OptionsPrivate.CreateFrame()
     frame.addonsButton = addonsButton
   end
 
+  local pendingImportButton = AceGUI:Create("WeakAurasLoadedHeaderButton")
+  pendingImportButton:SetText(L["Ready to Import"])
+  pendingImportButton:Disable()
+  pendingImportButton:EnableExpand()
+  if odb.pendingImportCollapse then
+    pendingImportButton:Collapse()
+  else
+    pendingImportButton:Expand()
+  end
+  pendingImportButton:SetOnExpandCollapse(function()
+    if pendingImportButton:GetExpanded() then
+      odb.pendingImportCollapse = nil
+    else
+      odb.pendingImportCollapse = true
+    end
+    WeakAuras.SortDisplayButtons()
+  end)
+  pendingImportButton:SetExpandDescription(L["Expand all Pending Import"])
+  pendingImportButton:SetCollapseDescription(L["Collapse all Pending Import"])
+  frame.pendingImportButton = pendingImportButton
+
   local loadedButton = AceGUI:Create("WeakAurasLoadedHeaderButton")
   loadedButton:SetText(L["Loaded"])
   loadedButton:Disable()

--- a/WeakAurasOptions/WeakAurasOptions.lua
+++ b/WeakAurasOptions/WeakAurasOptions.lua
@@ -625,6 +625,9 @@ local function LayoutDisplayButtons(msg)
   --if(frame.addonsButton) then
   --  frame.buttonsScroll:AddChild(frame.addonsButton);
   --end
+  if WeakAurasCompanion and WeakAurasCompanion.stash and next(WeakAurasCompanion.stash) then
+    frame.buttonsScroll:AddChild(frame.pendingImportButton);
+  end
   frame.buttonsScroll:AddChild(frame.loadedButton);
   frame.buttonsScroll:AddChild(frame.unloadedButton);
 
@@ -870,6 +873,7 @@ function OptionsPrivate.UpdateButtonsScroll()
 end
 
 local previousFilter;
+local pendingUpdateButtons = {}
 function WeakAuras.SortDisplayButtons(filter, overrideReset, id)
   if (OptionsPrivate.Private.IsOptionsProcessingPaused()) then
     return;
@@ -887,10 +891,31 @@ function WeakAuras.SortDisplayButtons(filter, overrideReset, id)
   filter = filter:lower();
 
   wipe(frame.buttonsScroll.children);
-  --tinsert(frame.buttonsScroll.children, frame.newButton);
-  --if(frame.addonsButton) then
-  --  tinsert(frame.buttonsScroll.children, frame.addonsButton);
-  --end
+
+  if WeakAurasCompanion and WeakAurasCompanion.stash then
+    local pendingImportButtonShown = false
+    for id, data in pairs(WeakAurasCompanion.stash) do
+      if not pendingImportButtonShown then
+        tinsert(frame.buttonsScroll.children, frame.pendingImportButton)
+        pendingImportButtonShown = true
+      end
+      if frame.pendingImportButton:GetExpanded() then
+        if not(pendingUpdateButtons[id]) then
+          pendingUpdateButtons[id] = AceGUI:Create("WeakAurasPendingUpdateButton")
+          pendingUpdateButtons[id]:Initialize(id, data)
+        end
+        pendingUpdateButtons[id].frame:Show()
+        pendingUpdateButtons[id]:AcquireThumbnail()
+        frame.buttonsScroll:AddChild(pendingUpdateButtons[id])
+      elseif pendingUpdateButtons[id] then
+        pendingUpdateButtons[id].frame:Hide()
+        if pendingUpdateButtons[id].ReleaseThumbnail then
+          pendingUpdateButtons[id]:ReleaseThumbnail()
+        end
+      end
+    end
+  end
+
   tinsert(frame.buttonsScroll.children, frame.loadedButton);
   local numLoaded = 0;
   local to_sort = {};

--- a/WeakAurasOptions/WeakAurasOptions.lua
+++ b/WeakAurasOptions/WeakAurasOptions.lua
@@ -903,6 +903,12 @@ function WeakAuras.SortDisplayButtons(filter, overrideReset, id)
         if not(pendingUpdateButtons[id]) then
           pendingUpdateButtons[id] = AceGUI:Create("WeakAurasPendingUpdateButton")
           pendingUpdateButtons[id]:Initialize(id, data)
+          if data.logo then
+            pendingUpdateButtons[id]:SetLogo(data.logo)
+          end
+          if data.refreshLogo then
+            pendingUpdateButtons[id]:SetRefreshLogo(data.logo)
+          end
         end
         pendingUpdateButtons[id].frame:Show()
         pendingUpdateButtons[id]:AcquireThumbnail()

--- a/WeakAurasOptions/WeakAurasOptions.toc
+++ b/WeakAurasOptions/WeakAurasOptions.toc
@@ -75,6 +75,7 @@ AceGUI-Widgets\AceGUIWidget-WeakAurasIcon.lua
 AceGUI-Widgets\AceGUIWidget-WeakAurasNewHeaderButton.lua
 AceGUI-Widgets\AceGUIWidget-WeakAurasLoadedHeaderButton.lua
 AceGUI-Widgets\AceGUIWidget-WeakAurasDisplayButton.lua
+AceGUI-Widgets\AceGUIWidget-WeakAurasPendingUpdateButton.lua
 AceGUI-Widgets\AceGUIWidget-WeakAurasTextureButton.lua
 AceGUI-Widgets\AceGUIWidget-WeakAurasIconButton.lua
 AceGUI-Widgets\AceGUIWidget-WeakAurasMultiLineEditBox.lua


### PR DESCRIPTION
# Description

Add a WeakAuras.StashShow function that WeakAurasCompanion can use when there are auras pushed from Wago with weakauras-companion://wago/push/<wagoID>

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How to test

- get last companion build (current https://github.com/WeakAuras/WeakAuras-Companion/suites/2521299971/artifacts/54607460)
- go to https://wago.io/d3cV99LwL
- ctrl+shift+k on firefox to open dev console and type/run `enableCompanion = true`
![image](https://user-images.githubusercontent.com/189656/115134232-a39e9f00-a00e-11eb-8e0f-b9935ec09b83.png)

- press button "SEND TO WEAKAURA COMPANION APP"
![image](https://user-images.githubusercontent.com/189656/115133891-df843500-a00b-11eb-9262-7fa640e55552.png)

- unfinished UI show in companion
![image](https://user-images.githubusercontent.com/189656/115133898-eca12400-a00b-11eb-845c-4ded13d575a1.png)

- /reload in game
![image](https://user-images.githubusercontent.com/189656/115148019-010e0c80-a05e-11eb-850e-ab92ed0e86de.png)



## TODO in WeakAuras
- make less ugly UI

## TODO in Companion
- make less ugly UI