### PR TITLE
Add Ready for Update section + fixes to Install section

### DIFF
--- a/WeakAuras/Transmission.lua
+++ b/WeakAuras/Transmission.lua
@@ -229,6 +229,15 @@ showCodeButton:SetPoint("BOTTOMLEFT", 8, 8)
 showCodeButton:SetText(L["Show Code"])
 showCodeButton:SetWidth(90)
 
+local urlEditBox = CreateFrame("EDITBOX", "WeakAurasTooltipUrlEditBox", buttonAnchor)
+urlEditBox:SetWidth(250)
+urlEditBox:SetHeight(34)
+urlEditBox:SetFont(STANDARD_TEXT_FONT, 12)
+urlEditBox:SetPoint("TOPLEFT", 65, -57)
+urlEditBox:SetScript("OnMouseUp", function() urlEditBox:HighlightText() end)
+urlEditBox:SetScript("OnChar", function() urlEditBox:SetText(urlEditBox.text) urlEditBox:HighlightText() end)
+urlEditBox:SetAutoFocus(false)
+
 local checkButtons, radioButtons, keyToButton, pendingData = {}, {}, {}, {}
 
 for _, key in pairs(Private.internal_fields) do
@@ -843,6 +852,15 @@ function Private.RefreshTooltipButtons()
   else
     showCodeButton:Show()
   end
+  urlEditBox:Enable()
+  if pendingData.url then
+    urlEditBox:Show()
+    urlEditBox.text = pendingData.url
+    urlEditBox:SetText(pendingData.url)
+    urlEditBox:HighlightText(0, 0)
+  else
+    urlEditBox:Hide()
+  end
   if InCombatLockdown() then
     importButton:SetText(L["In Combat"])
     importButton.tooltipText = L["Importing is disabled while in combat"]
@@ -1453,6 +1471,7 @@ local function ShowDisplayTooltip(data, children, matchInfo, icon, icons, import
   local highestVersion = data.internalVersion or 1;
   local hasDescription = data.desc and data.desc ~= "";
   local hasUrl = data.url and data.url ~= "";
+  pendingData.url = hasUrl and data.url
   local hasVersion = (data.semver and data.semver ~= "") or (data.version and data.version ~= "");
   local tocversion = data.tocversion;
 
@@ -1460,12 +1479,12 @@ local function ShowDisplayTooltip(data, children, matchInfo, icon, icons, import
     tinsert(tooltip, {1, " "});
   end
 
-  if hasDescription then
-    tinsert(tooltip, {1, "\""..data.desc.."\"", 1, 0.82, 0, 1});
+  if hasUrl then
+    tinsert(tooltip, {1, L["Source: "], 1, 0.82, 0, 1});
   end
 
-  if hasUrl then
-    tinsert(tooltip, {1, L["Source: "] .. data.url, 1, 0.82, 0, 1});
+  if hasDescription then
+    tinsert(tooltip, {1, "\""..data.desc.."\"", 1, 0.82, 0, 1});
   end
 
   if hasVersion then

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -815,11 +815,7 @@ function WeakAuras.CountWagoUpdates()
       end
       if slug and version then
         local wago = CompanionData.slugs and CompanionData.slugs[slug]
-        if wago and wago.wagoVersion
-        and tonumber(wago.wagoVersion) > (
-          aura.skipWagoUpdate and tonumber(aura.skipWagoUpdate) or tonumber(version)
-        )
-        then
+        if wago and wago.wagoVersion and tonumber(wago.wagoVersion) > tonumber(version) then
           if not updatedSlugs[slug] then
             updatedSlugs[slug] = true
             updatedSlugsCount = updatedSlugsCount + 1

--- a/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasDisplayButton.lua
+++ b/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasDisplayButton.lua
@@ -820,13 +820,6 @@ local methods = {
       end
     end
 
-    function self.callbacks.OnUpdateClick()
-      local _,_,updateData = self:HasUpdate()
-      if updateData then
-        WeakAuras.Import(updateData.encoded, self.data)
-      end
-    end
-
     function self.callbacks.OnRenameAction(newid)
       if (WeakAuras.IsImporting()) then return end;
       local oldid = data.id;
@@ -854,44 +847,17 @@ local methods = {
       end
     end
 
-    function self.callbacks.wagoStopIgnoreAll(_, skipUpdateIcon)
-      self.data.ignoreWagoUpdate = nil
-      self.data.skipWagoUpdate = nil
-      if not skipUpdateIcon then
-        self:RefreshUpdate("wagoStopIgnoreAll")
+    self.frame:SetScript("OnEnter", function()
+      if(OptionsPrivate.IsPickedMultiple() and OptionsPrivate.IsDisplayPicked(self.frame.id)) then
+        Show_Long_Tooltip(self.frame, OptionsPrivate.MultipleDisplayTooltipDesc());
+      else
+        if not self.grouping then
+          self:SetNormalTooltip();
+        end
+        Show_Long_Tooltip(self.frame, self.frame.description);
       end
-    end
-
-    function self.callbacks.wagoIgnoreAll(_, skipUpdateIcon)
-      self.data.ignoreWagoUpdate = true
-      if not skipUpdateIcon then
-        self:RefreshUpdate("wagoIgnoreAll")
-      end
-    end
-
-    function self.callbacks.wagoStopIgnoreNext(_, skipUpdateIcon)
-      self.data.skipWagoUpdate = nil
-      if not skipUpdateIcon then
-        self:RefreshUpdate("wagoStopIgnoreNext")
-      end
-    end
-
-    function self.callbacks.wagoIgnoreNext(_, skipUpdateIcon)
-      self.data.skipWagoUpdate = self.update.version
-      if not skipUpdateIcon then
-        self:RefreshUpdate("wagoIgnoreNext")
-      end
-    end
-
-    self.frame.terribleCodeOrganizationHackTable = {};
-
-    function self.frame.terribleCodeOrganizationHackTable.IsGroupingOrCopying()
-      return self.grouping;
-    end
-
-    function self.frame.terribleCodeOrganizationHackTable.SetNormalTooltip()
-      self:SetNormalTooltip();
-    end
+    end);
+    self.frame:SetScript("OnLeave", Hide_Tooltip);
 
     local copyEntries = {};
     tinsert(copyEntries, clipboard.copyEverythingEntry);
@@ -961,15 +927,6 @@ local methods = {
       func = function() OptionsPrivate.ExportToTable(data.id) end
     });
 
-    if WeakAurasCompanion then
-      tinsert(self.menu, {
-        text = '|TInterface\\OptionsFrame\\UI-OptionsFrame-NewFeatureIcon:0|t' .. L["Wago Update"],
-        notCheckable = true,
-        hasArrow = true,
-        menuList = { }
-      });
-    end
-
     tinsert(self.menu, {
       text = " ",
       notClickable = true,
@@ -1025,22 +982,6 @@ local methods = {
     self.ungroup:SetScript("OnClick", self.callbacks.OnUngroupClick);
     self.upgroup:SetScript("OnClick", self.callbacks.OnUpGroupClick);
     self.downgroup:SetScript("OnClick", self.callbacks.OnDownGroupClick);
-
-    if WeakAurasCompanion then
-      local hasUpdate, _, updateData = self:HasUpdate()
-      if hasUpdate then
-        self.update.hasUpdate = hasUpdate
-        self.update.version = updateData.wagoVersion
-        local showVersion = self.data.semver or self.data.version or 0
-        local showCompanionVersion = updateData.wagoSemver or updateData.wagoVersion
-        self.update.title = L["Update %s by %s"]:format(updateData.name, updateData.author)
-        self.update.desc = L["From version %s to version %s"]:format(showVersion, showCompanionVersion)
-        if updateData.versionNote then
-          self.update.desc = ("%s\n\n%s"):format(self.update.desc, updateData.versionNote)
-        end
-        self.update:SetScript("OnClick", self.callbacks.OnUpdateClick);
-      end
-    end
 
     if data.parent then
       local parentData = WeakAuras.GetData(data.parent);
@@ -1440,98 +1381,6 @@ local methods = {
       self:Collapse();
     end
   end,
-  ["ShowGroupUpdate"] = function(self)
-    if self.groupUpdate and self.groupUpdate.disabled then
-      self.groupUpdate:Show()
-      self.groupUpdate.disabled = false
-    end
-  end,
-  ["HideGroupUpdate"] = function(self)
-    if self.groupUpdate and not self.groupUpdate.disabled then
-      self.groupUpdate:Hide()
-      self.groupUpdate.disabled = true
-    end
-  end,
-  ["RefreshUpdateMenu"] = function(self)
-    local pos
-    for k, menu in pairs(self.menu) do
-      if menu.text and menu.text:find(L["Wago Update"]) then
-        pos = k
-        break
-      end
-    end
-    if pos then
-      local wagoMenu = self.menu[pos].menuList
-      for i=1,#wagoMenu do tremove(wagoMenu, 1) end
-      tinsert(wagoMenu, {
-        text = self.data.ignoreWagoUpdate and L["Stop ignoring Updates"] or L["Ignore all Updates"],
-        notCheckable = true,
-        func = self.data.ignoreWagoUpdate and self.callbacks.wagoStopIgnoreAll or self.callbacks.wagoIgnoreAll
-      })
-      if not self.data.ignoreWagoUpdate and self.update.hasUpdate then
-        if self.data.skipWagoUpdate and self.update.version == self.data.skipWagoUpdate then
-          tinsert(wagoMenu, {
-            text =  L["Don't skip this Version"],
-            notCheckable = true,
-            func = self.callbacks.wagoStopIgnoreNext
-          });
-        else
-          tinsert(wagoMenu, {
-            text = L["Skip this Version"],
-            notCheckable = true,
-            func = self.callbacks.wagoIgnoreNext
-          });
-          tinsert(wagoMenu, {
-            text = " ",
-            notClickable = true,
-            notCheckable = true,
-          });
-          tinsert(wagoMenu, {
-            text = L["Update this Aura"],
-            notCheckable = true,
-            func = self.callbacks.OnUpdateClick
-          });
-        end
-      end
-    end
-  end,
-  ["ShowUpdateIcon"] = function(self)
-    if self.update and self.update.disabled then
-      self.update:Show()
-      self.update:Enable()
-      self.updateLogo:Show()
-      self.update.disabled = false
-    end
-  end,
-  ["HideUpdateIcon"] = function(self)
-    if self.update and not self.update.disabled then
-      self.update:Hide()
-      self.update:Disable()
-      self.updateLogo:Hide()
-      self.update.disabled = true
-    end
-  end,
-  ["HasUpdate"] = function(self)
-    local CompanionData = WeakAurasCompanion and WeakAurasCompanion.WeakAuras or WeakAurasCompanion
-    if not (CompanionData and CompanionData.uids and CompanionData.ids) or self.data.ignoreWagoUpdate then return end
-    local slug = self.data.uid and CompanionData.uids[self.data.uid] or CompanionData.ids[self.data.id]
-    if slug then
-      local updateData = CompanionData.slugs and CompanionData.slugs[slug]
-      if updateData then
-        if not (self.data.skipWagoUpdate and self.data.skipWagoUpdate == updateData.wagoVersion) then
-          if not self.data.version or tonumber(updateData.wagoVersion) > tonumber(self.data.version) then
-            -- got update
-            return true, false, updateData, slug
-          end
-        else
-          -- version skip flag
-          return true, true, updateData, slug
-        end
-      end
-    end
-    -- no addon, or no data, or ignore flag
-    return false, false, nil, nil
-  end,
   ["UpdateWarning"] = function(self)
     local icon, title, warningText = OptionsPrivate.Private.AuraWarnings.FormatWarnings(self.data.uid)
     if warningText then
@@ -1549,50 +1398,6 @@ local methods = {
       end)
     else
       self.warning:Hide()
-    end
-  end,
-  ["RefreshUpdate"] = function(self, actionFunc)
-    if self.data.parent then
-      -- is in a group
-      local parentButton = WeakAuras.GetDisplayButton(self.data.parent)
-      if parentButton then
-        parentButton:RefreshUpdate(actionFunc)
-      end
-    else
-      -- is top level
-      local hasUpdate, skipVersion, _, slug = self:HasUpdate()
-      self:RefreshUpdateMenu()
-      if hasUpdate and not skipVersion then
-        self:ShowUpdateIcon()
-      else
-        self:HideUpdateIcon()
-      end
-      if self.data.controlledChildren then
-        -- is a group
-        local hasUpdate, skipVersion, _, slug = self:HasUpdate()
-        local showGroupUpdateIcon = false
-        for childIndex, childId in pairs(self.data.controlledChildren) do
-          local childButton = WeakAuras.GetDisplayButton(childId);
-          if childButton then
-            if actionFunc then
-              childButton.callbacks[actionFunc](nil, true)
-            end
-            childButton:RefreshUpdateMenu()
-            local childHasUpdate, childSkipVersion, _, childSlug = childButton:HasUpdate()
-            if childHasUpdate and slug ~= childSlug and not childSkipVersion then
-              showGroupUpdateIcon = true
-              childButton:ShowUpdateIcon()
-            else
-              childButton:HideUpdateIcon()
-            end
-          end
-        end
-        if showGroupUpdateIcon then
-          self:ShowGroupUpdate()
-        else
-          self:HideGroupUpdate()
-        end
-      end
     end
   end,
   ["SetGroupOrder"] = function(self, order, max)
@@ -1821,18 +1626,6 @@ local function Constructor()
 
   button.description = {};
 
-  button:SetScript("OnEnter", function()
-    if(OptionsPrivate.IsPickedMultiple() and OptionsPrivate.IsDisplayPicked(button.id)) then
-      Show_Long_Tooltip(button, OptionsPrivate.MultipleDisplayTooltipDesc());
-    else
-      if not(button.terribleCodeOrganizationHackTable.IsGroupingOrCopying()) then
-        button.terribleCodeOrganizationHackTable.SetNormalTooltip();
-      end
-      Show_Long_Tooltip(button, button.description);
-    end
-  end);
-  button:SetScript("OnLeave", Hide_Tooltip);
-
   local view = CreateFrame("BUTTON", nil, button);
   button.view = view;
   view:SetWidth(16);
@@ -2017,67 +1810,6 @@ local function Constructor()
   expand:SetScript("OnEnter", function() Show_Tooltip(button, expand.title, expand.desc) end);
   expand:SetScript("OnLeave", Hide_Tooltip);
 
-  local update, updateLogo
-  local groupUpdate
-  if WeakAurasCompanion then
-    update = CreateFrame("BUTTON", nil, button);
-    button.update = update
-    update.disabled = true
-    update.func = function() end
-    update:SetNormalTexture([[Interface\AddOns\WeakAuras\Media\Textures\wagoupdate_refresh.tga]])
-    update:Disable()
-    update:SetWidth(24)
-    update:SetHeight(24)
-    update:SetPoint("RIGHT", button, "RIGHT", -35, 0)
-    update.title = ""
-    update.desc = ""
-    update.hasUpdate = false
-    update.version = nil
-    update.menuDisabled = true
-
-    -- Add logo
-    updateLogo = CreateFrame("Frame", nil, button)
-    button.updateLogo = updateLogo
-    local tex = updateLogo:CreateTexture(nil, "OVERLAY")
-    tex:SetTexture([[Interface\AddOns\WeakAuras\Media\Textures\wagoupdate_logo.tga]])
-    tex:SetAllPoints()
-    updateLogo:SetSize(24,24)
-    updateLogo:SetPoint("CENTER",update)
-
-    -- Animation On Hover
-    local animGroup = update:CreateAnimationGroup()
-    update.animGroup = animGroup
-    local animRotate = animGroup:CreateAnimation("rotation")
-    animRotate:SetDegrees(-360)
-    animRotate:SetDuration(1)
-    animRotate:SetSmoothing("OUT")
-
-    animGroup:SetScript("OnFinished",function() if (MouseIsOver(update)) then animGroup:Play() end end)
-    update:SetScript("OnEnter", function()
-      animGroup:Play()
-      Show_Tooltip(button, update.title, update.desc)
-    end);
-    update:SetScript("OnLeave", Hide_Tooltip)
-    update:Hide()
-    updateLogo:Hide()
-
-    -- Update in group icon
-    groupUpdate = CreateFrame("Frame", nil, button)
-    button.groupUpdate = groupUpdate
-    local gTex = groupUpdate:CreateTexture(nil, "OVERLAY")
-    gTex:SetTexture([[Interface\AddOns\WeakAuras\Media\Textures\wagoupdate_logo.tga]])
-    gTex:SetAllPoints()
-    groupUpdate:SetSize(16, 16)
-    groupUpdate:SetPoint("BOTTOM", button, "BOTTOM")
-    groupUpdate:SetPoint("LEFT", icon, "RIGHT", 20, 0)
-    groupUpdate.disabled = true
-    groupUpdate.title = L["Update in Group"]
-    groupUpdate.desc = L["Group contains updates from Wago"]
-    groupUpdate:SetScript("OnEnter", function() Show_Tooltip(button, groupUpdate.title, groupUpdate.desc) end)
-    groupUpdate:SetScript("OnLeave", Hide_Tooltip)
-    groupUpdate:Hide()
-  end
-
   local warning = CreateFrame("BUTTON", nil, button);
   button.warning = warning
   warning:SetWidth(16)
@@ -2099,10 +1831,7 @@ local function Constructor()
     loaded = loaded,
     background = background,
     expand = expand,
-    update = update,
     warning = warning,
-    groupUpdate = groupUpdate,
-    updateLogo = updateLogo,
     type = Type
   }
   for method, func in pairs(methods) do

--- a/WeakAurasOptions/OptionsFrames/OptionsFrame.lua
+++ b/WeakAurasOptions/OptionsFrames/OptionsFrame.lua
@@ -707,27 +707,53 @@ function OptionsPrivate.CreateFrame()
     frame.addonsButton = addonsButton
   end
 
-  local pendingImportButton = AceGUI:Create("WeakAurasLoadedHeaderButton")
-  pendingImportButton:SetText(L["Ready to Import"])
-  pendingImportButton:Disable()
-  pendingImportButton:EnableExpand()
+  -- Ready to Install section
+  local pendingInstallButton = AceGUI:Create("WeakAurasLoadedHeaderButton")
+  pendingInstallButton:SetText(L["Ready for Install"])
+  pendingInstallButton:Disable()
+  pendingInstallButton:EnableExpand()
+  pendingInstallButton.frame.view:Hide()
   if odb.pendingImportCollapse then
-    pendingImportButton:Collapse()
+    pendingInstallButton:Collapse()
   else
-    pendingImportButton:Expand()
+    pendingInstallButton:Expand()
   end
-  pendingImportButton:SetOnExpandCollapse(function()
-    if pendingImportButton:GetExpanded() then
+  pendingInstallButton:SetOnExpandCollapse(function()
+    if pendingInstallButton:GetExpanded() then
       odb.pendingImportCollapse = nil
     else
       odb.pendingImportCollapse = true
     end
     WeakAuras.SortDisplayButtons()
   end)
-  pendingImportButton:SetExpandDescription(L["Expand all Pending Import"])
-  pendingImportButton:SetCollapseDescription(L["Collapse all Pending Import"])
-  frame.pendingImportButton = pendingImportButton
+  pendingInstallButton:SetExpandDescription(L["Expand all pending Import"])
+  pendingInstallButton:SetCollapseDescription(L["Collapse all pending Import"])
+  frame.pendingInstallButton = pendingInstallButton
 
+  -- Ready for update section
+  local pendingUpdateButton = AceGUI:Create("WeakAurasLoadedHeaderButton")
+  pendingUpdateButton:SetText(L["Ready for Update"])
+  pendingUpdateButton:Disable()
+  pendingUpdateButton:EnableExpand()
+  pendingUpdateButton.frame.view:Hide()
+  if odb.pendingUpdateCollapse then
+    pendingUpdateButton:Collapse()
+  else
+    pendingUpdateButton:Expand()
+  end
+  pendingUpdateButton:SetOnExpandCollapse(function()
+    if pendingUpdateButton:GetExpanded() then
+      odb.pendingUpdateCollapse = nil
+    else
+      odb.pendingUpdateCollapse = true
+    end
+    WeakAuras.SortDisplayButtons()
+  end)
+  pendingUpdateButton:SetExpandDescription(L["Expand all pending Import"])
+  pendingUpdateButton:SetCollapseDescription(L["Collapse all pending Import"])
+  frame.pendingUpdateButton = pendingUpdateButton
+
+  -- Loaded section
   local loadedButton = AceGUI:Create("WeakAurasLoadedHeaderButton")
   loadedButton:SetText(L["Loaded"])
   loadedButton:Disable()
@@ -787,6 +813,7 @@ function OptionsPrivate.CreateFrame()
   loadedButton:SetViewDescription(L["Toggle the visibility of all loaded displays"])
   frame.loadedButton = loadedButton
 
+  -- Not Loaded section
   local unloadedButton = AceGUI:Create("WeakAurasLoadedHeaderButton")
   unloadedButton:SetText(L["Not Loaded"])
   unloadedButton:Disable()

--- a/WeakAurasOptions/WeakAurasOptions.lua
+++ b/WeakAurasOptions/WeakAurasOptions.lua
@@ -418,6 +418,26 @@ StaticPopupDialogs["WEAKAURAS_CONFIRM_DELETE"] = {
   preferredindex = STATICPOPUP_NUMDIALOGS,
 }
 
+StaticPopupDialogs["WEAKAURAS_CONFIRM_IGNORE_UPDATES"] = {
+  text = L["Do you want to ignore all future updates for this aura"],
+  button1 = L["Yes"],
+  button2 = L["Cancel"],
+  OnAccept = function(self)
+    if self.data then
+      local auraData = WeakAuras.GetData(self.data)
+      if auraData then
+        for child in OptionsPrivate.Private.TraverseAll(auraData) do
+          child.ignoreWagoUpdate = true
+        end
+      end
+      WeakAuras.SortDisplayButtons(nil, true)
+    end
+  end,
+  OnCancel = function(self) end,
+  whileDead = true,
+  preferredindex = STATICPOPUP_NUMDIALOGS,
+}
+
 function OptionsPrivate.ConfirmDelete(toDelete, parents)
   if toDelete then
     local warningForm = L["You are about to delete %d aura(s). |cFFFF0000This cannot be undone!|r Would you like to continue?"]
@@ -625,8 +645,9 @@ local function LayoutDisplayButtons(msg)
   --if(frame.addonsButton) then
   --  frame.buttonsScroll:AddChild(frame.addonsButton);
   --end
-  if WeakAurasCompanion and WeakAurasCompanion.stash and next(WeakAurasCompanion.stash) then
-    frame.buttonsScroll:AddChild(frame.pendingImportButton);
+  if WeakAurasCompanion then
+    frame.buttonsScroll:AddChild(frame.pendingInstallButton);
+    frame.buttonsScroll:AddChild(frame.pendingUpdateButton);
   end
   frame.buttonsScroll:AddChild(frame.loadedButton);
   frame.buttonsScroll:AddChild(frame.unloadedButton);
@@ -663,10 +684,6 @@ local function LayoutDisplayButtons(msg)
       for id, button in pairs(displayButtons) do
         if(OptionsPrivate.Private.loaded[id] ~= nil) then
           button:PriorityShow(1);
-        end
-        if WeakAurasCompanion and not button.data.parent then
-          -- initialize update icons on top level buttons
-          button:RefreshUpdate()
         end
       end
     end
@@ -874,6 +891,7 @@ end
 
 local previousFilter;
 local pendingUpdateButtons = {}
+local pendingInstallButtons = {}
 function WeakAuras.SortDisplayButtons(filter, overrideReset, id)
   if (OptionsPrivate.Private.IsOptionsProcessingPaused()) then
     return;
@@ -892,38 +910,109 @@ function WeakAuras.SortDisplayButtons(filter, overrideReset, id)
 
   wipe(frame.buttonsScroll.children);
 
-  local pendingImportButtonShown = false
+  local pendingInstallButtonShown = false
   local CompanionData = WeakAurasCompanion and WeakAurasCompanion.WeakAuras or WeakAurasCompanion
   if CompanionData and CompanionData.stash then
     for id, companionData in pairs(CompanionData.stash) do
-      if not pendingImportButtonShown then
-        tinsert(frame.buttonsScroll.children, frame.pendingImportButton)
-        pendingImportButtonShown = true
+      if not pendingInstallButtonShown then
+        tinsert(frame.buttonsScroll.children, frame.pendingInstallButton)
+        pendingInstallButtonShown = true
       end
-      if frame.pendingImportButton:GetExpanded() then
-        if not(pendingUpdateButtons[id]) then
-          pendingUpdateButtons[id] = AceGUI:Create("WeakAurasPendingUpdateButton")
-          pendingUpdateButtons[id]:Initialize(id, companionData)
+      local child = pendingInstallButtons[id]
+      if frame.pendingInstallButton:GetExpanded() then
+        if not child then
+          child = AceGUI:Create("WeakAurasPendingInstallButton")
+          pendingInstallButtons[id] = child
+          child:Initialize(id, companionData)
           if companionData.logo then
-            pendingUpdateButtons[id]:SetLogo(companionData.logo)
+            child:SetLogo(companionData.logo)
           end
           if companionData.refreshLogo then
-            pendingUpdateButtons[id]:SetRefreshLogo(companionData.refreshLogo)
+            child:SetRefreshLogo(companionData.refreshLogo)
           end
         end
-        pendingUpdateButtons[id].frame:Show()
-        pendingUpdateButtons[id]:AcquireThumbnail()
-        frame.buttonsScroll:AddChild(pendingUpdateButtons[id])
-      elseif pendingUpdateButtons[id] then
-        pendingUpdateButtons[id].frame:Hide()
-        if pendingUpdateButtons[id].ReleaseThumbnail then
-          pendingUpdateButtons[id]:ReleaseThumbnail()
+        child.frame:Show()
+        child:AcquireThumbnail()
+        frame.buttonsScroll:AddChild(child)
+      elseif child then
+        child.frame:Hide()
+        if child.ReleaseThumbnail then
+          child:ReleaseThumbnail()
         end
       end
     end
   end
-  if not pendingImportButtonShown and frame.pendingImportButton then
-    frame.pendingImportButton.frame:Hide()
+  if not pendingInstallButtonShown and frame.pendingInstallButton then
+    frame.pendingInstallButton.frame:Hide()
+  end
+
+  local pendingUpdateButtonShown = false
+  if CompanionData then
+    local buttonsShown = {}
+    for _, button in pairs(pendingUpdateButtons) do
+      button:ResetLinkedAuras()
+    end
+    for id, aura in pairs(WeakAurasSaved.displays) do
+      if not aura.ignoreWagoUpdate and aura.url and aura.url ~= "" then
+        local slug, version = aura.url:match("wago.io/([^/]+)/([0-9]+)")
+        if not slug and not version then
+          slug = aura.url:match("wago.io/([^/]+)$")
+          version = 1
+        end
+        if slug and version then
+          local auraData = CompanionData.slugs and CompanionData.slugs[slug]
+          if auraData and auraData.wagoVersion then
+            if tonumber(auraData.wagoVersion) > tonumber(version) then
+              -- there is an update for this aura
+              if not pendingUpdateButtonShown then
+                tinsert(frame.buttonsScroll.children, frame.pendingUpdateButton)
+                pendingUpdateButtonShown = true
+              end
+              if frame.pendingUpdateButton:GetExpanded() then
+                local child = pendingUpdateButtons[slug]
+                if not child then
+                  child = AceGUI:Create("WeakAurasPendingUpdateButton")
+                  pendingUpdateButtons[slug] = child
+                  child:Initialize(slug, auraData)
+                  if auraData.logo then
+                    child:SetLogo(auraData.logo)
+                  end
+                  if auraData.refreshLogo then
+                    child:SetRefreshLogo(auraData.refreshLogo)
+                  end
+                end
+                if not child.frame:IsShown() then
+                  child.frame:Show()
+                  child:AcquireThumbnail()
+                end
+                if not buttonsShown[slug] then
+                  frame.buttonsScroll:AddChild(child)
+                  buttonsShown[slug] = true
+                end
+                child:MarkLinkedAura(id)
+                for childData in OptionsPrivate.Private.TraverseAllChildren(aura) do
+                  child:MarkLinkedChildren(childData.id)
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+    -- hide all buttons not marked as shown
+    for slug, button in pairs(pendingUpdateButtons) do
+      if not buttonsShown[slug] then
+        if button and button.frame:IsShown() then
+          button.frame:Hide()
+          if button.ReleaseThumbnail then
+            button:ReleaseThumbnail()
+          end
+        end
+      end
+    end
+  end
+  if not pendingUpdateButtonShown and frame.pendingUpdateButton then
+    frame.pendingUpdateButton.frame:Hide()
   end
 
   tinsert(frame.buttonsScroll.children, frame.loadedButton);
@@ -1301,9 +1390,6 @@ function WeakAuras.UpdateDisplayButton(data)
   local button = displayButtons[id];
   if (button) then
     button:UpdateThumbnail()
-    if WeakAurasCompanion and button:IsGroup() then
-      button:RefreshUpdate()
-    end
   end
 end
 

--- a/WeakAurasOptions/WeakAurasOptions.toc
+++ b/WeakAurasOptions/WeakAurasOptions.toc
@@ -77,6 +77,7 @@ AceGUI-Widgets\AceGUIWidget-WeakAurasIcon.lua
 AceGUI-Widgets\AceGUIWidget-WeakAurasNewHeaderButton.lua
 AceGUI-Widgets\AceGUIWidget-WeakAurasLoadedHeaderButton.lua
 AceGUI-Widgets\AceGUIWidget-WeakAurasDisplayButton.lua
+AceGUI-Widgets\AceGUIWidget-WeakAurasPendingInstallButton.lua
 AceGUI-Widgets\AceGUIWidget-WeakAurasPendingUpdateButton.lua
 AceGUI-Widgets\AceGUIWidget-WeakAurasTextureButton.lua
 AceGUI-Widgets\AceGUIWidget-WeakAurasIconButton.lua


### PR DESCRIPTION
# Description

Add a section on top with all auras that can be updated called "Ready for Update"
The buttons for this section are not directly linked to target's aura, if there is multiple target you can choose with right click menu which aura to update.

A goal of this PR is to regroup all update functions to the top of the UI, to achieve this **all wago update related options are removed from normal auras buttons and right click menu**.
Ignoring/un-ignoring aura updates was set per aura, this pr completely remove the ability to do that in WeakAuras UI, Companion app and its clones can implement it on their side

![image](https://user-images.githubusercontent.com/189656/117504860-68471e80-af83-11eb-962d-a68e9f86e590.png)

![image](https://user-images.githubusercontent.com/189656/117506418-d856a400-af85-11eb-9f53-10e6b32cc6d3.png)


## Type of change
- [x] Bug fix
- [x] New feature
- [x] Loss of functionality

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
