### PR TITLE
Add option to modify aura version

### DIFF
--- a/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasDisplayButton.lua
+++ b/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasDisplayButton.lua
@@ -1096,7 +1096,7 @@ local methods = {
 
     local hasDescription = data.desc and data.desc ~= "";
     local hasUrl = data.url and data.url ~= "";
-    local hasVersion = (data.semver and data.semver ~= "") or (data.version and data.version ~= "");
+    local hasVersion = (data.semver and data.semver ~= "") ;
 
     if(hasDescription or hasUrl or hasVersion) then
       tinsert(namestable, " ");
@@ -1111,7 +1111,7 @@ local methods = {
     end
 
     if (hasVersion) then
-      tinsert(namestable, "|cFFFFD100" .. L["Version: "]  .. (data.semver or data.version) .. "|r");
+      tinsert(namestable, "|cFFFFD100" .. L["Version: "]  .. data.semver .. "|r");
     end
 
     tinsert(namestable, " ");


### PR DESCRIPTION
# Description

This add an option in the information tab, to modify the version that is shown on the tooltip of an aura.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested

- [x] Changed version of a single aura
- [x] Changed version of a group

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings