### PR TITLE
Bind function cache with aura

### DIFF
--- a/WeakAuras/AuraEnvironment.lua
+++ b/WeakAuras/AuraEnvironment.lua
@@ -495,8 +495,8 @@ function WeakAuras.LoadFunction(string, id, inTrigger)
     error('Unable to find id in WeakAuras.LoadFunction')
   end
 
-  if function_cache[string] then
-    return function_cache[string]
+  if function_cache[id] and function_cache[id][string] then
+    return function_cache[id][string]
   else
     local loadedFunction, errorString = loadstring(
       string, "Error in '" .. (id or "Unknown") .. (inTrigger and ("':'".. inTrigger) or "") .."'"

--- a/WeakAuras/AuraEnvironment.lua
+++ b/WeakAuras/AuraEnvironment.lua
@@ -460,22 +460,24 @@ function env_getenv(id)
     return function_env_cache[id]
   end
 
-  local WaProxy = setmetatable({ __aura_id = id }, {
+  local __LoadFunction = function(code)
+    return WeakAuras.LoadFunction(code, id)
+  end
+
+  local WaProxy = setmetatable({}, {
     __index = function(t1, k1)
       if ( k1 == 'LoadFunction' ) then
-        return function(code)
-          return WeakAuras.LoadFunction(code, t1.__aura_id)
-        end
+        return __LoadFunction
       else
         return exec_env["WeakAuras"][k1]
       end
     end
   })
 
-  function_env_cache[id] = setmetatable({ __aura_id = id },{
+  function_env_cache[id] = setmetatable({},{
     __index = function(t, k)
       if k == "aura_env" then
-        return aura_environments[t.__aura_id]
+        return aura_environments[id]
       elseif k == 'WeakAuras' then
         return WaProxy
       else

--- a/WeakAuras/BuffTrigger2.lua
+++ b/WeakAuras/BuffTrigger2.lua
@@ -2225,7 +2225,7 @@ function BuffTrigger.Add(data)
       local remFunc
       if trigger.unit ~= "multi" and CanHaveMatchCheck(trigger) and trigger.useRem then
         local remFuncStr = Private.function_strings.count:format(trigger.remOperator or ">=", tonumber(trigger.rem) or 0)
-        remFunc = WeakAuras.LoadFunction(remFuncStr)
+        remFunc = WeakAuras.LoadFunction(remFuncStr, id)
       end
 
       local names
@@ -2255,14 +2255,14 @@ function BuffTrigger.Add(data)
         else
           group_countFuncStr = Private.function_strings.count:format(">", 0)
         end
-        groupCountFunc = WeakAuras.LoadFunction(group_countFuncStr)
+        groupCountFunc = WeakAuras.LoadFunction(group_countFuncStr, id)
       end
 
       local matchCountFunc
       if HasMatchCount(trigger) and trigger.match_countOperator and trigger.match_count and tonumber(trigger.match_count) then
         local count = tonumber(trigger.match_count)
         local match_countFuncStr = Private.function_strings.count:format(trigger.match_countOperator, count)
-        matchCountFunc = WeakAuras.LoadFunction(match_countFuncStr)
+        matchCountFunc = WeakAuras.LoadFunction(match_countFuncStr, ContainerIDToInventoryID)
       elseif IsGroupTrigger(trigger) then
         if trigger.showClones and not trigger.combinePerUnit then
           matchCountFunc = GreaterEqualOne

--- a/WeakAuras/BuffTrigger2.lua
+++ b/WeakAuras/BuffTrigger2.lua
@@ -2262,7 +2262,7 @@ function BuffTrigger.Add(data)
       if HasMatchCount(trigger) and trigger.match_countOperator and trigger.match_count and tonumber(trigger.match_count) then
         local count = tonumber(trigger.match_count)
         local match_countFuncStr = Private.function_strings.count:format(trigger.match_countOperator, count)
-        matchCountFunc = WeakAuras.LoadFunction(match_countFuncStr, ContainerIDToInventoryID)
+        matchCountFunc = WeakAuras.LoadFunction(match_countFuncStr, id)
       elseif IsGroupTrigger(trigger) then
         if trigger.showClones and not trigger.combinePerUnit then
           matchCountFunc = GreaterEqualOne

--- a/WeakAuras/GenericTrigger.lua
+++ b/WeakAuras/GenericTrigger.lua
@@ -1216,7 +1216,7 @@ function GenericTrigger.Add(data, region)
         else -- CUSTOM
           triggerFunc = WeakAuras.LoadFunction("return "..(trigger.custom or ""), id);
           if (trigger.custom_type == "stateupdate") then
-            tsuConditionVariables = WeakAuras.LoadFunction("return function() return \n" .. (trigger.customVariables or "") .. "\n end");
+            tsuConditionVariables = WeakAuras.LoadFunction("return function() return \n" .. (trigger.customVariables or "") .. "\n end", id);
             if not tsuConditionVariables then
               tsuConditionVariables = function() return end
             end


### PR DESCRIPTION
# Description

Create unique aura_environment to prevent wrong aura_env upvalue in C_Timer functions

## Type of change

Please delete options that are not relevant.

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested

OnInit code block
```
print("aura_env", "Init", aura_env)
C_Timer.After(5, function() print("aura_env", "from C_Timer", aura_env) end)
C_Timer.NewTicker(1, function() print("aura_env", "new_ticker", aura_env) end)
```


## Checklist
<!-- These can be checked off after the pull request is submitted, in case you want discussion before they are completely ready -->

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

<!-- Is there any additional work that needs to be done? If so, add it to the above list -->
