### PR TITLE
lock archivist version

### DIFF
--- a/.pkgmeta
+++ b/.pkgmeta
@@ -19,7 +19,9 @@ externals:
   WeakAuras/Libs/LibCustomGlow-1.0: https://github.com/Stanzilla/LibCustomGlow
   WeakAuras/Libs/LibDBIcon-1.0: https://repos.curseforge.com/wow/libdbicon-1-0/trunk/LibDBIcon-1.0
   WeakAuras/Libs/LibGetFrame-1.0: https://github.com/mrbuds/LibGetFrame
-  WeakAuras/Libs/Archivist: https://github.com/emptyrivers/Archivist
+  WeakAuras/Libs/Archivist:
+    url: https://github.com/emptyrivers/Archivist
+    tag: v1.0.8
   WeakAuras/Libs/LibSerialize:
     url: https://github.com/rossnichols/LibSerialize
     tag: v1.0.0

--- a/.pkgmeta-bc
+++ b/.pkgmeta-bc
@@ -19,7 +19,9 @@ externals:
   WeakAuras/Libs/LibDBIcon-1.0: https://repos.curseforge.com/wow/libdbicon-1-0/trunk/LibDBIcon-1.0
   WeakAuras/Libs/LibGetFrame-1.0: https://github.com/mrbuds/LibGetFrame
   WeakAuras/Libs/LibRangeCheck-2.0: https://github.com/WeakAuras/LibRangeCheck-2.0/
-  WeakAuras/Libs/Archivist: https://github.com/emptyrivers/Archivist
+  WeakAuras/Libs/Archivist:
+    url: https://github.com/emptyrivers/Archivist
+    tag: v1.0.8
   WeakAuras/Libs/LibSerialize:
     url: https://github.com/rossnichols/LibSerialize
     tag: v1.0.0

--- a/.pkgmeta-classic
+++ b/.pkgmeta-classic
@@ -22,7 +22,9 @@ externals:
   WeakAuras/Libs/LibGetFrame-1.0: https://github.com/mrbuds/LibGetFrame
   WeakAuras/Libs/LibRangeCheck-2.0: https://repos.curseforge.com/wow/librangecheck-2-0/trunk/LibRangeCheck-2.0
   WeakAuras/Libs/LibClassicSpellActionCount-1.0: https://github.com/Ennea/LibClassicSpellActionCount-1.0
-  WeakAuras/Libs/Archivist: https://github.com/emptyrivers/Archivist
+  WeakAuras/Libs/Archivist:
+    url: https://github.com/emptyrivers/Archivist
+    tag: v1.0.8
   WeakAuras/Libs/LibSerialize:
     url: https://github.com/rossnichols/LibSerialize
     tag: v1.0.0


### PR DESCRIPTION
I'm about to merge some incompatible changes to archivist, and I don't want to accidentally break the alpha builds until i've actually done the fixes for WeakAuras.

This will be reverted in a future patch.
