### PR TITLE
set chunk name on loadstring instead of injecting a comment

### DIFF
--- a/WeakAuras/AuraEnvironment.lua
+++ b/WeakAuras/AuraEnvironment.lua
@@ -455,7 +455,7 @@ function WeakAuras.LoadFunction(string, id, inTrigger)
   if function_cache[string] then
     return function_cache[string]
   else
-    local loadedFunction, errorString = loadstring("--[==[ Error in '" .. (id or "Unknown") .. (inTrigger and ("':'".. inTrigger) or "") .."' ]==] " .. string)
+    local loadedFunction, errorString = loadstring(string, "Error in: " .. (id or "Unknown") .. (inTrigger and ("':'".. inTrigger) or ""))
     if errorString then
       print(errorString)
     else


### PR DESCRIPTION
Timosh pointed this out recently - loadstring accepts a string as a second parameter, which will then be set as the name of the loaded chunk. This way we don't need to do a weird comment injection in order for custom code error messages to be identifiable.
