### PR TITLE
use weakauras fork of LibRangeCheck-2.0 for all versions

### DIFF
--- a/.pkgmeta
+++ b/.pkgmeta
@@ -15,7 +15,7 @@ externals:
   WeakAuras/Libs/LibDataBroker-1.1: https://github.com/tekkub/libdatabroker-1-1
   WeakAuras/Libs/LibCompress: https://repos.curseforge.com/wow/libcompress/trunk
   WeakAuras/Libs/LibSpellRange-1.0: https://github.com/ascott18/LibSpellRange-1.0
-  WeakAuras/Libs/LibRangeCheck-2.0: https://repos.curseforge.com/wow/librangecheck-2-0/trunk/LibRangeCheck-2.0
+  WeakAuras/Libs/LibRangeCheck-2.0: https://github.com/WeakAuras/LibRangeCheck-2.0/
   WeakAuras/Libs/LibCustomGlow-1.0: https://github.com/Stanzilla/LibCustomGlow
   WeakAuras/Libs/LibDBIcon-1.0: https://repos.curseforge.com/wow/libdbicon-1-0/trunk/LibDBIcon-1.0
   WeakAuras/Libs/LibGetFrame-1.0: https://github.com/mrbuds/LibGetFrame
@@ -49,3 +49,4 @@ move-folders:
   WeakAuras/WeakAurasModelPaths: WeakAurasModelPaths
   WeakAuras/WeakAurasTemplates: WeakAurasTemplates
   WeakAuras/WeakAurasArchive: WeakAurasArchive
+  WeakAuras/Libs/LibRangeCheck-2.0/LibRangeCheck-2.0: WeakAuras/Libs/LibRangeCheck-2.0

--- a/.pkgmeta-bcc
+++ b/.pkgmeta-bcc
@@ -49,3 +49,4 @@ move-folders:
   WeakAuras/WeakAurasModelPaths: WeakAurasModelPaths
   WeakAuras/WeakAurasTemplates: WeakAurasTemplates
   WeakAuras/WeakAurasArchive: WeakAurasArchive
+  WeakAuras/Libs/LibRangeCheck-2.0/LibRangeCheck-2.0: WeakAuras/Libs/LibRangeCheck-2.0

--- a/.pkgmeta-classic
+++ b/.pkgmeta-classic
@@ -20,7 +20,7 @@ externals:
   WeakAuras/Libs/LibClassicDurations: https://github.com/rgd87/LibClassicDurations
   WeakAuras/Libs/LibClassicCasterino: https://github.com/rgd87/LibClassicCasterino
   WeakAuras/Libs/LibGetFrame-1.0: https://github.com/mrbuds/LibGetFrame
-  WeakAuras/Libs/LibRangeCheck-2.0: https://repos.curseforge.com/wow/librangecheck-2-0/trunk/LibRangeCheck-2.0
+  WeakAuras/Libs/LibRangeCheck-2.0: https://github.com/WeakAuras/LibRangeCheck-2.0/
   WeakAuras/Libs/LibClassicSpellActionCount-1.0: https://github.com/Ennea/LibClassicSpellActionCount-1.0
   WeakAuras/Libs/Archivist:
     url: https://github.com/emptyrivers/Archivist
@@ -52,3 +52,4 @@ move-folders:
   WeakAuras/WeakAurasModelPaths: WeakAurasModelPaths
   WeakAuras/WeakAurasTemplates: WeakAurasTemplates
   WeakAuras/WeakAurasArchive: WeakAurasArchive
+  WeakAuras/Libs/LibRangeCheck-2.0/LibRangeCheck-2.0: WeakAuras/Libs/LibRangeCheck-2.0


### PR DESCRIPTION
# Description

it wasn't updated on all .pkgmeta* and is currently raising a Lua error on BCC since last commit