### PR TITLE
fix CorrectSpellName for linked spells on TBC

### DIFF
--- a/WeakAurasOptions/LoadOptions.lua
+++ b/WeakAurasOptions/LoadOptions.lua
@@ -36,7 +36,7 @@ local function CorrectSpellName(input)
     else
       return nil;
     end
-  elseif (WeakAuras.IsClassic() or WeakAuras.IsBCC()) and input then
+  elseif WeakAuras.IsClassic() and input then
     local name, _, _, _, _, _, spellId = GetSpellInfo(input)
     if spellId then
       return spellId


### PR DESCRIPTION
# Description

Fixes  #3103
