### PR TITLE
Move SortDisplayButtons to private namespace

### DIFF
--- a/WeakAuras/Transmission.lua
+++ b/WeakAuras/Transmission.lua
@@ -593,7 +593,7 @@ local function importPendingData()
     WeakAuras.UpdateGroupOrders(parentData)
     WeakAuras.UpdateDisplayButton(parentData)
     WeakAuras.ClearAndUpdateOptions(parentData.id)
-    WeakAuras.SortDisplayButtons()
+    Private.SortDisplayButtons()
   end
   WeakAuras.SetImporting(false)
   return WeakAuras.PickDisplay(installedData[0].id)

--- a/WeakAuras/Transmission.lua
+++ b/WeakAuras/Transmission.lua
@@ -593,7 +593,7 @@ local function importPendingData()
     WeakAuras.UpdateGroupOrders(parentData)
     WeakAuras.UpdateDisplayButton(parentData)
     WeakAuras.ClearAndUpdateOptions(parentData.id)
-    Private.SortDisplayButtons()
+    Private.callbacks:Fire("Import")
   end
   WeakAuras.SetImporting(false)
   return WeakAuras.PickDisplay(installedData[0].id)

--- a/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasDisplayButton.lua
+++ b/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasDisplayButton.lua
@@ -99,7 +99,7 @@ clipboard.pasteMenuEntry = {
 
     WeakAuras.FillOptions()
     OptionsPrivate.Private.ScanForLoads({[clipboard.current.id] = true});
-    WeakAuras.SortDisplayButtons(nil, true);
+    OptionsPrivate.Private.SortDisplayButtons(nil, true);
     WeakAuras.PickDisplay(clipboard.current.id);
     WeakAuras.UpdateDisplayButton(clipboard.current.id);
     WeakAuras.ClearAndUpdateOptions(clipboard.current.id);
@@ -627,7 +627,7 @@ local methods = {
       WeakAuras.ClearAndUpdateOptions(data.id);
       WeakAuras.FillOptions();
       WeakAuras.UpdateGroupOrders(data);
-      WeakAuras.SortDisplayButtons();
+      OptionsPrivate.Private.SortDisplayButtons();
       self:ReloadTooltip();
       OptionsPrivate.ResetMoverSizer();
     end
@@ -675,13 +675,13 @@ local methods = {
         button.callbacks.UpdateExpandButton()
         WeakAuras.UpdateDisplayButton(WeakAuras.GetData(new_idGroup))
 
-        WeakAuras.SortDisplayButtons(nil, true)
+        OptionsPrivate.Private.SortDisplayButtons(nil, true)
         OptionsPrivate.PickAndEditDisplay(new_idGroup)
 
         OptionsPrivate.Private.ResumeAllDynamicGroups()
       else
         local new_id = OptionsPrivate.DuplicateAura(data)
-        WeakAuras.SortDisplayButtons(nil, true)
+        OptionsPrivate.Private.SortDisplayButtons(nil, true)
         OptionsPrivate.PickAndEditDisplay(new_id)
       end
     end
@@ -733,11 +733,11 @@ local methods = {
             self:SetGroupOrder(index - 1, #parentData.controlledChildren);
             local otherbutton = WeakAuras.GetDisplayButton(parentData.controlledChildren[index]);
             otherbutton:SetGroupOrder(index, #parentData.controlledChildren);
-            WeakAuras.SortDisplayButtons();
+            OptionsPrivate.Private.SortDisplayButtons();
             local updata = {duration = 0.15, type = "custom", use_translate = true, x = 0, y = -32};
             local downdata = {duration = 0.15, type = "custom", use_translate = true, x = 0, y = 32};
-            OptionsPrivate.Private.Animate("button", WeakAuras.GetData(parentData.controlledChildren[index-1]).uid, "main", updata, self.frame, true, function() WeakAuras.SortDisplayButtons() end);
-            OptionsPrivate.Private.Animate("button", WeakAuras.GetData(parentData.controlledChildren[index]).uid, "main", downdata, otherbutton.frame, true, function() WeakAuras.SortDisplayButtons() end);
+            OptionsPrivate.Private.Animate("button", WeakAuras.GetData(parentData.controlledChildren[index-1]).uid, "main", updata, self.frame, true, function() OptionsPrivate.Private.SortDisplayButtons() end);
+            OptionsPrivate.Private.Animate("button", WeakAuras.GetData(parentData.controlledChildren[index]).uid, "main", downdata, otherbutton.frame, true, function() OptionsPrivate.Private.SortDisplayButtons() end);
             WeakAuras.UpdateDisplayButton(parentData);
             WeakAuras.FillOptions()
           end
@@ -773,11 +773,11 @@ local methods = {
             self:SetGroupOrder(index + 1, #parentData.controlledChildren);
             local otherbutton = WeakAuras.GetDisplayButton(parentData.controlledChildren[index]);
             otherbutton:SetGroupOrder(index, #parentData.controlledChildren);
-            WeakAuras.SortDisplayButtons()
+            OptionsPrivate.Private.SortDisplayButtons()
             local updata = {duration = 0.15, type = "custom", use_translate = true, x = 0, y = -32};
             local downdata = {duration = 0.15, type = "custom", use_translate = true, x = 0, y = 32};
-            OptionsPrivate.Private.Animate("button", WeakAuras.GetData(parentData.controlledChildren[index+1]).uid, "main", downdata, self.frame, true, function() WeakAuras.SortDisplayButtons() end);
-            OptionsPrivate.Private.Animate("button", WeakAuras.GetData(parentData.controlledChildren[index]).uid, "main", updata, otherbutton.frame, true, function() WeakAuras.SortDisplayButtons() end);
+            OptionsPrivate.Private.Animate("button", WeakAuras.GetData(parentData.controlledChildren[index+1]).uid, "main", downdata, self.frame, true, function() OptionsPrivate.Private.SortDisplayButtons() end);
+            OptionsPrivate.Private.Animate("button", WeakAuras.GetData(parentData.controlledChildren[index]).uid, "main", updata, otherbutton.frame, true, function() OptionsPrivate.Private.SortDisplayButtons() end);
             WeakAuras.UpdateDisplayButton(parentData);
             WeakAuras.FillOptions()
           end
@@ -981,7 +981,7 @@ local methods = {
       self:SetViewTest(self.callbacks.ViewTest);
       self:DisableGroup();
       self.callbacks.UpdateExpandButton();
-      self:SetOnExpandCollapse(function() WeakAuras.SortDisplayButtons(nil, true) end);
+      self:SetOnExpandCollapse(function() OptionsPrivate.Private.SortDisplayButtons(nil, true) end);
     else
       self:SetViewRegion(WeakAuras.regions[data.id].region);
       self:EnableGroup();
@@ -1145,7 +1145,7 @@ local methods = {
     WeakAuras.ClearAndUpdateOptions(self.data.id);
     WeakAuras.UpdateGroupOrders(parentData);
     WeakAuras.UpdateDisplayButton(parentData);
-    WeakAuras.SortDisplayButtons();
+    OptionsPrivate.Private.SortDisplayButtons();
   end,
   ["SetDragging"] = function(self, data, drop, size)
     if (size) then
@@ -1280,7 +1280,7 @@ local methods = {
     if action then
       action(self, target)
     end
-    WeakAuras.SortDisplayButtons()
+    OptionsPrivate.Private.SortDisplayButtons()
   end,
   ["GetGroupOrCopying"] = function(self)
     return self.group;

--- a/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasDisplayButton.lua
+++ b/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasDisplayButton.lua
@@ -99,7 +99,7 @@ clipboard.pasteMenuEntry = {
 
     WeakAuras.FillOptions()
     OptionsPrivate.Private.ScanForLoads({[clipboard.current.id] = true});
-    OptionsPrivate.Private.SortDisplayButtons(nil, true);
+    OptionsPrivate.SortDisplayButtons(nil, true);
     WeakAuras.PickDisplay(clipboard.current.id);
     WeakAuras.UpdateDisplayButton(clipboard.current.id);
     WeakAuras.ClearAndUpdateOptions(clipboard.current.id);
@@ -627,7 +627,7 @@ local methods = {
       WeakAuras.ClearAndUpdateOptions(data.id);
       WeakAuras.FillOptions();
       WeakAuras.UpdateGroupOrders(data);
-      OptionsPrivate.Private.SortDisplayButtons();
+      OptionsPrivate.SortDisplayButtons();
       self:ReloadTooltip();
       OptionsPrivate.ResetMoverSizer();
     end
@@ -675,13 +675,13 @@ local methods = {
         button.callbacks.UpdateExpandButton()
         WeakAuras.UpdateDisplayButton(WeakAuras.GetData(new_idGroup))
 
-        OptionsPrivate.Private.SortDisplayButtons(nil, true)
+        OptionsPrivate.SortDisplayButtons(nil, true)
         OptionsPrivate.PickAndEditDisplay(new_idGroup)
 
         OptionsPrivate.Private.ResumeAllDynamicGroups()
       else
         local new_id = OptionsPrivate.DuplicateAura(data)
-        OptionsPrivate.Private.SortDisplayButtons(nil, true)
+        OptionsPrivate.SortDisplayButtons(nil, true)
         OptionsPrivate.PickAndEditDisplay(new_id)
       end
     end
@@ -733,11 +733,11 @@ local methods = {
             self:SetGroupOrder(index - 1, #parentData.controlledChildren);
             local otherbutton = WeakAuras.GetDisplayButton(parentData.controlledChildren[index]);
             otherbutton:SetGroupOrder(index, #parentData.controlledChildren);
-            OptionsPrivate.Private.SortDisplayButtons();
+            OptionsPrivate.SortDisplayButtons();
             local updata = {duration = 0.15, type = "custom", use_translate = true, x = 0, y = -32};
             local downdata = {duration = 0.15, type = "custom", use_translate = true, x = 0, y = 32};
-            OptionsPrivate.Private.Animate("button", WeakAuras.GetData(parentData.controlledChildren[index-1]).uid, "main", updata, self.frame, true, function() OptionsPrivate.Private.SortDisplayButtons() end);
-            OptionsPrivate.Private.Animate("button", WeakAuras.GetData(parentData.controlledChildren[index]).uid, "main", downdata, otherbutton.frame, true, function() OptionsPrivate.Private.SortDisplayButtons() end);
+            OptionsPrivate.Private.Animate("button", WeakAuras.GetData(parentData.controlledChildren[index-1]).uid, "main", updata, self.frame, true, function() OptionsPrivate.SortDisplayButtons() end);
+            OptionsPrivate.Private.Animate("button", WeakAuras.GetData(parentData.controlledChildren[index]).uid, "main", downdata, otherbutton.frame, true, function() OptionsPrivate.SortDisplayButtons() end);
             WeakAuras.UpdateDisplayButton(parentData);
             WeakAuras.FillOptions()
           end
@@ -773,11 +773,11 @@ local methods = {
             self:SetGroupOrder(index + 1, #parentData.controlledChildren);
             local otherbutton = WeakAuras.GetDisplayButton(parentData.controlledChildren[index]);
             otherbutton:SetGroupOrder(index, #parentData.controlledChildren);
-            OptionsPrivate.Private.SortDisplayButtons()
+            OptionsPrivate.SortDisplayButtons()
             local updata = {duration = 0.15, type = "custom", use_translate = true, x = 0, y = -32};
             local downdata = {duration = 0.15, type = "custom", use_translate = true, x = 0, y = 32};
-            OptionsPrivate.Private.Animate("button", WeakAuras.GetData(parentData.controlledChildren[index+1]).uid, "main", downdata, self.frame, true, function() OptionsPrivate.Private.SortDisplayButtons() end);
-            OptionsPrivate.Private.Animate("button", WeakAuras.GetData(parentData.controlledChildren[index]).uid, "main", updata, otherbutton.frame, true, function() OptionsPrivate.Private.SortDisplayButtons() end);
+            OptionsPrivate.Private.Animate("button", WeakAuras.GetData(parentData.controlledChildren[index+1]).uid, "main", downdata, self.frame, true, function() OptionsPrivate.SortDisplayButtons() end);
+            OptionsPrivate.Private.Animate("button", WeakAuras.GetData(parentData.controlledChildren[index]).uid, "main", updata, otherbutton.frame, true, function() OptionsPrivate.SortDisplayButtons() end);
             WeakAuras.UpdateDisplayButton(parentData);
             WeakAuras.FillOptions()
           end
@@ -981,7 +981,7 @@ local methods = {
       self:SetViewTest(self.callbacks.ViewTest);
       self:DisableGroup();
       self.callbacks.UpdateExpandButton();
-      self:SetOnExpandCollapse(function() OptionsPrivate.Private.SortDisplayButtons(nil, true) end);
+      self:SetOnExpandCollapse(function() OptionsPrivate.SortDisplayButtons(nil, true) end);
     else
       self:SetViewRegion(WeakAuras.regions[data.id].region);
       self:EnableGroup();
@@ -1145,7 +1145,7 @@ local methods = {
     WeakAuras.ClearAndUpdateOptions(self.data.id);
     WeakAuras.UpdateGroupOrders(parentData);
     WeakAuras.UpdateDisplayButton(parentData);
-    OptionsPrivate.Private.SortDisplayButtons();
+    OptionsPrivate.SortDisplayButtons();
   end,
   ["SetDragging"] = function(self, data, drop, size)
     if (size) then
@@ -1280,7 +1280,7 @@ local methods = {
     if action then
       action(self, target)
     end
-    OptionsPrivate.Private.SortDisplayButtons()
+    OptionsPrivate.SortDisplayButtons()
   end,
   ["GetGroupOrCopying"] = function(self)
     return self.group;

--- a/WeakAurasOptions/CommonOptions.lua
+++ b/WeakAurasOptions/CommonOptions.lua
@@ -938,7 +938,7 @@ local function CreateSetAll(subOption, getAll)
     OptionsPrivate.Private.ResumeAllDynamicGroups()
     OptionsPrivate.Private.pauseOptionsProcessing(false);
     OptionsPrivate.Private.ScanForLoads();
-    WeakAuras.SortDisplayButtons(nil, true);
+    OptionsPrivate.Private.SortDisplayButtons(nil, true);
     OptionsPrivate.UpdateOptions()
   end
 end

--- a/WeakAurasOptions/CommonOptions.lua
+++ b/WeakAurasOptions/CommonOptions.lua
@@ -938,7 +938,7 @@ local function CreateSetAll(subOption, getAll)
     OptionsPrivate.Private.ResumeAllDynamicGroups()
     OptionsPrivate.Private.pauseOptionsProcessing(false);
     OptionsPrivate.Private.ScanForLoads();
-    OptionsPrivate.Private.SortDisplayButtons(nil, true);
+    OptionsPrivate.SortDisplayButtons(nil, true);
     OptionsPrivate.UpdateOptions()
   end
 end

--- a/WeakAurasOptions/ExternalAddons.lua
+++ b/WeakAurasOptions/ExternalAddons.lua
@@ -74,7 +74,7 @@ function OptionsPrivate.CreateImportButtons()
         end
 
         OptionsPrivate.Private.ScanForLoads();
-        WeakAuras.SortDisplayButtons();
+        OptionsPrivate.Private.SortDisplayButtons();
       end);
     end);
 
@@ -134,7 +134,7 @@ function OptionsPrivate.CreateImportButtons()
             end
             OptionsPrivate.Private.ResolveCollisions(function()
               OptionsPrivate.Private.ScanForLoads();
-              WeakAuras.SortDisplayButtons();
+              OptionsPrivate.Private.SortDisplayButtons();
               UpdateGroupChecked();
             end);
           end);
@@ -174,7 +174,7 @@ function OptionsPrivate.CreateImportButtons()
             end
 
             OptionsPrivate.Private.ScanForLoads();
-            WeakAuras.SortDisplayButtons();
+            OptionsPrivate.Private.SortDisplayButtons();
             UpdateAddonChecked();
           end);
         end);
@@ -203,7 +203,7 @@ function OptionsPrivate.CreateImportButtons()
             WeakAuras.DisableAddonDisplay(id);
           end
           OptionsPrivate.Private.ResolveCollisions(function()
-            WeakAuras.SortDisplayButtons()
+            OptionsPrivate.Private.SortDisplayButtons()
             UpdateAddonChecked();
           end);
         end);

--- a/WeakAurasOptions/ExternalAddons.lua
+++ b/WeakAurasOptions/ExternalAddons.lua
@@ -74,7 +74,7 @@ function OptionsPrivate.CreateImportButtons()
         end
 
         OptionsPrivate.Private.ScanForLoads();
-        OptionsPrivate.Private.SortDisplayButtons();
+        OptionsPrivate.SortDisplayButtons();
       end);
     end);
 
@@ -134,7 +134,7 @@ function OptionsPrivate.CreateImportButtons()
             end
             OptionsPrivate.Private.ResolveCollisions(function()
               OptionsPrivate.Private.ScanForLoads();
-              OptionsPrivate.Private.SortDisplayButtons();
+              OptionsPrivate.SortDisplayButtons();
               UpdateGroupChecked();
             end);
           end);
@@ -174,7 +174,7 @@ function OptionsPrivate.CreateImportButtons()
             end
 
             OptionsPrivate.Private.ScanForLoads();
-            OptionsPrivate.Private.SortDisplayButtons();
+            OptionsPrivate.SortDisplayButtons();
             UpdateAddonChecked();
           end);
         end);
@@ -203,7 +203,7 @@ function OptionsPrivate.CreateImportButtons()
             WeakAuras.DisableAddonDisplay(id);
           end
           OptionsPrivate.Private.ResolveCollisions(function()
-            OptionsPrivate.Private.SortDisplayButtons()
+            OptionsPrivate.SortDisplayButtons()
             UpdateAddonChecked();
           end);
         end);

--- a/WeakAurasOptions/LoadOptions.lua
+++ b/WeakAurasOptions/LoadOptions.lua
@@ -190,7 +190,7 @@ function OptionsPrivate.ConstructOptions(prototype, data, startorder, triggernum
             OptionsPrivate.Private.ScanForLoads({[data.id] = true});
             WeakAuras.UpdateThumbnail(data);
             WeakAuras.UpdateDisplayButton(data);
-            OptionsPrivate.Private.SortDisplayButtons(nil, true);
+            OptionsPrivate.SortDisplayButtons(nil, true);
           end,
           hidden = hidden,
           order = order
@@ -239,7 +239,7 @@ function OptionsPrivate.ConstructOptions(prototype, data, startorder, triggernum
             OptionsPrivate.Private.ScanForLoads({[data.id] = true});
             WeakAuras.UpdateThumbnail(data);
             WeakAuras.UpdateDisplayButton(data);
-            OptionsPrivate.Private.SortDisplayButtons(nil, true);
+            OptionsPrivate.SortDisplayButtons(nil, true);
           end,
           hidden = hidden,
           order = order
@@ -287,7 +287,7 @@ function OptionsPrivate.ConstructOptions(prototype, data, startorder, triggernum
             OptionsPrivate.Private.ScanForLoads({[data.id] = true});
             WeakAuras.UpdateThumbnail(data);
             WeakAuras.UpdateDisplayButton(data);
-            OptionsPrivate.Private.SortDisplayButtons(nil, true);
+            OptionsPrivate.SortDisplayButtons(nil, true);
           end
         };
       end
@@ -333,7 +333,7 @@ function OptionsPrivate.ConstructOptions(prototype, data, startorder, triggernum
               OptionsPrivate.Private.ScanForLoads({[data.id] = true});
               WeakAuras.UpdateThumbnail(data);
               WeakAuras.UpdateDisplayButton(data);
-              OptionsPrivate.Private.SortDisplayButtons(nil, true);
+              OptionsPrivate.SortDisplayButtons(nil, true);
             end
           };
           if(arg.required and not triggertype) then
@@ -344,7 +344,7 @@ function OptionsPrivate.ConstructOptions(prototype, data, startorder, triggernum
                 WeakAuras.ClearAndUpdateOptions(data.id)
               end
               OptionsPrivate.Private.ScanForLoads({[data.id] = true});
-              OptionsPrivate.Private.SortDisplayButtons(nil, true);
+              OptionsPrivate.SortDisplayButtons(nil, true);
             end
           end
           order = order + 1;
@@ -368,7 +368,7 @@ function OptionsPrivate.ConstructOptions(prototype, data, startorder, triggernum
             OptionsPrivate.Private.ScanForLoads({[data.id] = true});
             WeakAuras.UpdateThumbnail(data);
             WeakAuras.UpdateDisplayButton(data);
-            OptionsPrivate.Private.SortDisplayButtons(nil, true);
+            OptionsPrivate.SortDisplayButtons(nil, true);
           end
         };
         if(arg.required and not triggertype) then
@@ -379,7 +379,7 @@ function OptionsPrivate.ConstructOptions(prototype, data, startorder, triggernum
               WeakAuras.ClearAndUpdateOptions(data.id)
             end
             OptionsPrivate.Private.ScanForLoads({[data.id] = true});
-            OptionsPrivate.Private.SortDisplayButtons(nil, true);
+            OptionsPrivate.SortDisplayButtons(nil, true);
           end
         end
         order = order + 1;
@@ -401,7 +401,7 @@ function OptionsPrivate.ConstructOptions(prototype, data, startorder, triggernum
             OptionsPrivate.Private.ScanForLoads({[data.id] = true});
             WeakAuras.UpdateThumbnail(data);
             WeakAuras.UpdateDisplayButton(data);
-            OptionsPrivate.Private.SortDisplayButtons(nil, true);
+            OptionsPrivate.SortDisplayButtons(nil, true);
           end
         };
 
@@ -421,7 +421,7 @@ function OptionsPrivate.ConstructOptions(prototype, data, startorder, triggernum
               WeakAuras.ClearAndUpdateOptions(data.id)
             end
             OptionsPrivate.Private.ScanForLoads({[data.id] = true});
-            OptionsPrivate.Private.SortDisplayButtons(nil, true);
+            OptionsPrivate.SortDisplayButtons(nil, true);
           end
         end
         order = order + 1;
@@ -444,7 +444,7 @@ function OptionsPrivate.ConstructOptions(prototype, data, startorder, triggernum
             OptionsPrivate.Private.ScanForLoads({[data.id] = true});
             WeakAuras.UpdateThumbnail(data);
             WeakAuras.UpdateDisplayButton(data);
-            OptionsPrivate.Private.SortDisplayButtons(nil, true);
+            OptionsPrivate.SortDisplayButtons(nil, true);
           end
         };
         if(arg.required and not triggertype) then
@@ -455,7 +455,7 @@ function OptionsPrivate.ConstructOptions(prototype, data, startorder, triggernum
               WeakAuras.ClearAndUpdateOptions(data.id)
             end
             OptionsPrivate.Private.ScanForLoads({[data.id] = true});
-            OptionsPrivate.Private.SortDisplayButtons(nil, true);
+            OptionsPrivate.SortDisplayButtons(nil, true);
           end
         end
         order = order + 1;
@@ -477,7 +477,7 @@ function OptionsPrivate.ConstructOptions(prototype, data, startorder, triggernum
             OptionsPrivate.Private.ScanForLoads({[data.id] = true});
             WeakAuras.UpdateThumbnail(data);
             WeakAuras.UpdateDisplayButton(data);
-            OptionsPrivate.Private.SortDisplayButtons(nil, true);
+            OptionsPrivate.SortDisplayButtons(nil, true);
           end
         };
         if(arg.required and not triggertype) then
@@ -488,7 +488,7 @@ function OptionsPrivate.ConstructOptions(prototype, data, startorder, triggernum
               WeakAuras.ClearAndUpdateOptions(data.id)
             end
             OptionsPrivate.Private.ScanForLoads({[data.id] = true});
-            OptionsPrivate.Private.SortDisplayButtons(nil, true);
+            OptionsPrivate.SortDisplayButtons(nil, true);
           end
         end
         order = order + 1;
@@ -509,7 +509,7 @@ function OptionsPrivate.ConstructOptions(prototype, data, startorder, triggernum
               OptionsPrivate.Private.ScanForLoads({[data.id] = true});
               WeakAuras.UpdateThumbnail(data);
               WeakAuras.UpdateDisplayButton(data);
-              OptionsPrivate.Private.SortDisplayButtons(nil, true);
+              OptionsPrivate.SortDisplayButtons(nil, true);
             end,
           };
           order = order + 1;
@@ -604,7 +604,7 @@ function OptionsPrivate.ConstructOptions(prototype, data, startorder, triggernum
             OptionsPrivate.Private.ScanForLoads({[data.id] = true});
             WeakAuras.UpdateThumbnail(data);
             WeakAuras.UpdateDisplayButton(data);
-            OptionsPrivate.Private.SortDisplayButtons(nil, true);
+            OptionsPrivate.SortDisplayButtons(nil, true);
           end
         };
         order = order + 1;
@@ -658,7 +658,7 @@ function OptionsPrivate.ConstructOptions(prototype, data, startorder, triggernum
             OptionsPrivate.Private.ScanForLoads({[data.id] = true});
             WeakAuras.UpdateThumbnail(data);
             WeakAuras.UpdateDisplayButton(data);
-            OptionsPrivate.Private.SortDisplayButtons(nil, true);
+            OptionsPrivate.SortDisplayButtons(nil, true);
           end
         };
         if(arg.required and not triggertype) then
@@ -676,7 +676,7 @@ function OptionsPrivate.ConstructOptions(prototype, data, startorder, triggernum
             OptionsPrivate.Private.ScanForLoads({[data.id] = true});
             WeakAuras.UpdateThumbnail(data);
             WeakAuras.UpdateDisplayButton(data);
-            OptionsPrivate.Private.SortDisplayButtons(nil, true);
+            OptionsPrivate.SortDisplayButtons(nil, true);
           end
         end
         if (arg.control) then
@@ -749,7 +749,7 @@ function OptionsPrivate.ConstructOptions(prototype, data, startorder, triggernum
             OptionsPrivate.Private.ScanForLoads({[data.id] = true});
             WeakAuras.UpdateThumbnail(data);
             WeakAuras.UpdateDisplayButton(data);
-            OptionsPrivate.Private.SortDisplayButtons(nil, true);
+            OptionsPrivate.SortDisplayButtons(nil, true);
           end
         };
         if(arg.required and not triggertype) then
@@ -762,7 +762,7 @@ function OptionsPrivate.ConstructOptions(prototype, data, startorder, triggernum
             OptionsPrivate.Private.ScanForLoads({[data.id] = true});
             WeakAuras.UpdateThumbnail(data);
             WeakAuras.UpdateDisplayButton(data);
-            OptionsPrivate.Private.SortDisplayButtons(nil, true);
+            OptionsPrivate.SortDisplayButtons(nil, true);
           end
         end
 
@@ -782,7 +782,7 @@ function OptionsPrivate.ConstructOptions(prototype, data, startorder, triggernum
               trigger[realname .. "_extraOption"] = v
               WeakAuras.Add(data)
               OptionsPrivate.Private.ScanForLoads({[data.id] = true})
-              OptionsPrivate.Private.SortDisplayButtons(nil, true)
+              OptionsPrivate.SortDisplayButtons(nil, true)
             end
           }
           order = order + 1
@@ -816,7 +816,7 @@ function OptionsPrivate.ConstructOptions(prototype, data, startorder, triggernum
             OptionsPrivate.Private.ScanForLoads({[data.id] = true});
             WeakAuras.UpdateThumbnail(data);
             WeakAuras.UpdateDisplayButton(data);
-            OptionsPrivate.Private.SortDisplayButtons(nil, true);
+            OptionsPrivate.SortDisplayButtons(nil, true);
           end
         };
         if(arg.required and not triggertype) then
@@ -833,7 +833,7 @@ function OptionsPrivate.ConstructOptions(prototype, data, startorder, triggernum
             OptionsPrivate.Private.ScanForLoads({[data.id] = true});
             WeakAuras.UpdateThumbnail(data);
             WeakAuras.UpdateDisplayButton(data);
-            OptionsPrivate.Private.SortDisplayButtons(nil, true);
+            OptionsPrivate.SortDisplayButtons(nil, true);
           end
         end
 
@@ -901,7 +901,7 @@ function OptionsPrivate.GetLoadOptions(data)
         WeakAuras.Add(data);
         WeakAuras.UpdateThumbnail(data);
         OptionsPrivate.Private.ScanForLoads({[data.id] = true});
-        OptionsPrivate.Private.SortDisplayButtons(nil, true);
+        OptionsPrivate.SortDisplayButtons(nil, true);
       end,
       args = {}
     }

--- a/WeakAurasOptions/LoadOptions.lua
+++ b/WeakAurasOptions/LoadOptions.lua
@@ -190,7 +190,7 @@ function OptionsPrivate.ConstructOptions(prototype, data, startorder, triggernum
             OptionsPrivate.Private.ScanForLoads({[data.id] = true});
             WeakAuras.UpdateThumbnail(data);
             WeakAuras.UpdateDisplayButton(data);
-            WeakAuras.SortDisplayButtons(nil, true);
+            OptionsPrivate.Private.SortDisplayButtons(nil, true);
           end,
           hidden = hidden,
           order = order
@@ -239,7 +239,7 @@ function OptionsPrivate.ConstructOptions(prototype, data, startorder, triggernum
             OptionsPrivate.Private.ScanForLoads({[data.id] = true});
             WeakAuras.UpdateThumbnail(data);
             WeakAuras.UpdateDisplayButton(data);
-            WeakAuras.SortDisplayButtons(nil, true);
+            OptionsPrivate.Private.SortDisplayButtons(nil, true);
           end,
           hidden = hidden,
           order = order
@@ -287,7 +287,7 @@ function OptionsPrivate.ConstructOptions(prototype, data, startorder, triggernum
             OptionsPrivate.Private.ScanForLoads({[data.id] = true});
             WeakAuras.UpdateThumbnail(data);
             WeakAuras.UpdateDisplayButton(data);
-            WeakAuras.SortDisplayButtons(nil, true);
+            OptionsPrivate.Private.SortDisplayButtons(nil, true);
           end
         };
       end
@@ -333,7 +333,7 @@ function OptionsPrivate.ConstructOptions(prototype, data, startorder, triggernum
               OptionsPrivate.Private.ScanForLoads({[data.id] = true});
               WeakAuras.UpdateThumbnail(data);
               WeakAuras.UpdateDisplayButton(data);
-              WeakAuras.SortDisplayButtons(nil, true);
+              OptionsPrivate.Private.SortDisplayButtons(nil, true);
             end
           };
           if(arg.required and not triggertype) then
@@ -344,7 +344,7 @@ function OptionsPrivate.ConstructOptions(prototype, data, startorder, triggernum
                 WeakAuras.ClearAndUpdateOptions(data.id)
               end
               OptionsPrivate.Private.ScanForLoads({[data.id] = true});
-              WeakAuras.SortDisplayButtons(nil, true);
+              OptionsPrivate.Private.SortDisplayButtons(nil, true);
             end
           end
           order = order + 1;
@@ -368,7 +368,7 @@ function OptionsPrivate.ConstructOptions(prototype, data, startorder, triggernum
             OptionsPrivate.Private.ScanForLoads({[data.id] = true});
             WeakAuras.UpdateThumbnail(data);
             WeakAuras.UpdateDisplayButton(data);
-            WeakAuras.SortDisplayButtons(nil, true);
+            OptionsPrivate.Private.SortDisplayButtons(nil, true);
           end
         };
         if(arg.required and not triggertype) then
@@ -379,7 +379,7 @@ function OptionsPrivate.ConstructOptions(prototype, data, startorder, triggernum
               WeakAuras.ClearAndUpdateOptions(data.id)
             end
             OptionsPrivate.Private.ScanForLoads({[data.id] = true});
-            WeakAuras.SortDisplayButtons(nil, true);
+            OptionsPrivate.Private.SortDisplayButtons(nil, true);
           end
         end
         order = order + 1;
@@ -401,7 +401,7 @@ function OptionsPrivate.ConstructOptions(prototype, data, startorder, triggernum
             OptionsPrivate.Private.ScanForLoads({[data.id] = true});
             WeakAuras.UpdateThumbnail(data);
             WeakAuras.UpdateDisplayButton(data);
-            WeakAuras.SortDisplayButtons(nil, true);
+            OptionsPrivate.Private.SortDisplayButtons(nil, true);
           end
         };
 
@@ -421,7 +421,7 @@ function OptionsPrivate.ConstructOptions(prototype, data, startorder, triggernum
               WeakAuras.ClearAndUpdateOptions(data.id)
             end
             OptionsPrivate.Private.ScanForLoads({[data.id] = true});
-            WeakAuras.SortDisplayButtons(nil, true);
+            OptionsPrivate.Private.SortDisplayButtons(nil, true);
           end
         end
         order = order + 1;
@@ -444,7 +444,7 @@ function OptionsPrivate.ConstructOptions(prototype, data, startorder, triggernum
             OptionsPrivate.Private.ScanForLoads({[data.id] = true});
             WeakAuras.UpdateThumbnail(data);
             WeakAuras.UpdateDisplayButton(data);
-            WeakAuras.SortDisplayButtons(nil, true);
+            OptionsPrivate.Private.SortDisplayButtons(nil, true);
           end
         };
         if(arg.required and not triggertype) then
@@ -455,7 +455,7 @@ function OptionsPrivate.ConstructOptions(prototype, data, startorder, triggernum
               WeakAuras.ClearAndUpdateOptions(data.id)
             end
             OptionsPrivate.Private.ScanForLoads({[data.id] = true});
-            WeakAuras.SortDisplayButtons(nil, true);
+            OptionsPrivate.Private.SortDisplayButtons(nil, true);
           end
         end
         order = order + 1;
@@ -477,7 +477,7 @@ function OptionsPrivate.ConstructOptions(prototype, data, startorder, triggernum
             OptionsPrivate.Private.ScanForLoads({[data.id] = true});
             WeakAuras.UpdateThumbnail(data);
             WeakAuras.UpdateDisplayButton(data);
-            WeakAuras.SortDisplayButtons(nil, true);
+            OptionsPrivate.Private.SortDisplayButtons(nil, true);
           end
         };
         if(arg.required and not triggertype) then
@@ -488,7 +488,7 @@ function OptionsPrivate.ConstructOptions(prototype, data, startorder, triggernum
               WeakAuras.ClearAndUpdateOptions(data.id)
             end
             OptionsPrivate.Private.ScanForLoads({[data.id] = true});
-            WeakAuras.SortDisplayButtons(nil, true);
+            OptionsPrivate.Private.SortDisplayButtons(nil, true);
           end
         end
         order = order + 1;
@@ -509,7 +509,7 @@ function OptionsPrivate.ConstructOptions(prototype, data, startorder, triggernum
               OptionsPrivate.Private.ScanForLoads({[data.id] = true});
               WeakAuras.UpdateThumbnail(data);
               WeakAuras.UpdateDisplayButton(data);
-              WeakAuras.SortDisplayButtons(nil, true);
+              OptionsPrivate.Private.SortDisplayButtons(nil, true);
             end,
           };
           order = order + 1;
@@ -604,7 +604,7 @@ function OptionsPrivate.ConstructOptions(prototype, data, startorder, triggernum
             OptionsPrivate.Private.ScanForLoads({[data.id] = true});
             WeakAuras.UpdateThumbnail(data);
             WeakAuras.UpdateDisplayButton(data);
-            WeakAuras.SortDisplayButtons(nil, true);
+            OptionsPrivate.Private.SortDisplayButtons(nil, true);
           end
         };
         order = order + 1;
@@ -658,7 +658,7 @@ function OptionsPrivate.ConstructOptions(prototype, data, startorder, triggernum
             OptionsPrivate.Private.ScanForLoads({[data.id] = true});
             WeakAuras.UpdateThumbnail(data);
             WeakAuras.UpdateDisplayButton(data);
-            WeakAuras.SortDisplayButtons(nil, true);
+            OptionsPrivate.Private.SortDisplayButtons(nil, true);
           end
         };
         if(arg.required and not triggertype) then
@@ -676,7 +676,7 @@ function OptionsPrivate.ConstructOptions(prototype, data, startorder, triggernum
             OptionsPrivate.Private.ScanForLoads({[data.id] = true});
             WeakAuras.UpdateThumbnail(data);
             WeakAuras.UpdateDisplayButton(data);
-            WeakAuras.SortDisplayButtons(nil, true);
+            OptionsPrivate.Private.SortDisplayButtons(nil, true);
           end
         end
         if (arg.control) then
@@ -749,7 +749,7 @@ function OptionsPrivate.ConstructOptions(prototype, data, startorder, triggernum
             OptionsPrivate.Private.ScanForLoads({[data.id] = true});
             WeakAuras.UpdateThumbnail(data);
             WeakAuras.UpdateDisplayButton(data);
-            WeakAuras.SortDisplayButtons(nil, true);
+            OptionsPrivate.Private.SortDisplayButtons(nil, true);
           end
         };
         if(arg.required and not triggertype) then
@@ -762,7 +762,7 @@ function OptionsPrivate.ConstructOptions(prototype, data, startorder, triggernum
             OptionsPrivate.Private.ScanForLoads({[data.id] = true});
             WeakAuras.UpdateThumbnail(data);
             WeakAuras.UpdateDisplayButton(data);
-            WeakAuras.SortDisplayButtons(nil, true);
+            OptionsPrivate.Private.SortDisplayButtons(nil, true);
           end
         end
 
@@ -782,7 +782,7 @@ function OptionsPrivate.ConstructOptions(prototype, data, startorder, triggernum
               trigger[realname .. "_extraOption"] = v
               WeakAuras.Add(data)
               OptionsPrivate.Private.ScanForLoads({[data.id] = true})
-              WeakAuras.SortDisplayButtons(nil, true)
+              OptionsPrivate.Private.SortDisplayButtons(nil, true)
             end
           }
           order = order + 1
@@ -816,7 +816,7 @@ function OptionsPrivate.ConstructOptions(prototype, data, startorder, triggernum
             OptionsPrivate.Private.ScanForLoads({[data.id] = true});
             WeakAuras.UpdateThumbnail(data);
             WeakAuras.UpdateDisplayButton(data);
-            WeakAuras.SortDisplayButtons(nil, true);
+            OptionsPrivate.Private.SortDisplayButtons(nil, true);
           end
         };
         if(arg.required and not triggertype) then
@@ -833,7 +833,7 @@ function OptionsPrivate.ConstructOptions(prototype, data, startorder, triggernum
             OptionsPrivate.Private.ScanForLoads({[data.id] = true});
             WeakAuras.UpdateThumbnail(data);
             WeakAuras.UpdateDisplayButton(data);
-            WeakAuras.SortDisplayButtons(nil, true);
+            OptionsPrivate.Private.SortDisplayButtons(nil, true);
           end
         end
 
@@ -901,7 +901,7 @@ function OptionsPrivate.GetLoadOptions(data)
         WeakAuras.Add(data);
         WeakAuras.UpdateThumbnail(data);
         OptionsPrivate.Private.ScanForLoads({[data.id] = true});
-        WeakAuras.SortDisplayButtons(nil, true);
+        OptionsPrivate.Private.SortDisplayButtons(nil, true);
       end,
       args = {}
     }

--- a/WeakAurasOptions/OptionsFrames/OptionsFrame.lua
+++ b/WeakAurasOptions/OptionsFrames/OptionsFrame.lua
@@ -543,7 +543,7 @@ function OptionsPrivate.CreateFrame()
   local filterInput = CreateFrame("editbox", "WeakAurasFilterInput", frame, "SearchBoxTemplate")
   filterInput:SetScript("OnTextChanged", function(self)
     SearchBoxTemplate_OnTextChanged(self)
-    OptionsPrivate.Private.SortDisplayButtons(filterInput:GetText())
+    OptionsPrivate.SortDisplayButtons(filterInput:GetText())
   end)
   filterInput:SetHeight(15)
   filterInput:SetPoint("TOP", frame, "TOP", 0, -44)
@@ -724,7 +724,7 @@ function OptionsPrivate.CreateFrame()
     else
       odb.pendingImportCollapse = true
     end
-    OptionsPrivate.Private.SortDisplayButtons()
+    OptionsPrivate.SortDisplayButtons()
   end)
   pendingInstallButton:SetExpandDescription(L["Expand all pending Import"])
   pendingInstallButton:SetCollapseDescription(L["Collapse all pending Import"])
@@ -747,7 +747,7 @@ function OptionsPrivate.CreateFrame()
     else
       odb.pendingUpdateCollapse = true
     end
-    OptionsPrivate.Private.SortDisplayButtons()
+    OptionsPrivate.SortDisplayButtons()
   end)
   pendingUpdateButton:SetExpandDescription(L["Expand all pending Import"])
   pendingUpdateButton:SetCollapseDescription(L["Collapse all pending Import"])
@@ -769,7 +769,7 @@ function OptionsPrivate.CreateFrame()
     else
       odb.loadedCollapse = true
     end
-    OptionsPrivate.Private.SortDisplayButtons()
+    OptionsPrivate.SortDisplayButtons()
   end)
   loadedButton:SetExpandDescription(L["Expand all loaded displays"])
   loadedButton:SetCollapseDescription(L["Collapse all loaded displays"])
@@ -829,7 +829,7 @@ function OptionsPrivate.CreateFrame()
     else
       odb.unloadedCollapse = true
     end
-    OptionsPrivate.Private.SortDisplayButtons()
+    OptionsPrivate.SortDisplayButtons()
   end)
   unloadedButton:SetExpandDescription(L["Expand all non-loaded displays"])
   unloadedButton:SetCollapseDescription(L["Collapse all non-loaded displays"])

--- a/WeakAurasOptions/OptionsFrames/OptionsFrame.lua
+++ b/WeakAurasOptions/OptionsFrames/OptionsFrame.lua
@@ -543,7 +543,7 @@ function OptionsPrivate.CreateFrame()
   local filterInput = CreateFrame("editbox", "WeakAurasFilterInput", frame, "SearchBoxTemplate")
   filterInput:SetScript("OnTextChanged", function(self)
     SearchBoxTemplate_OnTextChanged(self)
-    WeakAuras.SortDisplayButtons(filterInput:GetText())
+    OptionsPrivate.Private.SortDisplayButtons(filterInput:GetText())
   end)
   filterInput:SetHeight(15)
   filterInput:SetPoint("TOP", frame, "TOP", 0, -44)
@@ -724,7 +724,7 @@ function OptionsPrivate.CreateFrame()
     else
       odb.pendingImportCollapse = true
     end
-    WeakAuras.SortDisplayButtons()
+    OptionsPrivate.Private.SortDisplayButtons()
   end)
   pendingInstallButton:SetExpandDescription(L["Expand all pending Import"])
   pendingInstallButton:SetCollapseDescription(L["Collapse all pending Import"])
@@ -747,7 +747,7 @@ function OptionsPrivate.CreateFrame()
     else
       odb.pendingUpdateCollapse = true
     end
-    WeakAuras.SortDisplayButtons()
+    OptionsPrivate.Private.SortDisplayButtons()
   end)
   pendingUpdateButton:SetExpandDescription(L["Expand all pending Import"])
   pendingUpdateButton:SetCollapseDescription(L["Collapse all pending Import"])
@@ -769,7 +769,7 @@ function OptionsPrivate.CreateFrame()
     else
       odb.loadedCollapse = true
     end
-    WeakAuras.SortDisplayButtons()
+    OptionsPrivate.Private.SortDisplayButtons()
   end)
   loadedButton:SetExpandDescription(L["Expand all loaded displays"])
   loadedButton:SetCollapseDescription(L["Collapse all loaded displays"])
@@ -829,7 +829,7 @@ function OptionsPrivate.CreateFrame()
     else
       odb.unloadedCollapse = true
     end
-    WeakAuras.SortDisplayButtons()
+    OptionsPrivate.Private.SortDisplayButtons()
   end)
   unloadedButton:SetExpandDescription(L["Expand all non-loaded displays"])
   unloadedButton:SetCollapseDescription(L["Collapse all non-loaded displays"])

--- a/WeakAurasOptions/WeakAurasOptions.lua
+++ b/WeakAurasOptions/WeakAurasOptions.lua
@@ -270,7 +270,7 @@ function OptionsPrivate.MultipleDisplayTooltipMenu()
         local button = WeakAuras.GetDisplayButton(data.id);
         button.callbacks.UpdateExpandButton();
         WeakAuras.UpdateDisplayButton(data);
-        OptionsPrivate.Private.SortDisplayButtons();
+        OptionsPrivate.SortDisplayButtons();
         button:Expand();
       end
     },
@@ -307,7 +307,7 @@ function OptionsPrivate.MultipleDisplayTooltipMenu()
         local button = WeakAuras.GetDisplayButton(data.id);
         button.callbacks.UpdateExpandButton();
         WeakAuras.UpdateDisplayButton(data);
-        OptionsPrivate.Private.SortDisplayButtons();
+        OptionsPrivate.SortDisplayButtons();
         button:Expand();
         WeakAuras.PickDisplay(data.id);
       end
@@ -408,7 +408,7 @@ StaticPopupDialogs["WEAKAURAS_CONFIRM_DELETE"] = {
         end
       end
       OptionsPrivate.Private.ResumeAllDynamicGroups()
-      OptionsPrivate.Private.SortDisplayButtons(nil, true)
+      OptionsPrivate.SortDisplayButtons(nil, true)
     end
   end,
   OnCancel = function(self)
@@ -439,7 +439,7 @@ StaticPopupDialogs["WEAKAURAS_CONFIRM_IGNORE_UPDATES"] = {
           child.ignoreWagoUpdate = true
         end
       end
-      OptionsPrivate.Private.SortDisplayButtons(nil, true)
+      OptionsPrivate.SortDisplayButtons(nil, true)
     end
   end,
   OnCancel = function(self) end,
@@ -466,7 +466,7 @@ end
 local function AfterScanForLoads()
   if(frame) then
     if (frame:IsVisible()) then
-      OptionsPrivate.Private.SortDisplayButtons(nil, true);
+      OptionsPrivate.SortDisplayButtons(nil, true);
     else
       frame.needsSort = true;
     end
@@ -535,7 +535,7 @@ local function OnRename(event, uid, oldid, newid)
   end
 
   OptionsPrivate.SetGrouping()
-  OptionsPrivate.Private.SortDisplayButtons()
+  OptionsPrivate.SortDisplayButtons()
   WeakAuras.PickDisplay(newid)
 end
 
@@ -678,7 +678,7 @@ local function LayoutDisplayButtons(msg)
 
     frame.buttonsScroll:ResumeLayout()
     frame.buttonsScroll:PerformLayout()
-    OptionsPrivate.Private.SortDisplayButtons(msg);
+    OptionsPrivate.SortDisplayButtons(msg);
 
     OptionsPrivate.Private.PauseAllDynamicGroups();
     if (WeakAuras.IsOptionsOpen()) then
@@ -751,7 +751,7 @@ function WeakAuras.ShowOptions(msg)
   frame.buttonsScroll.frame:Show();
 
   if (frame.needsSort) then
-    OptionsPrivate.Private.SortDisplayButtons();
+    OptionsPrivate.SortDisplayButtons();
     frame.needsSort = nil;
   end
 
@@ -861,7 +861,7 @@ function OptionsPrivate.ConvertDisplay(data, newType)
   WeakAuras.UpdateDisplayButton(data);
   WeakAuras.SetMoverSizer(id)
   OptionsPrivate.ResetMoverSizer();
-  OptionsPrivate.Private.SortDisplayButtons()
+  OptionsPrivate.SortDisplayButtons()
 end
 
 function WeakAuras.NewDisplayButton(data, massEdit)
@@ -871,7 +871,7 @@ function WeakAuras.NewDisplayButton(data, massEdit)
   WeakAuras.UpdateDisplayButton(db.displays[id]);
   frame.buttonsScroll:AddChild(displayButtons[id]);
   if not massEdit then
-    OptionsPrivate.Private.SortDisplayButtons()
+    OptionsPrivate.SortDisplayButtons()
   end
 end
 
@@ -925,7 +925,7 @@ end
 local previousFilter;
 local pendingUpdateButtons = {}
 local pendingInstallButtons = {}
-function OptionsPrivate.Private.SortDisplayButtons(filter, overrideReset, id)
+function OptionsPrivate.SortDisplayButtons(filter, overrideReset, id)
   if (OptionsPrivate.Private.IsOptionsProcessingPaused()) then
     return;
   end

--- a/WeakAurasOptions/WeakAurasOptions.lua
+++ b/WeakAurasOptions/WeakAurasOptions.lua
@@ -270,7 +270,7 @@ function OptionsPrivate.MultipleDisplayTooltipMenu()
         local button = WeakAuras.GetDisplayButton(data.id);
         button.callbacks.UpdateExpandButton();
         WeakAuras.UpdateDisplayButton(data);
-        WeakAuras.SortDisplayButtons();
+        OptionsPrivate.Private.SortDisplayButtons();
         button:Expand();
       end
     },
@@ -307,7 +307,7 @@ function OptionsPrivate.MultipleDisplayTooltipMenu()
         local button = WeakAuras.GetDisplayButton(data.id);
         button.callbacks.UpdateExpandButton();
         WeakAuras.UpdateDisplayButton(data);
-        WeakAuras.SortDisplayButtons();
+        OptionsPrivate.Private.SortDisplayButtons();
         button:Expand();
         WeakAuras.PickDisplay(data.id);
       end
@@ -408,7 +408,7 @@ StaticPopupDialogs["WEAKAURAS_CONFIRM_DELETE"] = {
         end
       end
       OptionsPrivate.Private.ResumeAllDynamicGroups()
-      WeakAuras.SortDisplayButtons(nil, true)
+      OptionsPrivate.Private.SortDisplayButtons(nil, true)
     end
   end,
   OnCancel = function(self)
@@ -439,7 +439,7 @@ StaticPopupDialogs["WEAKAURAS_CONFIRM_IGNORE_UPDATES"] = {
           child.ignoreWagoUpdate = true
         end
       end
-      WeakAuras.SortDisplayButtons(nil, true)
+      OptionsPrivate.Private.SortDisplayButtons(nil, true)
     end
   end,
   OnCancel = function(self) end,
@@ -466,7 +466,7 @@ end
 local function AfterScanForLoads()
   if(frame) then
     if (frame:IsVisible()) then
-      WeakAuras.SortDisplayButtons(nil, true);
+      OptionsPrivate.Private.SortDisplayButtons(nil, true);
     else
       frame.needsSort = true;
     end
@@ -535,7 +535,7 @@ local function OnRename(event, uid, oldid, newid)
   end
 
   OptionsPrivate.SetGrouping()
-  WeakAuras.SortDisplayButtons()
+  OptionsPrivate.Private.SortDisplayButtons()
   WeakAuras.PickDisplay(newid)
 end
 
@@ -678,7 +678,7 @@ local function LayoutDisplayButtons(msg)
 
     frame.buttonsScroll:ResumeLayout()
     frame.buttonsScroll:PerformLayout()
-    WeakAuras.SortDisplayButtons(msg);
+    OptionsPrivate.Private.SortDisplayButtons(msg);
 
     OptionsPrivate.Private.PauseAllDynamicGroups();
     if (WeakAuras.IsOptionsOpen()) then
@@ -751,7 +751,7 @@ function WeakAuras.ShowOptions(msg)
   frame.buttonsScroll.frame:Show();
 
   if (frame.needsSort) then
-    WeakAuras.SortDisplayButtons();
+    OptionsPrivate.Private.SortDisplayButtons();
     frame.needsSort = nil;
   end
 
@@ -861,7 +861,7 @@ function OptionsPrivate.ConvertDisplay(data, newType)
   WeakAuras.UpdateDisplayButton(data);
   WeakAuras.SetMoverSizer(id)
   OptionsPrivate.ResetMoverSizer();
-  WeakAuras.SortDisplayButtons()
+  OptionsPrivate.Private.SortDisplayButtons()
 end
 
 function WeakAuras.NewDisplayButton(data, massEdit)
@@ -871,7 +871,7 @@ function WeakAuras.NewDisplayButton(data, massEdit)
   WeakAuras.UpdateDisplayButton(db.displays[id]);
   frame.buttonsScroll:AddChild(displayButtons[id]);
   if not massEdit then
-    WeakAuras.SortDisplayButtons()
+    OptionsPrivate.Private.SortDisplayButtons()
   end
 end
 
@@ -925,7 +925,7 @@ end
 local previousFilter;
 local pendingUpdateButtons = {}
 local pendingInstallButtons = {}
-function WeakAuras.SortDisplayButtons(filter, overrideReset, id)
+function OptionsPrivate.Private.SortDisplayButtons(filter, overrideReset, id)
   if (OptionsPrivate.Private.IsOptionsProcessingPaused()) then
     return;
   end


### PR DESCRIPTION
# Description

Moves the `SortDisplayButtons` from the public `WeakAuras` to the private table.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Logged in
- [x] Imported and shared auras

## Checklist
<!-- These can be checked off after the pull request is submitted, in case you want discussion before they are completely ready -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

<!-- Is there any additional work that needs to be done? If so, add it to the above list -->
