### PR TITLE
Update Types.lua

### DIFF
--- a/WeakAuras/Types.lua
+++ b/WeakAuras/Types.lua
@@ -2554,6 +2554,11 @@ Private.absorb_modes = {
   OVERLAY_FROM_END = L["Attach to End"]
 }
 
+Private.absorb_heal_modes = {
+  OVERLAY_FROM_START = L["Attach to Start"],
+  OVERLAY_FROM_END = L["Attach to End"]
+}
+
 Private.mythic_plus_affixes = {}
 
 local mythic_plus_ignorelist = {


### PR DESCRIPTION
Added Heal Absorb

Fixes #(3129)

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested
- [x] Go to any monster that put up a Heal Absorb (NW/TOP Necrotic Bolt or outside/behind of mists of tirna scithe there are Oakheart Drust-Taken that use Death Blow)

## Checklist
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

<!-- Is there any additional work that needs to be done? If so, add it to the above list -->
I only copy & pasted normal absorb and changed to heal absorb. No eduction in programming!