### PR TITLE
Fixing personal resource display anchor for disabled Plater personal bar module

### DIFF
--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -4770,7 +4770,7 @@ function Private.ensurePRDFrame()
     personalRessourceDisplayFrame:SetScale(1);
     local frame = C_NamePlate.GetNamePlateForUnit("player");
     if (frame) then
-      if (Plater and frame.Plater and frame.unitFrame.Plater) then
+      if (Plater and frame.unitFrame.PlaterOnScreen) then
         personalRessourceDisplayFrame:Attach(frame, frame.unitFrame.healthBar, frame.unitFrame.powerBar);
       elseif (frame.kui and frame.kui.bg and frame.kui:IsShown()) then
         personalRessourceDisplayFrame:Attach(frame.kui, frame.kui.bg, frame.kui.bg);
@@ -4796,7 +4796,7 @@ function Private.ensurePRDFrame()
       if (UnitIsUnit(nameplate, "player")) then
         local frame = C_NamePlate.GetNamePlateForUnit("player");
         if (frame) then
-          if (Plater and frame.Plater and frame.unitFrame.Plater) then
+          if (Plater and frame.unitFrame.PlaterOnScreen) then
             personalRessourceDisplayFrame:Attach(frame, frame.unitFrame.healthBar, frame.unitFrame.powerBar);
           elseif (frame.kui and frame.kui.bg and frame.kui:IsShown()) then
             personalRessourceDisplayFrame:Attach(frame.kui, KuiNameplatesPlayerAnchor, KuiNameplatesPlayerAnchor);


### PR DESCRIPTION
# Description

This changes the existing (#2614) behavior for the personal resource display detection when Plater is enabled but default blizzard personal resource display is used. The check is no longer performed against existing `unitFrame.Plater`, but against the "is the Plater unitFrame acutally on screen" indicator with `unitFrame.PlaterOnScreen` instead.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

- [X] Test with stock Plater personal resource bar and this group of anchored WAs: https://wago.io/n8tDyoqqt
- [X] Test with "moved" Plater personal resource bar with the above group and this Plater mod: https://wago.io/yobXEcUZW
- [X] Test with Plater personal resource bar module disabled (Plater -> Personal Bar -> Module Enabled)

## Checklist
<!-- These can be checked off after the pull request is submitted, in case you want discussion before they are completely ready -->

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings

<!-- Is there any additional work that needs to be done? If so, add it to the above list -->
