### PR TITLE
Validate Companion Data before showing it to the user as a potential update.

### DIFF
--- a/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasPendingInstallButton.lua
+++ b/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasPendingInstallButton.lua
@@ -35,6 +35,7 @@ local methods = {
     self:SetTitle(self.companionData.name)
     self.update:SetScript("OnClick", self.callbacks.OnUpdateClick)
     local data = OptionsPrivate.Private.StringToTable(self.companionData.encoded, true)
+    WeakAuras.PreAdd(data.d)
     self.data = data.d
     self.frame:EnableKeyboard(false)
     self:Enable()

--- a/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasPendingUpdateButton.lua
+++ b/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasPendingUpdateButton.lua
@@ -65,6 +65,7 @@ local methods = {
     self:SetTitle(self.companionData.name)
     self.update:SetScript("OnClick", self.callbacks.OnUpdateClick)
     local data = OptionsPrivate.Private.StringToTable(self.companionData.encoded, true)
+    WeakAuras.PreAdd(data.d)
     self.data = data.d
     self.frame:EnableKeyboard(false)
     self:Enable()


### PR DESCRIPTION
# Description

In rare situations it's possible for some of the data provided by the companion update to be invalid. In the usual scenario, this is a result of an old aura missing modern data used to display the thumbnail. This change validates and modernizes the data before attempting to use it.

Fixes an issue from Discord by Dradux.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

First I imported an older version of an aura, where the most recent version is missing modern data:

https://wago.io/AggramarTechnique/0.0.4

Note the missing `barColor` and `orientation` fields necessary for aurabars to display their thumbnail.

Second I closed the game and loaded up the companion for updates.

Third I opened up the game again, logged in, and then opened WA Options. (You may need to Expand the Ready for Updates section if it is not already)

Prior to the update, an error was thrown and WA Options was broken preventing use. After fix, it works as intended.

## Checklist

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My changes generate no new warnings


I did not traverse the children, as the only aura used by the update is the "base" aura.