### PR TITLE
add text replacements to message_dest

### DIFF
--- a/WeakAuras/Conditions.lua
+++ b/WeakAuras/Conditions.lua
@@ -63,9 +63,19 @@ local function formatValueForAssignment(vType, value, pathToCustomFunction, path
     return "{1, 1, 1, 1}";
   elseif(vType == "chat") then
     if (value and type(value) == "table") then
+      -- can't ReplacePlaceHolders here because the region is required
+      -- will have to send the function forward but I'm already adding the Voice to that function call in another PR
+      -- so wait until that's gone in then return to this.
+      local message_dest = Private.QuotedString(tostring(value.message_dest)) or ""
+      local message_dest_custom = Private.QuotedString(tostring(value.message_dest_custom))
+      if(message_dest == "target" or message_dest == "'target'" or message_dest == "\"target\"" or message_dest == "%t" or message_dest == "'%t'" or message_dest == "\"%t\"") then
+        message_dest = UnitName("target") or ""
+      elseif (message_dest:find('%%') and message_dest_custom) then
+        --message_dest = Private.ReplacePlaceHolders(message_dest, region, message_dest_custom)
+      end
       local serialized = string.format("{message_type = %s, message = %s, message_dest = %s, message_channel = %s, message_custom = %s, message_formaters = %s}",
         Private.QuotedString(tostring(value.message_type)), Private.QuotedString(tostring(value.message or "")),
-        Private.QuotedString(tostring(value.message_dest)), Private.QuotedString(tostring(value.message_channel)),
+        message_dest, Private.QuotedString(tostring(value.message_channel)),
         pathToCustomFunction,
         pathToFormatters)
       return serialized

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -2996,6 +2996,9 @@ function Private.HandleChatAction(message_type, message, message_dest, message_c
   if (message:find('%%')) then
     message = Private.ReplacePlaceHolders(message, region, customFunc, useHiddenStates, formatters);
   end
+  if message_dest and (message_dest:find('%%')) then
+    message_dest = Private.ReplacePlaceHolders(message_dest, region, customFunc, useHiddenStates, formatters);
+  end
   if(message_type == "PRINT") then
     DEFAULT_CHAT_FRAME:AddMessage(message, r or 1, g or 1, b or 1);
   elseif message_type == "ERROR" then
@@ -3006,7 +3009,7 @@ function Private.HandleChatAction(message_type, message, message_dest, message_c
     end
   elseif(message_type == "WHISPER") then
     if(message_dest) then
-      if(message_dest == "target" or message_dest == "'target'" or message_dest == "\"target\"" or message_dest == "%t" or message_dest == "'%t'" or message_dest == "\"%t\"") then
+      if(message_dest == "target" or message_dest == "'target'" or message_dest == "\"target\"") then
         pcall(function() SendChatMessage(message, "WHISPER", nil, UnitName("target")) end);
       else
         pcall(function() SendChatMessage(message, "WHISPER", nil, message_dest) end);

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -2996,9 +2996,6 @@ function Private.HandleChatAction(message_type, message, message_dest, message_c
   if (message:find('%%')) then
     message = Private.ReplacePlaceHolders(message, region, customFunc, useHiddenStates, formatters);
   end
-  if message_dest and (message_dest:find('%%')) then
-    message_dest = Private.ReplacePlaceHolders(message_dest, region, customFunc, useHiddenStates, formatters);
-  end
   if(message_type == "PRINT") then
     DEFAULT_CHAT_FRAME:AddMessage(message, r or 1, g or 1, b or 1);
   elseif message_type == "ERROR" then

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -3009,8 +3009,11 @@ function Private.HandleChatAction(message_type, message, message_dest, message_c
     end
   elseif(message_type == "WHISPER") then
     if(message_dest) then
-      if(message_dest == "target" or message_dest == "'target'" or message_dest == "\"target\"") then
+      if(message_dest == "target" or message_dest == "'target'" or message_dest == "\"target\"" or message_dest == "%t" or message_dest == "'%t'" or message_dest == "\"%t\"") then
         pcall(function() SendChatMessage(message, "WHISPER", nil, UnitName("target")) end);
+      elseif (message_dest:find('%%')) then
+        message_dest = Private.ReplacePlaceHolders(message_dest, region, customFunc, useHiddenStates, formatters);
+        pcall(function() SendChatMessage(message, "WHISPER", nil, message_dest) end);
       else
         pcall(function() SendChatMessage(message, "WHISPER", nil, message_dest) end);
       end

--- a/WeakAurasOptions/ActionOptions.lua
+++ b/WeakAurasOptions/ActionOptions.lua
@@ -865,6 +865,9 @@ function OptionsPrivate.GetActionOptions(data)
   OptionsPrivate.commonOptions.AddCodeOption(action.args, data, L["Custom Code"], "start_message", "https://github.com/WeakAuras/WeakAuras2/wiki/Custom-Code-Blocks#chat-message---custom-code",
                           5, function() return not (data.actions.start.do_message and OptionsPrivate.Private.ContainsCustomPlaceHolder(data.actions.start.message)) end, {"actions", "start", "message_custom"}, false);
 
+  OptionsPrivate.commonOptions.AddCodeOption(action.args, data, L["Custom Code"], "start_message_dest", "https://github.com/WeakAuras/WeakAuras2/wiki/Custom-Code-Blocks#send-to",
+                          3.2, function() return not(data.actions.start.message_type == "WHISPER" and OptionsPrivate.Private.ContainsCustomPlaceHolder(data.actions.start.message_dest)) end, {"actions", "start", "message_dest_custom"}, false)
+
   local startHidden = function()
     return OptionsPrivate.IsCollapsed("format_option", "actions", "start_message", true)
   end
@@ -928,6 +931,9 @@ function OptionsPrivate.GetActionOptions(data)
 
   OptionsPrivate.commonOptions.AddCodeOption(action.args, data, L["Custom Code"], "finish_message", "https://github.com/WeakAuras/WeakAuras2/wiki/Custom-Code-Blocks#chat-message---custom-code",
                           25, function() return not (data.actions.finish.do_message and OptionsPrivate.Private.ContainsCustomPlaceHolder(data.actions.finish.message)) end, {"actions", "finish", "message_custom"}, false);
+
+  OptionsPrivate.commonOptions.AddCodeOption(action.args, data, L["Custom Code"], "finish_message_dest", "https://github.com/WeakAuras/WeakAuras2/wiki/Custom-Code-Blocks#send-to",
+                          23.2, function() return not(data.actions.finish.message_type == "WHISPER" and OptionsPrivate.Private.ContainsCustomPlaceHolder(data.actions.finish.message_dest)) end, {"actions", "finish", "message_dest_custom"}, false)
 
   local finishHidden = function()
     return OptionsPrivate.IsCollapsed("format_option", "actions", "finish_message", true)

--- a/WeakAurasOptions/ConditionOptions.lua
+++ b/WeakAurasOptions/ConditionOptions.lua
@@ -729,6 +729,87 @@ local function addControlsForChange(args, order, data, conditionVariable, totalA
     }
     order = order + 1;
 
+    local function customDestHidden()
+      local message_dest = type(conditions[i].changes[j].value) == "table" and conditions[i].changes[j].value.message_dest;
+      if (not message_dest) then return true; end
+      return not OptionsPrivate.Private.ContainsCustomPlaceHolder(message_dest);
+    end
+
+    args["condition" .. i .. "value" .. j .. "custom dest"] = {
+      type = "input",
+      width = WeakAuras.doubleWidth,
+      name = blueIfNoValue2(data, conditions[i].changes[j], "value", "message_dest_custom", L["Custom Code"], L["Custom Code"]),
+      desc = descIfNoValue2(data, conditions[i].changes[j], "value", "message_dest_custom", propertyType),
+      order = order,
+      multiline = true,
+      hidden = customDestHidden,
+      get = function()
+        return type(conditions[i].changes[j].value) == "table" and conditions[i].changes[j].value.message_dest_custom;
+      end,
+      control = "WeakAurasMultiLineEditBox",
+      set = setValueComplex("message_dest_custom"),
+      arg = {
+        extraFunctions = {
+          {
+            buttonLabel = L["Expand"],
+            func = function()
+              if (data.controlledChildren) then
+                -- Collect multi paths
+                local multipath = {};
+                for id, reference in pairs(conditions[i].changes[j].references) do
+                  local conditionIndex = conditions[i].check.references[id].conditionIndex;
+                  local changeIndex = reference.changeIndex;
+                  multipath[id] = {"conditions", conditionIndex, "changes", changeIndex, "value", "message_dest_custom"};
+                end
+                OptionsPrivate.OpenTextEditor(data, multipath, nil, true, nil, nil, "https://github.com/WeakAuras/WeakAuras2/wiki/Custom-Code-Blocks#send-to");
+              else
+                OptionsPrivate.OpenTextEditor(data, {"conditions", i, "changes", j, "value", "message_dest_custom"}, nil, nil, nil, nil, "https://github.com/WeakAuras/WeakAuras2/wiki/Custom-Code-Blocks#send-to");
+              end
+            end
+          }
+        }
+      }
+    }
+
+    order = order + 1;
+
+    args["condition" .. i .. "value" .. j .. "message_dest_custom_error"] = {
+      type = "description",
+      name = function()
+        local custom = type(conditions[i].changes[j].value) == "table" and conditions[i].changes[j].value.message_dest_custom;
+        if not custom then
+          return "";
+        end
+        local _, errorString = loadstring("return  " .. custom);
+        return errorString and "|cFFFF0000"..errorString or "";
+      end,
+      width = WeakAuras.doubleWidth,
+      order = order,
+      hidden = function()
+        local message_dest = type(conditions[i].changes[j].value) == "table" and conditions[i].changes[j].value.message_dest;
+        if (not message_dest) then
+          return true;
+        end
+        if (not OptionsPrivate.Private.ContainsCustomPlaceHolder(message_dest)) then
+          return true;
+        end
+
+        local custom = type(conditions[i].changes[j].value) == "table" and conditions[i].changes[j].value.message_dest_custom;
+
+        if (not custom) then
+          return true;
+        end
+
+        local loadedFunction, errorString = loadstring("return " .. custom);
+        if(errorString and not loadedFunction) then
+          return false;
+        else
+          return true;
+        end
+      end
+    }
+    order = order + 1;
+
     local descMessage = descIfNoValue2(data, conditions[i].changes[j], "value", "message", propertyType);
     if (not descMessage and data ~= OptionsPrivate.tempGroup) then
       descMessage = L["Dynamic text tooltip"] .. OptionsPrivate.Private.GetAdditionalProperties(data)


### PR DESCRIPTION
# Description

I don't know if anyone ever made a ticket for it but people often want to use text replacements in the "Send To" setting when using Chat Message - Whisper. Most commonly stuff like using a whisper to reply to the person that just cast something on you or whatever. I'd always assumed this was too tricky or awkward to do but when doing the recent TTS PR I noticed it wasn't so awkward after all. 

~~The only awkwardness was having to remove the handling of `%t` that was already in. In defence of this I don't know if anyone knew this was an available option. I've certainly never seen anyone use it.~~ 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Checklist
<!-- These can be checked off after the pull request is submitted, in case you want discussion before they are completely ready -->

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

<!-- Is there any additional work that needs to be done? If so, add it to the above list -->
