### PR TITLE
change party/raid/group units to include pets support

### DIFF
--- a/WeakAuras/BuffTrigger2.lua
+++ b/WeakAuras/BuffTrigger2.lua
@@ -1665,9 +1665,12 @@ local function EventHandler(frame, event, arg1, arg2, ...)
       tinsert(unitsToRemove, "focus")
     end
   elseif event == "UNIT_PET" then
-    ScanGroupUnit(time, matchDataChanged, nil, arg1)
-    if not UnitExistsFixed(arg1) then
-      tinsert(unitsToRemove, arg1) -- not sure if his is working, needs tests
+    local pet = WeakAuras.unitToPetUnit[arg1]
+    if pet then
+      ScanGroupUnit(time, matchDataChanged, nil, pet)
+      if not UnitExistsFixed(pet) then
+        tinsert(unitsToRemove, pet)
+      end
     end
   elseif event == "NAME_PLATE_UNIT_ADDED" then
     nameplateExists[arg1] = true
@@ -1747,7 +1750,7 @@ frame:RegisterEvent("UNIT_FACTION")
 frame:RegisterEvent("UNIT_NAME_UPDATE")
 frame:RegisterEvent("UNIT_FLAGS")
 frame:RegisterEvent("PLAYER_FLAGS_CHANGED")
-frame:RegisterUnitEvent("UNIT_PET", "player")
+frame:RegisterEvent("UNIT_PET")
 if not WeakAuras.IsClassic() then
   frame:RegisterEvent("PLAYER_FOCUS_CHANGED")
   if WeakAuras.IsRetail() then

--- a/WeakAuras/BuffTrigger2.lua
+++ b/WeakAuras/BuffTrigger2.lua
@@ -128,8 +128,14 @@ local function UnitIsVisibleFixed(unit)
   return unitVisible[unit]
 end
 
-local function UnitInSubgroupOrPlayer(unit)
-  return UnitInSubgroup(WeakAuras.petUnitToUnit[unit] or unit) or UnitIsUnit("player", unit)
+local function UnitInSubgroupOrPlayer(unit, includePets)
+  if includePets == nil then
+    return UnitInSubgroup(unit) or UnitIsUnit("player", unit)
+  elseif includePets == true then
+    return UnitInSubgroup(WeakAuras.petUnitToUnit[unit] or unit) or UnitIsUnit("player", unit) or UnitIsUnit("pet", unit)
+  elseif includePets == false then
+    return UnitInSubgroup(WeakAuras.petUnitToUnit[unit]) or UnitIsUnit("pet", unit)
+  end
 end
 
 local function GetOrCreateSubTable(base, next, ...)
@@ -1050,11 +1056,11 @@ local function TriggerInfoApplies(triggerInfo, unit)
   if triggerInfo.unit == "group" and triggerInfo.groupSubType == "party" then
     if IsInRaid() then
       -- Filter our player/party# while in raid and keep only raid units that are correct
-      if not Private.multiUnitUnits.raid[unit] or not UnitInSubgroupOrPlayer(unit) then
+      if not Private.multiUnitUnits.raid[unit] or not UnitInSubgroupOrPlayer(unit, triggerInfo.includePets) then
         return false
       end
     else
-      if not UnitInSubgroupOrPlayer(unit) then
+      if not UnitInSubgroupOrPlayer(unit, triggerInfo.includePets) then
         return false
       end
     end

--- a/WeakAuras/BuffTrigger2.lua
+++ b/WeakAuras/BuffTrigger2.lua
@@ -129,7 +129,7 @@ local function UnitIsVisibleFixed(unit)
 end
 
 local function UnitInSubgroupOrPlayer(unit)
-  return UnitInSubgroup(unit) or UnitIsUnit("player", unit)
+  return UnitInSubgroup(WeakAuras.petUnitToUnit[unit] or unit) or UnitIsUnit("player", unit)
 end
 
 local function GetOrCreateSubTable(base, next, ...)
@@ -837,17 +837,34 @@ local function RemoveState(triggerStates, cloneId)
   end
 end
 
-local function GetAllUnits(unit, allUnits)
+local function GetAllUnits(unit, allUnits, includePets)
   if unit == "group" then
     if allUnits then
       local i = 1
       local raid = true
+      local pets = true
       return function()
         if raid then
           if i <= 40 then
-            local ret = WeakAuras.raidUnits[i]
-            i = i + 1
+            local ret
+            if includePets == true then -- pets + raid
+              ret = pets and WeakAuras.raidpetUnits[i] or WeakAuras.raidUnits[i]
+              pets = not pets
+              if pets then
+                i = i + 1
+              end
+            elseif includePets == false then -- pets only
+              ret = WeakAuras.raidpetUnits[i]
+              i = i + 1
+            else -- raid
+              ret = WeakAuras.raidUnits[i]
+              i = i + 1
+            end
             return ret
+          end
+          if includePets and pets then
+            pets = not pets
+            return "pet"
           end
           raid = false
           i = 1
@@ -855,8 +872,20 @@ local function GetAllUnits(unit, allUnits)
         end
 
         if i <= 4 then
-          local ret =  WeakAuras.partyUnits[i]
-          i = i + 1
+          local ret
+          if includePets == true then -- pets + group
+            ret = pets and WeakAuras.partypetUnits[i] or WeakAuras.partyUnits[i]
+            pets = not pets
+            if pets then
+              i = i + 1
+            end
+          elseif includePets == false then -- pets only
+            ret = WeakAuras.partypetUnits[i]
+            i = i + 1
+          else -- group
+            ret = WeakAuras.partyUnits[i]
+            i = i + 1
+          end
           return ret
         end
 
@@ -869,10 +898,23 @@ local function GetAllUnits(unit, allUnits)
     if IsInRaid() then
       local i = 1
       local max = GetNumGroupMembers()
+      local pets = true
       return function()
         if i <= max then
-          local ret = WeakAuras.raidUnits[i]
-          i = i + 1
+          local ret
+          if includePets == true then -- pets + raid
+            ret = pets and WeakAuras.raidpetUnits[i] or WeakAuras.raidUnits[i]
+            pets = not pets
+            if pets then
+              i = i + 1
+            end
+          elseif includePets == false then -- pets only
+            ret = WeakAuras.raidpetUnits[i]
+            i = i + 1
+          else -- raid
+            ret = WeakAuras.raidUnits[i]
+            i = i + 1
+          end
           return ret
         end
         i = 1
@@ -880,14 +922,31 @@ local function GetAllUnits(unit, allUnits)
     else
       local i = 0
       local max = GetNumSubgroupMembers()
+      local pets = true
       return function()
         if i == 0 then
+          if includePets and pets then
+            pets = not pets
+            return "pet"
+          end
           i = 1
           return "player"
         else
           if i <= max then
-            local ret =  WeakAuras.partyUnits[i]
-            i = i + 1
+            local ret
+            if includePets == true then -- pets + group
+              ret = pets and WeakAuras.partypetUnits[i] or WeakAuras.partyUnits[i]
+              pets = not pets
+              if pets then
+                i = i + 1
+              end
+            elseif includePets == false then -- pets only
+              ret = WeakAuras.partypetUnits[i]
+              i = i + 1
+            else -- group
+              ret = WeakAuras.partyUnits[i]
+              i = i + 1
+            end
             return ret
           end
         end
@@ -979,6 +1038,15 @@ local function TriggerInfoApplies(triggerInfo, unit)
     return false
   end
 
+  if triggerInfo.unit == "group" then
+    local isPet = WeakAuras.UnitIsPet(unit)
+    if triggerInfo.includePets == false and not isPet then -- pets only
+      return false
+    elseif triggerInfo.includePets == nil and isPet then -- exclude pets
+      return false
+    end
+  end
+
   if triggerInfo.unit == "group" and triggerInfo.groupSubType == "party" then
     if IsInRaid() then
       -- Filter our player/party# while in raid and keep only raid units that are correct
@@ -1015,7 +1083,7 @@ end
 local function FormatAffectedUnaffected(triggerInfo, matchedUnits)
   local affected = ""
   local unaffected = ""
-  for unit in GetAllUnits(triggerInfo.unit) do
+  for unit in GetAllUnits(triggerInfo.unit, nil, triggerInfo.includePets) do
     if activeGroupScanFuncs[unit] and activeGroupScanFuncs[unit][triggerInfo] then
       if matchedUnits[unit] then
         affected = affected .. (GetUnitName(unit, false) or unit) .. ", "
@@ -1200,7 +1268,7 @@ local function UpdateTriggerState(time, id, triggernum)
         end
       else
         -- state per unaffected unit
-        for unit in GetAllUnits(triggerInfo.unit) do
+        for unit in GetAllUnits(triggerInfo.unit, nil, triggerInfo.includePets) do
           if activeGroupScanFuncs[unit] and activeGroupScanFuncs[unit][triggerInfo] then
             local bestMatch = matches[unit]
             if bestMatch then
@@ -1348,7 +1416,6 @@ end
 local function ScanUnitWithFilter(matchDataChanged, time, unit, filter,
   scanFuncNameGroup, scanFuncSpellIdGroup, scanFuncGeneralGroup,
   scanFuncName, scanFuncSpellId, scanFuncGeneral)
-
   if not scanFuncName and not scanFuncSpellId and not scanFuncGeneral and not scanFuncNameGroup and not scanFuncSpellIdGroup and not scanFuncGeneralGroup then
     if matchDataUpToDate[unit] then
       matchDataUpToDate[unit][filter] = nil
@@ -1426,7 +1493,6 @@ local function ScanGroupUnit(time, matchDataChanged, unitType, unit)
   scanFuncName[unit] = scanFuncName[unit] or {}
   scanFuncSpellId[unit] = scanFuncSpellId[unit] or {}
   scanFuncGeneral[unit] = scanFuncGeneral[unit] or {}
-
   if unitType then
     scanFuncNameGroup[unit] = scanFuncNameGroup[unit] or {}
     scanFuncSpellIdGroup[unit] = scanFuncSpellIdGroup[unit] or {}
@@ -1463,7 +1529,7 @@ end
 local function ScanAllGroup(time, matchDataChanged)
   -- We iterate over all raid/player unit ids here because ScanGroupUnit also
   -- handles the cases where a unit existence changes.
-  for unit in GetAllUnits("group") do
+  for unit in GetAllUnits("group", nil, true) do
     ScanGroupUnit(time, matchDataChanged, "group", unit)
   end
 end
@@ -1607,9 +1673,9 @@ local function EventHandler(frame, event, arg1, arg2, ...)
       tinsert(unitsToRemove, "focus")
     end
   elseif event == "UNIT_PET" then
-    ScanGroupUnit(time, matchDataChanged, nil, "pet")
-    if not UnitExistsFixed("pet") then
-      tinsert(unitsToRemove, "pet")
+    ScanGroupUnit(time, matchDataChanged, nil, arg1)
+    if not UnitExistsFixed(arg1) then
+      tinsert(unitsToRemove, arg1) -- not sure if his is working, needs tests
     end
   elseif event == "NAME_PLATE_UNIT_ADDED" then
     nameplateExists[arg1] = true
@@ -1641,7 +1707,7 @@ local function EventHandler(frame, event, arg1, arg2, ...)
   elseif event == "GROUP_ROSTER_UPDATE" then
     unitVisible = {}
     local unitsToCheck = {}
-    for unit in GetAllUnits("group", true) do
+    for unit in GetAllUnits("group", true, true) do
       RecheckActiveForUnitType("group", unit, deactivatedTriggerInfos)
       if not UnitExistsFixed(unit) then
         tinsert(unitsToRemove, unit)
@@ -1818,7 +1884,7 @@ local function LoadAura(id, triggernum, triggerInfo)
      AddScanFuncs(triggerInfo, nil, scanFuncNameMulti, scanFuncSpellIdMulti, nil)
   elseif triggerInfo.groupTrigger then
     triggerInfo.maxUnitCount = 0
-    for unit in GetAllUnits(triggerInfo.unit) do
+    for unit in GetAllUnits(triggerInfo.unit, nil, triggerInfo.includePets) do
       RecheckActive(triggerInfo, unit, unitsToCheck)
     end
   else
@@ -2357,7 +2423,8 @@ function BuffTrigger.Add(data)
         matchCountFunc = matchCountFunc,
         useAffected = unit == "group" and trigger.useAffected,
         isMulti = trigger.unit == "multi",
-        nameChecker = effectiveNameCheck and WeakAuras.ParseNameCheck(trigger.unitName)
+        nameChecker = effectiveNameCheck and WeakAuras.ParseNameCheck(trigger.unitName),
+        includePets = trigger.use_includePets
       }
       triggerInfos[id] = triggerInfos[id] or {}
       triggerInfos[id][triggernum] = triggerInformation

--- a/WeakAuras/BuffTrigger2.lua
+++ b/WeakAuras/BuffTrigger2.lua
@@ -1532,20 +1532,6 @@ local function ScanGroupUnit(time, matchDataChanged, unitType, unit)
   end
 end
 
-local function ScanAllGroup(time, matchDataChanged)
-  -- We iterate over all raid/player unit ids here because ScanGroupUnit also
-  -- handles the cases where a unit existence changes.
-  for unit in GetAllUnits("group", nil, true) do
-    ScanGroupUnit(time, matchDataChanged, "group", unit)
-  end
-end
-
-local function ScanAllBoss(time, matchDataChanged)
-  for unit in GetAllUnits("boss") do
-    ScanGroupUnit(time, matchDataChanged, "boss", unit)
-  end
-end
-
 local function ScanUnit(time, arg1)
   if (Private.multiUnitUnits.raid[arg1] and IsInRaid()) then
     ScanGroupUnit(time, matchDataChanged, "group", arg1)

--- a/WeakAuras/BuffTrigger2.lua
+++ b/WeakAuras/BuffTrigger2.lua
@@ -131,9 +131,9 @@ end
 local function UnitInSubgroupOrPlayer(unit, includePets)
   if includePets == nil then
     return UnitInSubgroup(unit) or UnitIsUnit("player", unit)
-  elseif includePets == true then
+  elseif includePets == "PlayersAndPets" then
     return UnitInSubgroup(WeakAuras.petUnitToUnit[unit] or unit) or UnitIsUnit("player", unit) or UnitIsUnit("pet", unit)
-  elseif includePets == false then
+  elseif includePets == "PetsOnly" then
     return UnitInSubgroup(WeakAuras.petUnitToUnit[unit]) or UnitIsUnit("pet", unit)
   end
 end
@@ -853,13 +853,13 @@ local function GetAllUnits(unit, allUnits, includePets)
         if raid then
           if i <= 40 then
             local ret
-            if includePets == true then -- pets + raid
+            if includePets == "PlayersAndPets" then
               ret = pets and WeakAuras.raidpetUnits[i] or WeakAuras.raidUnits[i]
               pets = not pets
               if pets then
                 i = i + 1
               end
-            elseif includePets == false then -- pets only
+            elseif includePets == "PetsOnly" then
               ret = WeakAuras.raidpetUnits[i]
               i = i + 1
             else -- raid
@@ -879,13 +879,13 @@ local function GetAllUnits(unit, allUnits, includePets)
 
         if i <= 4 then
           local ret
-          if includePets == true then -- pets + group
+          if includePets == "PlayersAndPets" then
             ret = pets and WeakAuras.partypetUnits[i] or WeakAuras.partyUnits[i]
             pets = not pets
             if pets then
               i = i + 1
             end
-          elseif includePets == false then -- pets only
+          elseif includePets == "PetsOnly" then
             ret = WeakAuras.partypetUnits[i]
             i = i + 1
           else -- group
@@ -908,13 +908,13 @@ local function GetAllUnits(unit, allUnits, includePets)
       return function()
         if i <= max then
           local ret
-          if includePets == true then -- pets + raid
+          if includePets == "PlayersAndPets" then
             ret = pets and WeakAuras.raidpetUnits[i] or WeakAuras.raidUnits[i]
             pets = not pets
             if pets then
               i = i + 1
             end
-          elseif includePets == false then -- pets only
+          elseif includePets == "PetsOnly" then
             ret = WeakAuras.raidpetUnits[i]
             i = i + 1
           else -- raid
@@ -940,13 +940,13 @@ local function GetAllUnits(unit, allUnits, includePets)
         else
           if i <= max then
             local ret
-            if includePets == true then -- pets + group
+            if includePets == "PlayersAndPets" then
               ret = pets and WeakAuras.partypetUnits[i] or WeakAuras.partyUnits[i]
               pets = not pets
               if pets then
                 i = i + 1
               end
-            elseif includePets == false then -- pets only
+            elseif includePets == "PetsOnly" then
               ret = WeakAuras.partypetUnits[i]
               i = i + 1
             else -- group
@@ -1046,7 +1046,7 @@ local function TriggerInfoApplies(triggerInfo, unit)
 
   if triggerInfo.unit == "group" then
     local isPet = WeakAuras.UnitIsPet(unit)
-    if triggerInfo.includePets == false and not isPet then -- pets only
+    if triggerInfo.includePets == "PetsOnly" and not isPet then
       return false
     elseif triggerInfo.includePets == nil and isPet then -- exclude pets
       return false
@@ -2416,7 +2416,7 @@ function BuffTrigger.Add(data)
         useAffected = unit == "group" and trigger.useAffected,
         isMulti = trigger.unit == "multi",
         nameChecker = effectiveNameCheck and WeakAuras.ParseNameCheck(trigger.unitName),
-        includePets = trigger.use_includePets
+        includePets = trigger.use_includePets and trigger.includePets
       }
       triggerInfos[id] = triggerInfos[id] or {}
       triggerInfos[id][triggernum] = triggerInformation

--- a/WeakAuras/GenericTrigger.lua
+++ b/WeakAuras/GenericTrigger.lua
@@ -965,20 +965,26 @@ local function MultiUnitLoop(Func, unit, ...)
     end
   elseif unit == "group" then
     Func("player", ...)
+    Func("pet", ...)
     for i = 1, 4 do
       Func("party"..i, ...)
+      Func("partypet"..i, ...)
     end
     for i = 1, 40 do
       Func("raid"..i, ...)
+      Func("raidpet"..i, ...)
     end
   elseif unit == "party" then
     Func("player", ...)
+    Func("pet", ...)
     for i = 1, 4 do
       Func("party"..i, ...)
+      Func("partypet"..i, ...)
     end
   elseif unit == "raid" then
     for i = 1, 40 do
       Func("raid"..i, ...)
+      Func("raidpet"..i, ...)
     end
   else
     Func(unit, ...)

--- a/WeakAuras/GenericTrigger.lua
+++ b/WeakAuras/GenericTrigger.lua
@@ -1048,13 +1048,18 @@ function LoadEvent(id, triggernum, data)
             loaded_unit_events[u][event] = loaded_unit_events[u][event] or {};
             loaded_unit_events[u][event][id] = loaded_unit_events[u][event][id] or {}
             loaded_unit_events[u][event][id][triggernum] = data;
-            if WeakAuras.UnitIsPet(u) then
-              loaded_unit_events[u].UNIT_PET = loaded_unit_events[u].UNIT_PET or {}
-              loaded_unit_events[u].UNIT_PET[id] = loaded_unit_events[u].UNIT_PET[id] or {}
-              loaded_unit_events[u].UNIT_PET[id][triggernum] = data;
-            end
           end, unit, data.trigger.use_includePets
         )
+        if data.trigger.use_includePets ~= nil then
+          MultiUnitLoop(
+            function(u)
+              loaded_unit_events[u] = loaded_unit_events[u] or {};
+              loaded_unit_events[u].UNIT_PET = loaded_unit_events[u].UNIT_PET or {};
+              loaded_unit_events[u].UNIT_PET[id] = loaded_unit_events[u].UNIT_PET[id] or {}
+              loaded_unit_events[u].UNIT_PET[id][triggernum] = data;
+            end, unit, nil
+          )
+        end
       end
     end
   end
@@ -1343,11 +1348,16 @@ function GenericTrigger.Add(data, region)
                       trigger_unit_events[unit] = trigger_unit_events[unit] or {}
                       tinsert(trigger_unit_events[unit], trueEvent)
                       isUnitEvent = true
-                      if WeakAuras.UnitIsPet(unit) then
-                        tinsert(trigger_unit_events[unit], "UNIT_PET")
-                      end
                     end, i, includePets
                   )
+                  if includePets ~= nil then
+                    MultiUnitLoop(
+                      function(unit)
+                        trigger_unit_events[unit] = trigger_unit_events[unit] or {}
+                        tinsert(trigger_unit_events[unit], "UNIT_PET")
+                      end, unit, nil
+                    )
+                  end
                 end
               end
               if isCLEU then

--- a/WeakAuras/GenericTrigger.lua
+++ b/WeakAuras/GenericTrigger.lua
@@ -1355,7 +1355,7 @@ function GenericTrigger.Add(data, region)
                       function(unit)
                         trigger_unit_events[unit] = trigger_unit_events[unit] or {}
                         tinsert(trigger_unit_events[unit], "UNIT_PET")
-                      end, unit, nil
+                      end, i, nil
                     )
                   end
                 end
@@ -2621,6 +2621,7 @@ function WeakAuras.WatchUnitChange(unit)
     watchUnitChange:RegisterEvent("NAME_PLATE_UNIT_REMOVED")
     watchUnitChange:RegisterEvent("UNIT_FACTION")
     watchUnitChange:RegisterEvent("PLAYER_ENTERING_WORLD")
+    watchUnitChange:RegisterEvent("UNIT_PET")
 
     watchUnitChange:SetScript("OnEvent", function(self, event, unit)
       Private.StartProfileSystem("generictrigger unit change");
@@ -2640,6 +2641,11 @@ function WeakAuras.WatchUnitChange(unit)
             watchUnitChange.nameplateFaction[unit] = reaction
             WeakAuras.ScanEvents("UNIT_CHANGED_" .. unit, unit)
           end
+        end
+      elseif event == "UNIT_PET" then
+        local pet = WeakAuras.unitToPetUnit[unit]
+        if pet then
+          WeakAuras.ScanEvents("UNIT_CHANGED_" .. pet, pet)
         end
       else
         local inRaid = IsInRaid()

--- a/WeakAuras/GenericTrigger.lua
+++ b/WeakAuras/GenericTrigger.lua
@@ -3995,6 +3995,7 @@ else
   end
 end
 
+
 local types = {}
 tinsert(types, "custom")
 for type in pairs(Private.category_event_prototype) do

--- a/WeakAuras/GenericTrigger.lua
+++ b/WeakAuras/GenericTrigger.lua
@@ -964,14 +964,14 @@ local function MultiUnitLoop(Func, unit, includePets, ...)
       Func(unit..i, ...)
     end
   elseif unit == "group" then
-    if includePets ~= false then
+    if includePets ~= "PetsOnly" then
       Func("player", ...)
     end
     if includePets ~= nil then
       Func("pet", ...)
     end
     for i = 1, 4 do
-      if includePets ~= false then
+      if includePets ~= "PetsOnly" then
         Func("party"..i, ...)
       end
       if includePets ~= nil then
@@ -979,7 +979,7 @@ local function MultiUnitLoop(Func, unit, includePets, ...)
       end
     end
     for i = 1, 40 do
-      if includePets ~= false then
+      if includePets ~= "PetsOnly" then
         Func("raid"..i, ...)
       end
       if includePets ~= nil then
@@ -987,14 +987,14 @@ local function MultiUnitLoop(Func, unit, includePets, ...)
       end
     end
   elseif unit == "party" then
-    if includePets ~= false then
+    if includePets ~= "PetsOnly" then
       Func("player", ...)
     end
     if includePets ~= nil then
       Func("pet", ...)
     end
     for i = 1, 4 do
-      if includePets ~= false then
+      if includePets ~= "PetsOnly" then
         Func("party"..i, ...)
       end
       if includePets ~= nil then
@@ -1003,7 +1003,7 @@ local function MultiUnitLoop(Func, unit, includePets, ...)
     end
   elseif unit == "raid" then
     for i = 1, 40 do
-      if includePets ~= false then
+      if includePets ~= "PetsOnly" then
         Func("raid"..i, ...)
       end
       if includePets ~= nil then
@@ -1039,6 +1039,7 @@ function LoadEvent(id, triggernum, data)
     end
   end
   if data.unit_events then
+    local includePets = data.trigger.use_includePets == true and data.trigger.includePets or nil
     for unit, events in pairs(data.unit_events) do
       unit = string.lower(unit)
       for index, event in pairs(events) do
@@ -1048,9 +1049,9 @@ function LoadEvent(id, triggernum, data)
             loaded_unit_events[u][event] = loaded_unit_events[u][event] or {};
             loaded_unit_events[u][event][id] = loaded_unit_events[u][event][id] or {}
             loaded_unit_events[u][event][id][triggernum] = data;
-          end, unit, data.trigger.use_includePets
+          end, unit, includePets
         )
-        if data.trigger.use_includePets ~= nil then
+        if includePets ~= nil then
           MultiUnitLoop(
             function(u)
               loaded_unit_events[u] = loaded_unit_events[u] or {};
@@ -1099,6 +1100,7 @@ function GenericTrigger.LoadDisplays(toLoad, loadEvent, ...)
           end
         end
         if data.unit_events then
+          local includePets = data.trigger.use_includePets == true and data.trigger.includePets or nil
           for unit, events in pairs(data.unit_events) do
             for index, event in pairs(events) do
               MultiUnitLoop(
@@ -1110,7 +1112,7 @@ function GenericTrigger.LoadDisplays(toLoad, loadEvent, ...)
                       unitEventsToRegister[u].UNIT_PET = true
                     end
                   end
-                end, unit, data.trigger.use_includePets
+                end, unit, includePets
               )
             end
           end
@@ -1337,10 +1339,10 @@ function GenericTrigger.Add(data, region)
                 elseif trueEvent:match("^UNIT_") then
                   local includePets
                   if i == "grouppets" then
-                    includePets = true
+                    includePets = "PlayersAndPets"
                     i = "group"
                   elseif i == "grouppetsonly" then
-                    includePets = false
+                    includePets = "PetsOnly"
                     i = "group"
                   end
                   MultiUnitLoop(

--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -1717,7 +1717,7 @@ local function AddUnitChangeInternalEvents(triggerUnit, t, includePets)
       local isPet
       for unit in pairs(Private.multiUnitUnits[triggerUnit]) do
         isPet = WeakAuras.UnitIsPet(unit)
-        if (includePets ~= nil and isPet) or (includePets ~= false and not isPet) then
+        if (includePets ~= nil and isPet) or (includePets ~= "PetsOnly" and not isPet) then
           tinsert(t, "UNIT_CHANGED_" .. string.lower(unit))
           WeakAuras.WatchUnitChange(unit)
         end
@@ -1783,11 +1783,12 @@ end
 local unitHelperFunctions = {
   UnitChangedForceEvents = function(trigger)
     local events = {}
+    local includePets = trigger.use_includePets == true and trigger.includePets or nil
     if Private.multiUnitUnits[trigger.unit] then
       local isPet
       for unit in pairs(Private.multiUnitUnits[trigger.unit]) do
         isPet = WeakAuras.UnitIsPet(unit)
-        if (trigger.use_includePets ~= nil and isPet) or (trigger.use_includePets ~= false and not isPet) then
+        if (includePets ~= nil and isPet) or (includePets ~= "PetsOnly" and not isPet) then
           tinsert(events, {"UNIT_CHANGED_" .. unit, unit})
         end
       end
@@ -2307,8 +2308,9 @@ Private.event_prototypes = {
     internal_events = function(trigger)
       local unit = trigger.unit
       local result = {}
-      AddUnitChangeInternalEvents(unit, result, trigger.use_includePets)
-      if trigger.use_includePets ~= false then
+      local includePets = trigger.use_includePets == true and trigger.includePets or nil
+      AddUnitChangeInternalEvents(unit, result, includePets)
+      if includePets ~= "PetsOnly" then
         AddUnitRoleChangeInternalEvents(unit, result)
       end
       return result
@@ -2529,8 +2531,9 @@ Private.event_prototypes = {
       {
         name = "includePets",
         display = L["Include Pets"],
-        type = "tristate",
-        width = WeakAuras.doubleWidth,
+        type = "select",
+        values = "include_pets_types",
+        width = WeakAuras.normalWidth,
         test = "true",
         enable = function(trigger)
           return trigger.unit == "group" or trigger.unit == "raid" or trigger.unit == "party"

--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -2511,6 +2511,16 @@ Private.event_prototypes = {
         end
       },
       {
+        name = "ignorePets",
+        display = L["Ignore Pets"],
+        type = "toggle",
+        width = WeakAuras.doubleWidth,
+        init = "not WeakAuras.UnitIsPet(unit)",
+        enable = function(trigger)
+          return trigger.unit == "group" or trigger.unit == "raid" or trigger.unit == "party"
+        end
+      },
+      {
         name = "ignoreSelf",
         display = L["Ignore Self"],
         type = "toggle",

--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -2307,8 +2307,10 @@ Private.event_prototypes = {
     internal_events = function(trigger)
       local unit = trigger.unit
       local result = {}
-      AddUnitChangeInternalEvents(unit, result)
-      AddUnitRoleChangeInternalEvents(unit, result)
+      AddUnitChangeInternalEvents(unit, result, trigger.use_includePets)
+      if trigger.use_includePets ~= false then
+        AddUnitRoleChangeInternalEvents(unit, result)
+      end
       return result
     end,
     force_events = unitHelperFunctions.UnitChangedForceEvents,

--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -2545,7 +2545,7 @@ Private.event_prototypes = {
       },
       {
         name = "includePets",
-        display = L["Include Pets"],
+        display = WeakAuras.newFeatureString .. L["Include Pets"],
         type = "select",
         values = "include_pets_types",
         width = WeakAuras.normalWidth,
@@ -2957,7 +2957,7 @@ Private.event_prototypes = {
       },
       {
         name = "includePets",
-        display = L["Include Pets"],
+        display = WeakAuras.newFeatureString .. L["Include Pets"],
         type = "select",
         values = "include_pets_types",
         width = WeakAuras.normalWidth,
@@ -7519,7 +7519,7 @@ Private.event_prototypes = {
       },
       {
         name = "includePets",
-        display = L["Include Pets"],
+        display = WeakAuras.newFeatureString .. L["Include Pets"],
         type = "select",
         values = "include_pets_types",
         width = WeakAuras.normalWidth,

--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -1734,9 +1734,15 @@ local function AddUnitRoleChangeInternalEvents(triggerUnit, t)
     return
   end
 
+  if WeakAuras.UnitIsPet(triggerUnit) then
+    return
+  end
+
   if Private.multiUnitUnits[triggerUnit] then
     for unit in pairs(Private.multiUnitUnits[triggerUnit]) do
-      tinsert(t, "UNIT_ROLE_CHANGED_" .. string.lower(unit))
+      if not WeakAuras.UnitIsPet(unit) then
+        tinsert(t, "UNIT_ROLE_CHANGED_" .. string.lower(unit))
+      end
     end
   else
     tinsert(t, "UNIT_ROLE_CHANGED_" .. string.lower(triggerUnit))

--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -1784,8 +1784,12 @@ local unitHelperFunctions = {
   UnitChangedForceEvents = function(trigger)
     local events = {}
     if Private.multiUnitUnits[trigger.unit] then
+      local isPet
       for unit in pairs(Private.multiUnitUnits[trigger.unit]) do
-        tinsert(events, {"UNIT_CHANGED_" .. unit, unit})
+        isPet = WeakAuras.UnitIsPet(unit)
+        if (trigger.use_includePets ~= nil and isPet) or (trigger.use_includePets ~= false and not isPet) then
+          tinsert(events, {"UNIT_CHANGED_" .. unit, unit})
+        end
       end
     else
       if trigger.unit then

--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -2686,12 +2686,15 @@ Private.event_prototypes = {
     internal_events = function(trigger)
       local unit = trigger.unit
       local result = {}
-      AddUnitChangeInternalEvents(unit, result)
-      AddUnitRoleChangeInternalEvents(unit, result)
+      local includePets = trigger.use_includePets == true and trigger.includePets or nil
+      AddUnitChangeInternalEvents(unit, result, includePets)
+      if includePets ~= "PetsOnly" then
+        AddUnitRoleChangeInternalEvents(unit, result)
+      end
 
       return result
     end,
-    force_events = unitHelperFunctions.UnitChangedForceEvents,
+    force_events = unitHelperFunctions.UnitChangedForceEventsWithPets,
     name = L["Power"],
     init = function(trigger)
       trigger.unit = trigger.unit or "player";
@@ -2950,6 +2953,17 @@ Private.event_prototypes = {
         conditionType = "select",
         enable = function(trigger)
           return not WeakAuras.IsRetail() and (trigger.unit == "group" or trigger.unit == "raid" or trigger.unit == "party")
+        end
+      },
+      {
+        name = "includePets",
+        display = L["Include Pets"],
+        type = "select",
+        values = "include_pets_types",
+        width = WeakAuras.normalWidth,
+        test = "true",
+        enable = function(trigger)
+          return trigger.unit == "group" or trigger.unit == "raid" or trigger.unit == "party"
         end
       },
       {
@@ -7279,8 +7293,11 @@ Private.event_prototypes = {
         tinsert(result, "UNIT_SPELLCAST_CHANNEL_START")
       end
       AddRemainingCastInternalEvents(unit, result)
-      AddUnitChangeInternalEvents(unit, result)
-      AddUnitRoleChangeInternalEvents(unit, result)
+      local includePets = trigger.use_includePets == true and trigger.includePets or nil
+      AddUnitChangeInternalEvents(unit, result, includePets)
+      if includePets ~= "PetsOnly" then
+        AddUnitRoleChangeInternalEvents(unit, result)
+      end
       return result
     end,
     loadFunc = function(trigger)
@@ -7288,7 +7305,7 @@ Private.event_prototypes = {
         WeakAuras.WatchForCastLatency()
       end
     end,
-    force_events = unitHelperFunctions.UnitChangedForceEvents,
+    force_events = unitHelperFunctions.UnitChangedForceEventsWithPets,
     canHaveDuration = "timed",
     name = L["Cast"],
     init = function(trigger)
@@ -7498,6 +7515,17 @@ Private.event_prototypes = {
         enable = function(trigger)
           return not WeakAuras.IsRetail() and (trigger.unit == "group" or trigger.unit == "raid" or trigger.unit == "party")
                  and not trigger.use_inverse
+        end
+      },
+      {
+        name = "includePets",
+        display = L["Include Pets"],
+        type = "select",
+        values = "include_pets_types",
+        width = WeakAuras.normalWidth,
+        test = "true",
+        enable = function(trigger)
+          return trigger.unit == "group" or trigger.unit == "raid" or trigger.unit == "party"
         end
       },
       {

--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -1703,7 +1703,7 @@ Private.load_prototype = {
   }
 };
 
-local function AddUnitChangeInternalEvents(triggerUnit, t)
+local function AddUnitChangeInternalEvents(triggerUnit, t, includePets)
   if (triggerUnit == nil) then
     return
   end
@@ -1714,9 +1714,13 @@ local function AddUnitChangeInternalEvents(triggerUnit, t)
     tinsert(t, "PET_UPDATE")
   else
     if Private.multiUnitUnits[triggerUnit] then
+      local isPet
       for unit in pairs(Private.multiUnitUnits[triggerUnit]) do
-        tinsert(t, "UNIT_CHANGED_" .. string.lower(unit))
-        WeakAuras.WatchUnitChange(unit)
+        isPet = WeakAuras.UnitIsPet(unit)
+        if (includePets ~= nil and isPet) or (includePets ~= false and not isPet) then
+          tinsert(t, "UNIT_CHANGED_" .. string.lower(unit))
+          WeakAuras.WatchUnitChange(unit)
+        end
       end
     else
       tinsert(t, "UNIT_CHANGED_" .. string.lower(triggerUnit))

--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -2527,11 +2527,11 @@ Private.event_prototypes = {
         end
       },
       {
-        name = "ignorePets",
-        display = L["Ignore Pets"],
-        type = "toggle",
+        name = "includePets",
+        display = L["Include Pets"],
+        type = "tristate",
         width = WeakAuras.doubleWidth,
-        init = "not WeakAuras.UnitIsPet(unit)",
+        test = "true",
         enable = function(trigger)
           return trigger.unit == "group" or trigger.unit == "raid" or trigger.unit == "party"
         end

--- a/WeakAuras/Types.lua
+++ b/WeakAuras/Types.lua
@@ -1055,6 +1055,11 @@ Private.text_word_wrap = {
   Elide = L["Elide"]
 }
 
+Private.include_pets_types = {
+  PlayersAndPets = L["Players and Pets"],
+  PetsOnly = L["Pets only"]
+}
+
 Private.category_event_prototype = {}
 for name, prototype in pairs(Private.event_prototypes) do
   Private.category_event_prototype[prototype.type] = Private.category_event_prototype[prototype.type] or {}

--- a/WeakAuras/Types.lua
+++ b/WeakAuras/Types.lua
@@ -3063,7 +3063,11 @@ Private.multiUnitId = {
   ["boss"] = true,
   ["arena"] = true,
   ["group"] = true,
+  ["grouppets"] = true,
+  ["grouppetsonly"] = true,
   ["party"] = true,
+  ["partypets"] = true,
+  ["partypetsonly"] = true,
   ["raid"] = true,
 }
 

--- a/WeakAuras/Types.lua
+++ b/WeakAuras/Types.lua
@@ -3074,19 +3074,29 @@ Private.multiUnitUnits = {
 Private.multiUnitUnits.group["player"] = true
 Private.multiUnitUnits.party["player"] = true
 
+Private.multiUnitUnits.group["pet"] = true
+Private.multiUnitUnits.party["pet"] = true
+
 for i = 1, 4 do
   Private.baseUnitId["party"..i] = true
   Private.baseUnitId["partypet"..i] = true
   Private.multiUnitUnits.group["party"..i] = true
   Private.multiUnitUnits.party["party"..i] = true
+  Private.multiUnitUnits.group["partypet"..i] = true
+  Private.multiUnitUnits.party["partypet"..i] = true
 end
 
 if WeakAuras.IsRetail() then
   for i = 1, MAX_BOSS_FRAMES do
-    Private.baseUnitId["arena"..i] = true
     Private.baseUnitId["boss"..i] = true
-    Private.multiUnitUnits.arena["arena"..i] = true
     Private.multiUnitUnits.boss["boss"..i] = true
+  end
+end
+
+if WeakAuras.IsRetail() or WeakAuras.IsBCC() then
+  for i = 1, 5 do
+    Private.baseUnitId["arena"..i] = true
+    Private.multiUnitUnits.arena["arena"..i] = true
   end
 end
 
@@ -3097,6 +3107,8 @@ for i = 1, 40 do
   Private.multiUnitUnits.nameplate["nameplate"..i] = true
   Private.multiUnitUnits.group["raid"..i] = true
   Private.multiUnitUnits.raid["raid"..i] = true
+  Private.multiUnitUnits.group["raidpet"..i] = true
+  Private.multiUnitUnits.raid["raidpet"..i] = true
 end
 
 Private.dbm_types = {

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -259,13 +259,22 @@ local timers = {}; -- Timers for autohiding, keyed on id, triggernum, cloneid
 WeakAuras.timers = timers;
 
 WeakAuras.raidUnits = {};
+WeakAuras.raidpetUnits = {};
 WeakAuras.partyUnits = {};
+WeakAuras.partypetUnits = {};
+WeakAuras.petUnitToUnit = {
+  pet = "player"
+}
 do
   for i=1,40 do
     WeakAuras.raidUnits[i] = "raid"..i
+    WeakAuras.raidpetUnits[i] = "raidpet"..i
+    WeakAuras.petUnitToUnit["raidpet"..i] = "raid"..i
   end
   for i=1,4 do
     WeakAuras.partyUnits[i] = "party"..i
+    WeakAuras.partypetUnits[i] = "partypet"..i
+    WeakAuras.petUnitToUnit["partypet"..i] = "party"..i
   end
 end
 

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -265,16 +265,21 @@ WeakAuras.partypetUnits = {};
 WeakAuras.petUnitToUnit = {
   pet = "player"
 }
+WeakAuras.unitToPetUnit = {
+  player = "pet"
+}
 do
   for i=1,40 do
     WeakAuras.raidUnits[i] = "raid"..i
     WeakAuras.raidpetUnits[i] = "raidpet"..i
     WeakAuras.petUnitToUnit["raidpet"..i] = "raid"..i
+    WeakAuras.unitToPetUnit["raid"..i] = "raidpet"..i
   end
   for i=1,4 do
     WeakAuras.partyUnits[i] = "party"..i
     WeakAuras.partypetUnits[i] = "partypet"..i
     WeakAuras.petUnitToUnit["partypet"..i] = "party"..i
+    WeakAuras.unitToPetUnit["party"..i] = "partypet"..i
   end
 end
 

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -278,6 +278,10 @@ do
   end
 end
 
+WeakAuras.UnitIsPet = function(unit)
+  return WeakAuras.petUnitToUnit[unit] ~= nil
+end
+
 local playerLevel = UnitLevel("player");
 local currentInstanceType = "none"
 

--- a/WeakAurasOptions/BuffTrigger2.lua
+++ b/WeakAurasOptions/BuffTrigger2.lua
@@ -692,9 +692,30 @@ local function GetBuffTriggerOptions(data, triggernum)
     },
     use_includePets = {
       type = "toggle",
-      width = WeakAuras.doubleWidth,
+      width = WeakAuras.normalWidth,
       name = WeakAuras.newFeatureString .. L["Include Pets"],
-      order = 66.1
+      order = 66.1,
+      hidden = function() return
+        not (trigger.type == "aura2" and (trigger.unit == "group" or trigger.unit == "raid" or trigger.unit == "party"))
+      end
+    },
+    includePets = {
+      type = "select",
+      values = OptionsPrivate.Private.include_pets_types,
+      width = WeakAuras.normalWidth,
+      name = WeakAuras.newFeatureString .. L["Include Pets"],
+      order = 66.15,
+      hidden = function() return not (trigger.type == "aura2" and (trigger.unit == "group" or trigger.unit == "raid" or trigger.unit == "party") and trigger.use_includePets) end,
+    },
+    includePetsSpace = {
+      type = "description",
+      name = "",
+      order = 66.16,
+      width = WeakAuras.normalWidth,
+      hidden = function()
+        return not (trigger.type == "aura2"
+                    and (trigger.unit == "group" or trigger.unit == "raid" or trigger.unit == "party") and not trigger.use_includePets)
+      end
     },
     useGroupRole = {
       type = "toggle",

--- a/WeakAurasOptions/BuffTrigger2.lua
+++ b/WeakAurasOptions/BuffTrigger2.lua
@@ -703,7 +703,7 @@ local function GetBuffTriggerOptions(data, triggernum)
       order = 67.1,
       hidden = function() return
         not (trigger.type == "aura2" and (trigger.unit == "group" or trigger.unit == "raid" or trigger.unit == "party"))
-        or WeakAuras.IsClassic()
+        or WeakAuras.IsClassic() or WeakAuras.IsBCC()
       end
     },
     group_role = {

--- a/WeakAurasOptions/BuffTrigger2.lua
+++ b/WeakAurasOptions/BuffTrigger2.lua
@@ -690,6 +690,12 @@ local function GetBuffTriggerOptions(data, triggernum)
       order = 66,
       hidden = function() return not trigger.type == "aura2" end
     },
+    use_includePets = {
+      type = "toggle",
+      width = WeakAuras.doubleWidth,
+      name = WeakAuras.newFeatureString .. L["Include Pets"],
+      order = 66.1
+    },
     useGroupRole = {
       type = "toggle",
       width = WeakAuras.normalWidth,
@@ -722,7 +728,7 @@ local function GetBuffTriggerOptions(data, triggernum)
       order = 67.1,
       hidden = function() return
         not (trigger.type == "aura2" and (trigger.unit == "group" or trigger.unit == "raid" or trigger.unit == "party"))
-        or not WeakAuras.IsClassic()
+        or WeakAuras.IsRetail()
       end
     },
     raid_role = {


### PR DESCRIPTION
# Description

This PR add an options to generic triggers and aura trigger with unit = party / raid / smart group to for including pets, or show only pets

Fixes #3111

## Done
- [x] Add "Include Pets" option to Health Trigger
- [x] Filter pets for generic triggers at event level
- [x] Add UNIT_*:grouppets:grouppetsonly meta filter for custom events
- [x] Add "Include Pets" option to Bufftrigger2

## To Do
- [ ] Add includePets option to all unit generic trigger (will do after pre-review)
- [ ] Make some pics for blog

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## How Has This Been Tested
- [x] aura anchored to unit frames
- [x] dynamic group of health / power bars
- [x] test party/raid/group by switching hunter to own subgroup or an other subgroup


