### PR TITLE
Add alpha option for glows throughout settings

### DIFF
--- a/WeakAurasOptions/ActionOptions.lua
+++ b/WeakAurasOptions/ActionOptions.lua
@@ -322,6 +322,7 @@ function OptionsPrivate.GetActionOptions(data)
       },
       start_glow_color = {
         type = "color",
+        hasAlpha = true,
         width = WeakAuras.normalWidth,
         name = L["Glow Color"],
         order = 10.8,
@@ -693,6 +694,7 @@ function OptionsPrivate.GetActionOptions(data)
       },
       finish_glow_color = {
         type = "color",
+        hasAlpha = true,
         width = WeakAuras.normalWidth,
         name = L["Glow Color"],
         order = 30.8,

--- a/WeakAurasOptions/ConditionOptions.lua
+++ b/WeakAurasOptions/ConditionOptions.lua
@@ -1084,6 +1084,7 @@ local function addControlsForChange(args, order, data, conditionVariable, totalA
     order = order + 1
     args["condition" .. i .. "value" .. j .. "glow_color"] = {
       type = "color",
+      hasAlpha = true,
       width = WeakAuras.normalWidth,
       name = blueIfNoValue2(data, conditions[i].changes[j], "value", "glow_color", L["Glow Color"], L["Glow Color"]),
       desc = descIfNoValue2(data, conditions[i].changes[j], "value", "glow_color", "color"),

--- a/WeakAurasOptions/SubRegionOptions/Glow.lua
+++ b/WeakAurasOptions/SubRegionOptions/Glow.lua
@@ -118,6 +118,7 @@ local function createOptions(parentData, data, index, subIndex)
     },
     glowColor = {
       type = "color",
+      hasAlpha = true,
       width = WeakAuras.normalWidth,
       name = L["Custom Color"],
       order = 7,


### PR DESCRIPTION
# Description

Quick addition. It was noticed on Discord that glow settings throughout the addon don't use hasAlpha, though the glow lib allows for it. 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Checklist
<!-- These can be checked off after the pull request is submitted, in case you want discussion before they are completely ready -->

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

<!-- Is there any additional work that needs to be done? If so, add it to the above list -->
