### PR TITLE
Fix Weapon Enchant Trigger name state value.

### DIFF
--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -6314,7 +6314,7 @@ Private.event_prototypes = {
       {
         name = "name",
         hidden = true,
-        init = "spell",
+        init = "name",
         test = "true",
         store = true
       },


### PR DESCRIPTION
# Description

Fixes the Weapon Enchant trigger's name field. Appears to have been a copy-paste mistake.
Fixes #3242

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

- [x] Tested a built in trigger for both main hand and off hand with and without the change on an Enhancement Shaman with different Imbues active.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings