### PR TITLE
bcc: update encounter ids tooltip

### DIFF
--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -261,96 +261,96 @@ function Private.InitializeEncounterAndZoneLists()
       {
         L["Karazhan"],
         {
-          { L["Attumen the Huntsman"], 2444 },
-          { L["Moroes"], 2445 },
-          { L["Maiden of Virtue"], 2446 },
-          { L["Opera Hall"], 2447 },
-          { L["The Curator"], 2448 },
-          { L["Terestian Illhoof"], 2449 },
-          { L["Shade of Aran"], 2450 },
-          { L["Netherspite"], 2451 },
-          { L["Chess Event"], 2452 },
-          { L["Prince Malchezaar"], 2453 },
-          { L["Nightbane"], 2454 },
+          { L["Attumen the Huntsman"], 652 },
+          { L["Moroes"], 653 },
+          { L["Maiden of Virtue"], 654 },
+          { L["Opera Hall"], 655 },
+          { L["The Curator"], 656 },
+          { L["Terestian Illhoof"], 657 },
+          { L["Shade of Aran"], 658 },
+          { L["Netherspite"], 659 },
+          { L["Chess Event"], 660 },
+          { L["Prince Malchezaar"], 661 },
+          { L["Nightbane"], 662 },
         }
       },
       {
         L["Gruul's Lair"],
         {
-          { L["High King Maulgar"], 2455 },
-          { L["Gruul the Dragonkiller"], 2456 },
+          { L["High King Maulgar"], 649 },
+          { L["Gruul the Dragonkiller"], 650 },
         }
       },
       {
         L["Magtheridon's Lair"],
         {
-          { L["Magtheridon"], 2457 },
+          { L["Magtheridon"], 651 },
         }
       },
       {
         L["Coilfang: Serpentshrine Cavern"],
         {
-          { L["Hydross the Unstable"], 2458 },
-          { L["The Lurker Below"], 2459 },
-          { L["Leotheras the Blind"], 2460 },
-          { L["Fathom-Lord Karathress"], 2461 },
-          { L["Morogrim Tidewalker"], 2462 },
-          { L["Lady Vashj"], 2463 },
+          { L["Hydross the Unstable"], 623 },
+          { L["The Lurker Below"], 624 },
+          { L["Leotheras the Blind"], 625 },
+          { L["Fathom-Lord Karathress"], 626 },
+          { L["Morogrim Tidewalker"], 627 },
+          { L["Lady Vashj"], 628 },
         }
       },
       {
         L["Tempest Keep"],
         {
-          { L["Al'ar"], 2464 },
-          { L["Void Reaver"], 2465 },
-          { L["High Astromancer Solarian"], 2466 },
-          { L["Kael'thas Sunstrider"], 2467 },
+          { L["Al'ar"], 730 },
+          { L["Void Reaver"], 731 },
+          { L["High Astromancer Solarian"], 732 },
+          { L["Kael'thas Sunstrider"], 733 },
         }
       },
       {
         L["The Battle for Mount Hyjal"],
         {
-          { L["Rage Winterchill"], 2468 },
-          { L["Anetheron"], 2469 },
-          { L["Kaz'rogal"], 2470 },
-          { L["Azgalor"], 2471 },
-          { L["Archimonde"], 2472 },
+          { L["Rage Winterchill"], 618 },
+          { L["Anetheron"], 619 },
+          { L["Kaz'rogal"], 620 },
+          { L["Azgalor"], 621 },
+          { L["Archimonde"], 622 },
         }
       },
       {
         L["Black Temple"],
         {
-          { L["High Warlord Naj'entus"], 2473 },
-          { L["Supremus"], 2474 },
-          { L["Shade of Akama"], 2475 },
-          { L["Teron Gorefiend"], 2476 },
-          { L["Gurtogg Bloodboil"], 2477 },
-          { L["Reliquary of Souls"], 2478 },
-          { L["Mother Shahraz"], 2479 },
-          { L["The Illidari Council"], 2480 },
-          { L["Illidan Stormrage"], 2481 },
+          { L["High Warlord Naj'entus"], 601 },
+          { L["Supremus"], 602 },
+          { L["Shade of Akama"], 603 },
+          { L["Teron Gorefiend"], 604 },
+          { L["Gurtogg Bloodboil"], 605 },
+          { L["Reliquary of Souls"], 606 },
+          { L["Mother Shahraz"], 607 },
+          { L["The Illidari Council"], 608 },
+          { L["Illidan Stormrage"], 609 },
         }
       },
       {
         L["Zul'Aman"],
         {
-          { L["Akil'zon"], 2482 },
-          { L["Nalorakk"], 2483 },
-          { L["Jan'alai"], 2484 },
-          { L["Halazzi"], 2485 },
-          { L["Hex Lord Malacrass"], 2486 },
-          { L["Daakara"], 2487 },
+          { L["Akil'zon"], 1189 },
+          { L["Nalorakk"], 1190 },
+          { L["Jan'alai"], 1191 },
+          { L["Halazzi"], 1192 },
+          { L["Hex Lord Malacrass"], 1193 },
+          { L["Daakara"], 1194 },
         }
       },
       {
         L["The Sunwell Plateau"],
         {
-          { L["Kalecgos"], 2488 },
-          { L["Brutallus"], 2489 },
-          { L["Felmyst"], 2490 },
-          { L["Eredar Twins"], 2491 },
-          { L["M'uru"], 2492 },
-          { L["Kil'jaeden"], 2493 },
+          { L["Kalecgos"], 724 },
+          { L["Brutallus"], 725 },
+          { L["Felmyst"], 726 },
+          { L["Eredar Twins"], 727 },
+          { L["M'uru"], 728 },
+          { L["Kil'jaeden"], 729 },
         }
       },
     }


### PR DESCRIPTION
reflect changes made by blizzard with build 2.5.1.38453

Don't merge yet, waiting for information from adam to know if it's intended
