### PR TITLE
Accept e.g. 30% for Time Remaining triggers.

### DIFF
--- a/WeakAurasOptions/BuffTrigger2.lua
+++ b/WeakAurasOptions/BuffTrigger2.lua
@@ -441,7 +441,7 @@ local function GetBuffTriggerOptions(data, triggernum)
     rem = {
       type = "input",
       name = L["Remaining Time"],
-      validate = ValidateNumeric,
+      validate = ValidateNumericOrPercent,
       order = 61.2,
       width = WeakAuras.halfWidth,
       hidden = function() return not (trigger.type == "aura2" and trigger.unit ~= "multi" and CanHaveMatchCheck(trigger) and trigger.useRem) end,


### PR DESCRIPTION
# Description

Triggers now accept percentages (e.g. 50%) for the Time Remaining option. For a 10.0s duration aura, 30% would mean 3.0s.
In particular, this makes [pandemic window](https://blog.askmrrobot.com/how-wow-works-periodic-damage-and-healing-dots-and-hots/) tracking for dots much easier.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested

- [x] I made a new Aura Icon, with a Trigger: Aura, Unit=Target, Aura Type=Debuff, Name(s)=Rip, Remaining Time=(Operator:<=, Remaining Time:50%)
- [x] As a regression test, I made sure Remaining Time:3 still worked.

## Checklist
<!-- These can be checked off after the pull request is submitted, in case you want discussion before they are completely ready -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
