### PR TITLE
swing timer: fix spell that reset swing not starting swing timer

### DIFF
--- a/WeakAuras/GenericTrigger.lua
+++ b/WeakAuras/GenericTrigger.lua
@@ -1669,10 +1669,14 @@ do
         if casting then
           casting = false
         end
-        if isAttacking then
-          swingStart("main")
-          swingTriggerUpdate()
-        end
+        -- check next frame
+        swingTimerFrame:SetScript("OnUpdate", function(self)
+          if isAttacking then
+            swingStart("main")
+            swingTriggerUpdate()
+          end
+          self:SetScript("OnUpdate", nil)
+        end)
       end
       if Private.reset_ranged_swing_spells[spell] then
         if WeakAuras.IsClassic() or WeakAuras.IsBCC() then


### PR DESCRIPTION
by waiting a frame after the spell so "isAttacking" has correct state

It was tested for hunters in this comment https://github.com/WeakAuras/WeakAuras2/issues/3234#issuecomment-928974786 by @bozhou

@TheSorm @Bakamaka11 @Jovarask could you test if this doesn't break anything from current release for paladins ?