### PR TITLE
Serialize value.message_voice as number instead of string

### DIFF
--- a/WeakAuras/Conditions.lua
+++ b/WeakAuras/Conditions.lua
@@ -68,7 +68,7 @@ local function formatValueForAssignment(vType, value, pathToCustomFunction, path
         Private.QuotedString(tostring(value.message_dest)), Private.QuotedString(tostring(value.message_channel)),
         pathToCustomFunction,
         pathToFormatters,
-        Private.QuotedString(tostring(value.message_voice)))
+        tostring(value.message_voice))
       return serialized
     end
   elseif(vType == "sound") then


### PR DESCRIPTION
# Description
Fixes #3323

## Type of change
- [X] Bug fix

## How Has This Been Tested
Grab the WA reproducer from #3323 and run it before/after the changes. I have verified that this should be a number by checking the types: https://github.com/WeakAuras/WeakAuras2/blob/8a2651eb2de545601b1b8116d1f4e0485ee77dc3/WeakAuras/WeakAuras.lua#L3018-L3020

When printing the types, this is always `number`, except when it comes from a condition, where it was `string`. Checking the internal types coming from Types.lua, this is also supposed to be a number: https://github.com/WeakAuras/WeakAuras2/blob/8a2651eb2de545601b1b8116d1f4e0485ee77dc3/WeakAuras/Types.lua#L2337-L2343

After updating this line I get Zira in-game as expected, instead of David.

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings

<!-- Is there any additional work that needs to be done? If so, add it to the above list -->
