### PR TITLE
check that option key exists before writing

### DIFF
--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -2234,7 +2234,9 @@ local function validateUserConfig(data, options, config)
       corruptOptions[index] = true
     else
       local optionClass = Private.author_option_classes[option.type]
-      authorOptionKeys[option.key] = index
+      if option.key then
+        authorOptionKeys[option.key] = index
+      end
       if optionClass == "simple" then
         if not option.key then
           option.key = WeakAuras.GenerateUniqueID()


### PR DESCRIPTION
noninteractive options dont have keys, so we shouldn't assume that they always do
Fixes #3377