### PR TITLE
DBM Stage Trigger: new "stage total" option

### DIFF
--- a/WeakAuras/GenericTrigger.lua
+++ b/WeakAuras/GenericTrigger.lua
@@ -2706,8 +2706,8 @@ do
   local bars = {}
   local nextExpire -- time of next expiring timer
   local recheckTimer -- handle of timer
-  local currentStage = 0
-
+  local currentStage = 0 -- can do 1>2>1>2>1>...
+  local currentStageTotal = 0 -- always 1>2>3>4>...
   local function dbmRecheckTimers()
     local now = GetTime()
     nextExpire = nil
@@ -2827,8 +2827,9 @@ do
       end
       WeakAuras.ScanEvents("DBM_TimerUpdate", id)
     elseif event == "DBM_SetStage" then
-      local mod, modId, stage, encounterId = ...
+      local mod, modId, stage, encounterId, stageTotal = ...
       currentStage = stage
+      currentStageTotal = stageTotal
       WeakAuras.ScanEvents("DBM_SetStage", ...)
     else -- DBM_Announce
       WeakAuras.ScanEvents(event, ...)
@@ -2872,7 +2873,7 @@ do
   end
 
   function WeakAuras.GetDBMStage()
-    return currentStage
+    return currentStage, currentStageTotal
   end
 
   function WeakAuras.GetDBMTimerById(id)

--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -4889,11 +4889,21 @@ Private.event_prototypes = {
       {
         name = "stage",
         init = "WeakAuras.GetDBMStage()",
-        display = L["Stage"],
+        display = L["Journal Stage"],
+        desc = L["Matches stage number of encounter journal.\nIntermissions are .5\nE.g. 1;2;1;2;2.5;3"],
         type = "number",
         conditionType = "number",
         store = true,
-      }
+      },
+      {
+        name = "stageTotal",
+        init = "select(2, WeakAuras.GetDBMStage())",
+        display = L["Stage Counter"],
+        desc = L["Increases by one per stage or intermission."],
+        type = "number",
+        conditionType = "number",
+        store = true,
+      },
     },
     automaticrequired = true,
     statesParameter = "one",


### PR DESCRIPTION
this option is supported since
https://github.com/DeadlyBossMods/DBM-Unified/commit/407e3ba5156409b5fe6becce35d0662014bb2d1a


Renamed previous "Stage" option to "Current Stage"
Called new option "Stage Total", i don't know if "Total Stage" is better or not.