### PR TITLE
reflect Blizz changes to TTS volume and rate

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -121,7 +121,6 @@ globals = {
 	"STANDARD_TEXT_FONT",
 	"MAX_BOSS_FRAMES",
 	"MAX_SPELL_SCHOOLS",
-	"TEXTTOSPEECH_CONFIG",
 
 	-- ENUMS
 	"LOWER_LEFT_VERTEX",
@@ -1189,6 +1188,9 @@ globals = {
 	"C_Trophy.MonumentLoadSelectedTrophyID",
 	"C_Trophy.MonumentRevertAppearanceToSaved",
 	"C_Trophy.MonumentSaveSelection",
+	"C_TTSSettings",
+	"C_TTSSettings.GetSpeechRate",
+	"C_TTSSettings.GetSpeechVolume()",
 	"C_Vignettes",
 	"C_Vignettes.GetNumVignettes",
 	"C_Vignettes.GetVignetteGUID",

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -2859,8 +2859,8 @@ function Private.HandleChatAction(message_type, message, message_dest, message_c
           validVoice and voice or 0,
           message,
           0,
-          C_TTSSettings.GetSpeechRate() or 0,
-          C_TTSSettings.GetSpeechVolume() or 100
+          C_TTSSettings and C_TTSSettings.GetSpeechRate() or 0,
+          C_TTSSettings and C_TTSSettings.GetSpeechVolume() or 100
         );
       end)
     end

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -2859,8 +2859,8 @@ function Private.HandleChatAction(message_type, message, message_dest, message_c
           validVoice and voice or 0,
           message,
           0,
-          TEXTTOSPEECH_CONFIG and TEXTTOSPEECH_CONFIG.speechRate or 0,
-          TEXTTOSPEECH_CONFIG and TEXTTOSPEECH_CONFIG.speechVolume or 100
+          C_TTSSettings.GetSpeechRate() or 0,
+          C_TTSSettings.GetSpeechVolume() or 100
         );
       end)
     end


### PR DESCRIPTION
# Description

Looks like Blizz made some changes since first implementation. The table that was being checked for volume and rate no longer exists so were always falling back to default values no matter what the user was setting in their interface. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Checklist
<!-- These can be checked off after the pull request is submitted, in case you want discussion before they are completely ready -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

<!-- Is there any additional work that needs to be done? If so, add it to the above list -->
