### PR TITLE
sanitize foreground/background subregions

### DIFF
--- a/WeakAuras/Modernize.lua
+++ b/WeakAuras/Modernize.lua
@@ -1342,8 +1342,8 @@ function Private.Modernize(data)
       -- delete duplicate
       elseif #indexes > 1 then
         for i = 2, #indexes do
-          table.remove(data.subRegions, i)
-          move_condition_subregions(data, -1, i)
+          table.remove(data.subRegions, indexes[i])
+          move_condition_subregions(data, -1, indexes[i])
         end
       end
     end

--- a/WeakAuras/Modernize.lua
+++ b/WeakAuras/Modernize.lua
@@ -1341,7 +1341,7 @@ function Private.Modernize(data)
         move_condition_subregions(data, 1)
       -- delete duplicate
       elseif #indexes > 1 then
-        for i = 2, #indexes do
+        for i = #indexes, 2, -1 do
           table.remove(data.subRegions, indexes[i])
           move_condition_subregions(data, -1, indexes[i])
         end

--- a/WeakAuras/RegionTypes/AuraBar.lua
+++ b/WeakAuras/RegionTypes/AuraBar.lua
@@ -35,15 +35,7 @@ local default = {
   icon_side = "RIGHT",
   icon_color = {1.0, 1.0, 1.0, 1.0},
   frameStrata = 1,
-  zoom = 0,
-  subRegions = {
-    [1] = {
-      ["type"] = "subbackground"
-    },
-    [2] = {
-      ["type"] = "subforeground"
-    },
-  }
+  zoom = 0
 };
 
 WeakAuras.regionPrototype.AddAdjustedDurationToDefault(default);
@@ -1365,5 +1357,10 @@ local function modify(parent, region, data)
   WeakAuras.regionPrototype.modifyFinish(parent, region, data);
 end
 
+local function validate(data)
+  Private.EnforceSubregionExists(data, "subforeground")
+  Private.EnforceSubregionExists(data, "subbackground")
+end
+
 -- Register new region type with WeakAuras
-WeakAuras.RegisterRegionType("aurabar", create, modify, default, GetProperties);
+WeakAuras.RegisterRegionType("aurabar", create, modify, default, GetProperties, validate);

--- a/WeakAuras/RegionTypes/Icon.lua
+++ b/WeakAuras/RegionTypes/Icon.lua
@@ -30,12 +30,7 @@ local default = {
   cooldown = false,
   cooldownTextDisabled = false,
   cooldownSwipe = true,
-  cooldownEdge = false,
-  subRegions = {
-    [1] = {
-      ["type"] = "subbackground"
-    }
-  }
+  cooldownEdge = false
 };
 
 WeakAuras.regionPrototype.AddAlphaToDefault(default);
@@ -617,4 +612,8 @@ local function modify(parent, region, data)
   region:SetHeight(region:GetHeight())
 end
 
-WeakAuras.RegisterRegionType("icon", create, modify, default, GetProperties)
+local function validate(data)
+  Private.EnforceSubregionExists(data, "subbackground")
+end
+
+WeakAuras.RegisterRegionType("icon", create, modify, default, GetProperties, validate)

--- a/WeakAuras/RegionTypes/Model.lua
+++ b/WeakAuras/RegionTypes/Model.lua
@@ -40,12 +40,7 @@ local default = {
   borderOffset = 5,
   borderInset = 11,
   borderSize = 16,
-  borderBackdrop = "Blizzard Tooltip",
-  subRegions = {
-    [1] = {
-      ["type"] = "subbackground"
-    }
-  }
+  borderBackdrop = "Blizzard Tooltip"
 };
 
 local screenWidth, screenHeight = math.ceil(GetScreenWidth() / 20) * 20, math.ceil(GetScreenHeight() / 20) * 20;
@@ -328,5 +323,9 @@ do
   end
 end
 
+local function validate(data)
+  Private.EnforceSubregionExists(data, "subbackground")
+end
+
 -- Register new region type with WeakAuras
-WeakAuras.RegisterRegionType("model", create, modify, default, GetProperties);
+WeakAuras.RegisterRegionType("model", create, modify, default, GetProperties, validate);

--- a/WeakAuras/RegionTypes/ProgressTexture.lua
+++ b/WeakAuras/RegionTypes/ProgressTexture.lua
@@ -54,12 +54,7 @@ local default = {
   fontSize = defaultFontSize,
   mirror = false,
   frameStrata = 1,
-  slantMode = "INSIDE",
-  subRegions = {
-    [1] = {
-      ["type"] = "subbackground"
-    }
-  }
+  slantMode = "INSIDE"
 };
 
 WeakAuras.regionPrototype.AddAlphaToDefault(default);
@@ -1412,4 +1407,8 @@ local function modify(parent, region, data)
   WeakAuras.regionPrototype.modifyFinish(parent, region, data);
 end
 
-WeakAuras.RegisterRegionType("progresstexture", create, modify, default, GetProperties);
+local function validate(data)
+  Private.EnforceSubregionExists(data, "subbackground")
+end
+
+WeakAuras.RegisterRegionType("progresstexture", create, modify, default, GetProperties, validate);

--- a/WeakAuras/RegionTypes/StopMotion.lua
+++ b/WeakAuras/RegionTypes/StopMotion.lua
@@ -39,12 +39,7 @@ local default = {
     customBackgroundFrames = 0,
     customBackgroundRows = 16,
     customBackgroundColumns = 16,
-    hideBackground = true,
-    subRegions = {
-      [1] = {
-        ["type"] = "subbackground"
-      }
-    }
+    hideBackground = true
 };
 
 local screenWidth, screenHeight = math.ceil(GetScreenWidth() / 20) * 20, math.ceil(GetScreenHeight() / 20) * 20;
@@ -410,4 +405,8 @@ local function modify(parent, region, data)
     end
 end
 
-WeakAuras.RegisterRegionType("stopmotion", create, modify, default, properties);
+local function validate(data)
+  Private.EnforceSubregionExists(data, "subbackground")
+end
+
+WeakAuras.RegisterRegionType("stopmotion", create, modify, default, properties, validate);

--- a/WeakAuras/RegionTypes/Text.lua
+++ b/WeakAuras/RegionTypes/Text.lua
@@ -27,12 +27,7 @@ local default = {
 
   shadowColor = { 0, 0, 0, 1},
   shadowXOffset = 1,
-  shadowYOffset = -1,
-  subRegions = {
-    [1] = {
-      ["type"] = "subbackground"
-    }
-  }
+  shadowYOffset = -1
 };
 
 local properties = {
@@ -269,7 +264,11 @@ local function modify(parent, region, data)
   WeakAuras.regionPrototype.modifyFinish(parent, region, data);
 end
 
-WeakAuras.RegisterRegionType("text", create, modify, default, GetProperties);
+local function validate(data)
+  Private.EnforceSubregionExists(data, "subbackground")
+end
+
+WeakAuras.RegisterRegionType("text", create, modify, default, GetProperties, validate);
 
 -- Fallback region type
 

--- a/WeakAuras/RegionTypes/Texture.lua
+++ b/WeakAuras/RegionTypes/Texture.lua
@@ -23,12 +23,7 @@ local default = {
   anchorFrameType = "SCREEN",
   xOffset = 0,
   yOffset = 0,
-  frameStrata = 1,
-  subRegions = {
-    [1] = {
-      ["type"] = "subbackground"
-    }
-  }
+  frameStrata = 1
 };
 
 WeakAuras.regionPrototype.AddAlphaToDefault(default);
@@ -243,4 +238,8 @@ local function modify(parent, region, data)
   WeakAuras.regionPrototype.modifyFinish(parent, region, data);
 end
 
-WeakAuras.RegisterRegionType("texture", create, modify, default, properties);
+local function validate(data)
+  Private.EnforceSubregionExists(data, "subbackground")
+end
+
+WeakAuras.RegisterRegionType("texture", create, modify, default, properties, validate);

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -1,6 +1,6 @@
 local AddonName, Private = ...
 
-local internalVersion = 48
+local internalVersion = 49
 
 -- Lua APIs
 local insert = table.insert


### PR DESCRIPTION
fixes #3423

I could not find a way to reproduce exact same issue with icons & aurabar, but with this group <https://wago.io/ClassicBudsUI> all the 3 texts auras had 2 subbackground.

This PR bump internalVersion and replace the 2 last migrations

For both new subregions it check previous data, add them if they are missing and remove duplicates.

Tested with <https://wago.io/ClassicBudsUI> and bugged aura from #3423, their data are correct with the migration.
