### PR TITLE
fix bad order of aurabar foreground when importing old version, #3449

### DIFF
--- a/WeakAuras/RegionTypes/AuraBar.lua
+++ b/WeakAuras/RegionTypes/AuraBar.lua
@@ -1358,6 +1358,14 @@ local function modify(parent, region, data)
 end
 
 local function validate(data)
+  -- pre-migration
+  if data.subRegions then
+    for _, subRegionData in ipairs(data.subRegions) do
+      if subRegionData.type == "aurabar_bar" then
+        subRegionData.type = "subforeground"
+      end
+    end
+  end
   Private.EnforceSubregionExists(data, "subforeground")
   Private.EnforceSubregionExists(data, "subbackground")
 end

--- a/WeakAurasTemplates/TriggerTemplates.lua
+++ b/WeakAurasTemplates/TriggerTemplates.lua
@@ -49,9 +49,10 @@ local function changes(property, regionType)
       property = regionColorProperty[regionType],
     };
   elseif property == "glow" and (regionType == "icon" or regionType == "aurabar") then
+    local subregionPos = regionType == "aurabar" and 1 or 2
     return {
       value = true,
-      property = "sub.3.glow"
+      property = "sub."..subregionPos..".glow"
     };
   elseif WeakAuras.regionTypes[regionType].default[property] == nil then
     return nil;


### PR DESCRIPTION
# Description

rename aurabar_bar subregion before trying to add subforeground