### PR TITLE
make condition events use RegisterUnitEvent when possible

### DIFF
--- a/WeakAuras/Conditions.lua
+++ b/WeakAuras/Conditions.lua
@@ -815,8 +815,11 @@ end
 function Private.UnregisterForGlobalConditions(uid)
   for event, condFuncs in pairs(dynamicConditions) do
     condFuncs[uid] = nil;
-    if next(dynamicConditions) == nil then
-      if not event:match("([^:]+):([^:]+)") then
+    if next(condFuncs) == nil then
+      local unitEvent, unit = event:match("([^:]+):([^:]+)")
+      if unitEvent and unit then
+        dynamicConditionsFrame[unit]:UnregisterEvent(unitEvent)
+      else
         dynamicConditionsFrame:UnregisterEvent(event)
       end
     end

--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -4315,7 +4315,7 @@ Private.event_prototypes = {
         conditionEvents = {
           "SPELL_UPDATE_USABLE",
           "PLAYER_TARGET_CHANGED",
-          "UNIT_POWER_FREQUENT",
+          "UNIT_POWER_FREQUENT:player"
         },
       },
       {
@@ -4330,8 +4330,8 @@ Private.event_prototypes = {
         conditionEvents = {
           "SPELL_UPDATE_USABLE",
           "PLAYER_TARGET_CHANGED",
-          "UNIT_POWER_FREQUENT",
-        }
+          "UNIT_POWER_FREQUENT:player"
+        },
       },
       {
         name = "spellInRange",
@@ -4345,7 +4345,7 @@ Private.event_prototypes = {
         conditionEvents = {
           "PLAYER_TARGET_CHANGED",
           "WA_SPELL_RANGECHECK",
-        }
+        },
       },
       {
         hidden = true,


### PR DESCRIPTION
this should fix performance issues with the cooldown trigger with "Insufficient Resources" and "Spell Usable" conditions
add support for filtering in custom checks too
does not support multi units (group, nameplate, ...)

**This will break existing custom checks conditions using ":" as separator**