### PR TITLE
Fix swing timer resets and pauses

### DIFF
--- a/WeakAuras/Types.lua
+++ b/WeakAuras/Types.lua
@@ -3448,6 +3448,10 @@ if WeakAuras.IsBCC() then
     2764, 3018, -- Shoots,
     19434, 20900, 20901, 20902, 20903, 20904, 27065, -- Aimed Shot
     20066, -- Repentance
+    11350, -- Fire Shield (Oil of Immolation)
+    50986, -- Sulfuron Slammer
+    439, 440, 441, 2024, 4042, 17534, 28495, -- Minor/Lesser/Greater/Superior/Major/Super Healing Potion
+    41619, 41620 -- Cenarion Healing Salve/Bottled Nethergon Vapor
   }
   for _, spellid in ipairs(reset_swing_spell_list) do
     Private.reset_swing_spells[spellid] = true

--- a/WeakAuras/Types.lua
+++ b/WeakAuras/Types.lua
@@ -3229,6 +3229,12 @@ Private.noreset_swing_spells = {
   [35478] = true, -- Drums of Restoration
   [34120] = true, -- Steady Shot (rank 1)
   [19434] = true, -- Aimed Shot (rank 1)
+  [1464] = true, -- Slam (rank 1)
+  [8820] = true, -- Slam (rank 2)
+  [11604] = true, -- Slam (rank 3)
+  [11605] = true, -- Slam (rank 4)
+  [25241] = true, -- Slam (rank 5)
+  [25242] = true, -- Slam (rank 6)
   --35474 Drums of Panic DO reset the swing timer, do not add
 }
 


### PR DESCRIPTION
# Description

Update lists of spells resetting and not resetting swing timer.

Previous behavior:
- Drinking a swing-resetting potion would not cause swing timer to reset.
- Starting a cast of slam would pause the swing timer.

New behavior:
- Drinking a swing-resetting potion causes swing timer to reset.
- Starting a cast of slam does not pause swing timer.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

Testing with a basic swing timer (https://wago.io/VF0rkqXwQ) and two handed sword in TBC Classic.

All basic non-zone specific potions/drinks have been tested. Leaves out Nethergon Vapor/Cenarion Healing Salve, but they should work the same.

Slam change is easily tested by starting a cast of slam mid-swing and then cancelling the slam-cast before it lands. The swing timer should be unaffected by this.

## Checklist
<!-- These can be checked off after the pull request is submitted, in case you want discussion before they are completely ready -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

<!-- Is there any additional work that needs to be done? If so, add it to the above list -->
