### PR TITLE
Smallfix

### DIFF
--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -2153,9 +2153,18 @@ Private.event_prototypes = {
         end
         local standing
         if tonumber(standingId) then
-           standing = getglobal("FACTION_STANDING_LABEL"..standingId)
+           standing = GetText("FACTION_STANDING_LABEL"..standingId, UnitSex("player"))
         end
       ]=]
+      if WeakAuras.IsRetail() then
+        ret = ret .. [=[
+          local _, _, _, _, _, _, friendTextLevel = GetFriendshipReputation(factionID)
+          if friendTextLevel then
+            standing = friendTextLevel
+          end
+          local friendshipRank, friendshipMaxRank = GetFriendshipReputationRanks(factionID)
+        ]=]
+      end
       return ret:format(trigger.factionID or 0, trigger.use_watched and "true" or "false")
     end,
     statesParameter = "one",
@@ -2225,7 +2234,7 @@ Private.event_prototypes = {
         values = function()
           local ret = {}
           for i = 0, 8 do
-            ret[i] = getglobal("FACTION_STANDING_LABEL"..i)
+            ret[i] = GetText("FACTION_STANDING_LABEL"..i, UnitSex("player"))
           end
           return ret
         end,
@@ -2241,6 +2250,28 @@ Private.event_prototypes = {
         store = "true",
         hidden = "true",
         test = "true"
+      },
+      {
+        name = "friendshipRank",
+        display = L["Friendship Rank"],
+        type = "number",
+        init = "friendshipRank",
+        store = "true",
+        test = "true",
+        conditionType = "number",
+        enable = WeakAuras.IsRetail(),
+        hidden = not WeakAuras.IsRetail()
+      },
+      {
+        name = "friendshipMaxRank",
+        display = L["Friendship Max Rank"],
+        type = "number",
+        init = "friendshipMaxRank",
+        store = "true",
+        test = "true",
+        conditionType = "number",
+        enable = WeakAuras.IsRetail(),
+        hidden = not WeakAuras.IsRetail()
       },
       {
         name = "progressType",

--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -8145,7 +8145,7 @@ Private.event_prototypes = {
         name = "hastepercent",
         display = L["Haste (%)"],
         type = "number",
-        init = WeakAuras.IsClassic() and "GetHaste()" or "GetCombatRatingBonus(CR_HASTE_SPELL)",
+        init = WeakAuras.IsBCC() and "GetCombatRatingBonus(CR_HASTE_SPELL)" or "GetHaste()",
         store = true,
         conditionType = "number"
       },

--- a/WeakAuras/Types.lua
+++ b/WeakAuras/Types.lua
@@ -3424,8 +3424,6 @@ if WeakAuras.IsClassic() then
   for i, spellid in ipairs(reset_swing_spell_list) do
     Private.reset_swing_spells[spellid] = true
   end
-
-  Private.glow_types.ACShine = nil
 end
 
 if WeakAuras.IsBCC() then
@@ -3465,6 +3463,4 @@ if WeakAuras.IsBCC() then
   for _, spellid in ipairs(reset_ranged_swing_spell_list) do
     Private.reset_ranged_swing_spells[spellid] = true
   end
-
-  Private.glow_types.ACShine = nil
 end

--- a/WeakAurasOptions/OptionsFrames/ImportExport.lua
+++ b/WeakAurasOptions/OptionsFrames/ImportExport.lua
@@ -56,7 +56,7 @@ local function ConstructImportExport(frame)
         end
         input.editBox:SetMaxBytes(nil);
         input.editBox:SetScript("OnEscapePressed", function() group:Close(); end);
-        input.editBox:SetScript("OnChar", function() input:SetText(displayStr); input.editBox:HighlightText(); end);
+        input.editBox:SetScript("OnTextChanged", function() input:SetText(displayStr); input.editBox:HighlightText(); end);
         input.editBox:SetScript("OnMouseUp", function() input.editBox:HighlightText(); end);
         input:SetLabel(id.." - "..#displayStr);
         input.button:Hide();


### PR DESCRIPTION
## Faction Reputation

add 2 friendship filters in trigger, condition and text replacement
![image](https://user-images.githubusercontent.com/189656/154814575-39b6717a-a55c-41e6-8b00-4aab2fd48736.png)
![image](https://user-images.githubusercontent.com/189656/154814586-4559ec90-302c-4bf2-8d15-f2bf8cfcfb62.png)
![image](https://user-images.githubusercontent.com/189656/154814600-ba5a4a53-2f57-43b0-abcf-fa79932d0182.png)

text replacement for %standing will use friendship when it's not nil

updated the way we get standing text for gendered labels

Fixes #3494

## Character Stats

Revert hastepercent change for retail

