### PR TITLE
Add slam rank 5 to spells resetting swing

### DIFF
--- a/WeakAuras/Types.lua
+++ b/WeakAuras/Types.lua
@@ -3433,7 +3433,7 @@ if WeakAuras.IsBCC() then
   Private.actual_unit_types_cast.boss = nil
 
   local reset_swing_spell_list = {
-    1464, 8820, 11604, 11605, 25242, -- Slam
+    1464, 8820, 11604, 11605, 25241, 25242, -- Slam
     78, 284, 285, 1608, 11564, 11565, 11566, 11567, 25286, 29707, 30324, -- Heroic Strike
     845, 7369, 11608, 11609, 20569, 25231, -- Cleave
     2973, 14260, 14261, 14262, 14263, 14264, 14265, 14266, 27014, -- Raptor Strike


### PR DESCRIPTION
# Description

Add the missing slam rank 5 to the list of spells that reset swing in BCC.

Players using rank 5 slam would not have their swing timer reset when slam is cast, because the list of slam IDs for BCC is missing slam rank 5.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

I have advised people to fix Weakauras2 this way with success, so it is indirectly tested. 

You can verify the spell ID here:
https://tbc.wowhead.com/spell=25241/slam

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
