### PR TITLE
fix parry logic in swing timer

### DIFF
--- a/WeakAuras/GenericTrigger.lua
+++ b/WeakAuras/GenericTrigger.lua
@@ -1616,7 +1616,7 @@ do
       end
     elseif (destGUID == selfGUID and (... == "PARRY" or select(4, ...) == "PARRY")) then
       if (lastSwingMain) then
-        local timeLeft = lastSwingMain + swingDurationMain - GetTime() - (mainSwingOffset and mainSwingOffset or 0);
+        local timeLeft = lastSwingMain + swingDurationMain - GetTime() - (mainSwingOffset or 0);
         if (timeLeft > 0.2 * swingDurationMain) then
           local offset = 0.4 * swingDurationMain
           if (timeLeft - offset < 0.2 * swingDurationMain) then

--- a/WeakAuras/GenericTrigger.lua
+++ b/WeakAuras/GenericTrigger.lua
@@ -1624,7 +1624,7 @@ do
           end
           timer:CancelTimer(mainTimer);
           mainTimer = timer:ScheduleTimerFixed(swingEnd, timeLeft - offset, "main");
-          mainSwingOffset = mainSwingOffset and mainSwingOffset + offset or offset
+          mainSwingOffset = (mainSwingOffset or 0) + offset
           swingTriggerUpdate()
         end
       end

--- a/WeakAuras/GenericTrigger.lua
+++ b/WeakAuras/GenericTrigger.lua
@@ -1616,16 +1616,15 @@ do
       end
     elseif (destGUID == selfGUID and (... == "PARRY" or select(4, ...) == "PARRY")) then
       if (lastSwingMain) then
-        local timeLeft = lastSwingMain + swingDurationMain - GetTime();
-        if (timeLeft > 0.6 * swingDurationMain) then
+        local timeLeft = lastSwingMain + swingDurationMain - GetTime() - (mainSwingOffset and mainSwingOffset or 0);
+        if (timeLeft > 0.2 * swingDurationMain) then
+          local offset = 0.4 * swingDurationMain
+          if (timeLeft - offset < 0.2 * swingDurationMain) then
+            offset = timeLeft - 0.2 * swingDurationMain
+          end
           timer:CancelTimer(mainTimer);
-          mainTimer = timer:ScheduleTimerFixed(swingEnd, timeLeft - 0.4 * swingDurationMain, "main");
-          mainSwingOffset = 0.4 * swingDurationMain
-          swingTriggerUpdate()
-        elseif (timeLeft > 0.2 * swingDurationMain) then
-          timer:CancelTimer(mainTimer);
-          mainTimer = timer:ScheduleTimerFixed(swingEnd, timeLeft - 0.2 * swingDurationMain, "main");
-          mainSwingOffset = 0.2 * swingDurationMain
+          mainTimer = timer:ScheduleTimerFixed(swingEnd, timeLeft - offset, "main");
+          mainSwingOffset = mainSwingOffset and mainSwingOffset + offset or offset
           swingTriggerUpdate()
         end
       end


### PR DESCRIPTION
# Description

Provides 2 improvements to swing timer when an attack is parried.

1. Account for multiple parries during the same swing timer.
2. Correct the amount the swing timer is progressed after a parry.

I noticed that any time an attack is parried while my swing timer is sitting between 20 and 60 percent, my next auto attack would occur before the swing timer completes. This happens because the current code only progresses the swing timer by an additional 20% when it should a varying amount. The correct logic is as follows:

_When a swing timer has more than 20% time remaining, a parried attack will progress the swing timer by an additional 40% or such an amount so that the swing timer has 20% time remaining, whichever is less._

I also noticed that the `timeLeft` variable was sometimes incorrect because it was not accounting for `mainSwingOffset`, which would be a non-nil value if there was a previous parry during the same swing timer. This caused the swing timer to be incorrect when parrying multiple attacks.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

### Before Changes
- [x] Test A: Parry 2 or more attacks during the same swing timer. The following auto attack will fire **_before_** the swing timer completes.
- [x] Test B: Parry 1 attack while swing timer is sitting between 20 and 60 percent. The following auto attack will fire **_before_** the swing timer completes.

### After Changes
- [x] Test A: Parry 2 or more attacks during the same swing timer. The following auto attack will fire **_as_** the swing timer completes.
- [x] Test B: Parry 1 attack while swing timer is sitting between 20% and 60%. The following auto attack will fire **_as_** the swing timer completes.

## Checklist
<!-- These can be checked off after the pull request is submitted, in case you want discussion before they are completely ready -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] ~~I have made corresponding changes to the documentation~~
- [x] My changes generate no new warnings

<!-- Is there any additional work that needs to be done? If so, add it to the above list -->
