### PR TITLE
Smallfix

### DIFF
--- a/WeakAuras/RegionTypes/RegionPrototype.lua
+++ b/WeakAuras/RegionTypes/RegionPrototype.lua
@@ -921,7 +921,7 @@ end
 
 function WeakAuras.SetTextureOrAtlas(texture, path, wrapModeH, wrapModeV)
   if type(path) == "string" and GetAtlasInfo(path) then
-    texture:SetAtlas(path);
+    return texture:SetAtlas(path);
   else
     local needToClear = true
     if (texture.wrapModeH and texture.wrapModeH ~= wrapModeH) or (texture.wrapModeV and texture.wrapModeV ~= wrapModeV) then
@@ -932,7 +932,7 @@ function WeakAuras.SetTextureOrAtlas(texture, path, wrapModeH, wrapModeV)
     if needToClear then
       texture:SetTexture(nil)
     end
-    texture:SetTexture(path, wrapModeH, wrapModeV);
+    return texture:SetTexture(path, wrapModeH, wrapModeV);
   end
 end
 

--- a/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasDisplayButton.lua
+++ b/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasDisplayButton.lua
@@ -503,7 +503,11 @@ local methods = {
           if (OptionsPrivate.IsDisplayPicked(self.data.id)) then
             OptionsPrivate.ClearPicks();
           else
-            WeakAuras.PickDisplay(self.data.id);
+            if self.data.controlledChildren then
+              WeakAuras.PickDisplay(self.data.id, "group")
+            else
+              WeakAuras.PickDisplay(self.data.id);
+            end
           end
           self:ReloadTooltip();
         end

--- a/WeakAurasOptions/RegionOptions/DynamicGroup.lua
+++ b/WeakAurasOptions/RegionOptions/DynamicGroup.lua
@@ -522,7 +522,7 @@ local function modifyThumbnail(parent, frame, data)
       icon:SetAllPoints(frame)
       frame.icon = icon
     end
-    local success = frame.icon:SetTexture(path or data.groupIcon) and (path or data.groupIcon)
+    local success = WeakAuras.SetTextureOrAtlas(frame.icon, path or data.groupIcon) and (path or data.groupIcon)
     if success then
       if frame.defaultIcon then
         frame.defaultIcon:Hide()

--- a/WeakAurasOptions/RegionOptions/Group.lua
+++ b/WeakAurasOptions/RegionOptions/Group.lua
@@ -669,7 +669,7 @@ end
 local function modifyThumbnail(parent, frame, data)
   function frame:SetIcon(path)
     if data.groupIcon then
-      local success = frame.icon:SetTexture(data.groupIcon)
+      local success = WeakAuras.SetTextureOrAtlas(frame.icon, data.groupIcon)
       if success then
         if frame.defaultIcon then
           frame.defaultIcon:Hide()


### PR DESCRIPTION
# Description

Fixes #3621 and #3609


How GetSpellLossOfControlCooldown is handled by ActionButton:

https://github.com/Gethe/wow-ui-source/blob/live/Interface/FrameXML/ActionButton.lua#L543
https://github.com/Gethe/wow-ui-source/blob/live/Interface/FrameXML/ActionButton.lua#L792

/!\ GetSpellLossOfControlCooldown doesn't work on both classic & bcc