### PR TITLE
"Range Check" extended to handle multiple units

### DIFF
--- a/WeakAuras/GenericTrigger.lua
+++ b/WeakAuras/GenericTrigger.lua
@@ -102,6 +102,78 @@ function WeakAuras.UnitExistsFixed(unit, smart)
   return UnitExists(unit) or UnitGUID(unit)
 end
 
+-- similiar to GetAllUnits in BuffTrigger2
+-- this one does not support pets
+-- and has no flag to also return non existing units
+-- maybe this can be combined in the future
+function WeakAuras.GetAllUnits(unit)
+  if unit == "raid" or (unit == "group" and IsInRaid()) then
+    local i = 1
+    local max = GetNumGroupMembers()
+    return function()
+      if i <= max then
+        local ret = WeakAuras.raidUnits[i]
+        i = i + 1
+        return ret
+      end
+      i = 1
+    end
+  elseif unit == "party" or unit == "group" then
+    local i = 0
+    local max = GetNumSubgroupMembers()
+    return function()
+      if i == 0 then
+        i = 1
+        return "player"
+      else
+        if i <= max then
+          local ret = WeakAuras.partyUnits[i]
+          i = i + 1
+          return ret
+        end
+      end
+      i = 0
+    end
+  elseif unit == "boss" or unit == "arena" or unit == "nameplate" then
+    local i = 1
+    local max
+    if unit == "boss" then
+      max = 10
+    elseif unit == "arena" then
+      max = 5
+    elseif unit == "nameplate" then
+      max = 40
+    else
+      return function() end
+    end
+    return function()
+      local ret = unit .. i
+      while not WeakAuras.UnitExistsFixed(ret) do
+        i = i + 1
+        if i > max then
+          i = 1
+          return nil
+        end
+        ret = unit .. i
+      end
+      i = i + 1
+      if i > max then
+        i = 1
+        return nil
+      end
+      return ret
+    end
+  else
+    local toggle = false
+    return function()
+      toggle = not toggle
+      if toggle then
+        return unit
+      end
+    end
+  end
+end
+
 function WeakAuras.split(input)
   input = input or "";
   local ret = {};

--- a/WeakAuras/Types.lua
+++ b/WeakAuras/Types.lua
@@ -78,6 +78,11 @@ Private.group_hybrid_sort_types = {
   descending = L["Descending"]
 }
 
+Private.range_sort_types = {
+  ascending = L["Closest unit first"],
+  descending = L["Farthest unit first"]
+}
+
 if WeakAuras.IsClassic() then
   Private.time_format_types = {
     [0] = L["WeakAuras Built-In (63:42 | 3:07 | 10 | 2.4)"],

--- a/WeakAuras/Types.lua
+++ b/WeakAuras/Types.lua
@@ -870,6 +870,12 @@ Private.threat_unit_types = {
 Private.unit_types_range_check = {
   target = L["Target"],
   focus = L["Focus"],
+  group = L["Smart Group"],
+  raid = L["Raid"],
+  party = L["Party"],
+  boss = L["Boss"],
+  arena = L["Arena"],
+  nameplate = L["Nameplate"],
   pet = L["Pet"],
   member = L["Specific Unit"]
 }
@@ -3482,6 +3488,8 @@ if WeakAuras.IsClassic() then
   Private.actual_unit_types_cast.arena = nil
   Private.actual_unit_types_cast.focus = nil
   Private.unit_types_range_check.focus = nil
+  Private.unit_types_range_check.boss = nil
+  Private.unit_types_range_check.arena = nil
   Private.threat_unit_types.focus = nil
   Private.item_slot_types[0] = AMMOSLOT
   Private.item_slot_types[18] = RANGEDSLOT


### PR DESCRIPTION
# Description

This change adds the option to select a smart group, raid, party, boss, arena or nameplates in the "Range Check" trigger.

My motivation for this change was, that I wanted to create an aura which tells me how many party or raid members are within a certain range so i don't have to guess.
Also I found it odd that the new condition for range checks allows for multi unit checks but the trigger does not.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested

I did some smoke testing with nameplates where I tested all options and the glow for external elements (nameplates).
I didn't have time for testing with other unit types yet.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Should one change the way the "Distance" condition-option for this trigger works? This could lead to breaking changes for existing auras.
