### PR TITLE
Make right click open group tab by defaut

### DIFF
--- a/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasDisplayButton.lua
+++ b/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasDisplayButton.lua
@@ -496,7 +496,11 @@ local methods = {
             UpdateClipboardMenuEntry(self.data);
             EasyMenu(self.menu, WeakAuras_DropDownMenu, self.frame, 0, 0, "MENU");
             if not(OptionsPrivate.IsDisplayPicked(self.data.id)) then
-              WeakAuras.PickDisplay(self.data.id);
+              if self.data.controlledChildren then
+                WeakAuras.PickDisplay(self.data.id, "group")
+              else
+                WeakAuras.PickDisplay(self.data.id);
+              end
             end
           end
         else


### PR DESCRIPTION
# Description

Bring the change of 4d8a85e to right click. Currently right clicking on big group, freeze the game and trigger a script ran too long error. Still a quick solution for the problem of editing options of 1000+ auras, in the long term, I think the user should be asked if they really want to edit more than 1000 auras.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested

- [x] Right clicking on a group
- [x] Right clicking on a non group

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
