### PR TITLE
Fixed issue with "Array"-type options in aura groups

### DIFF
--- a/WeakAurasOptions/AuthorOptions.lua
+++ b/WeakAurasOptions/AuthorOptions.lua
@@ -1996,7 +1996,7 @@ local function addUserModeOption(options, args, data, order, prefix, i)
             while i <= #values or i <= #childValues do
               if firstChild then
                 values[i] = childValues[i][nameSource] or conflictBlue .. L["Entry %i"]:format(i)
-              elseif childValues[i] ~= values[i] then
+              elseif childValues[i][nameSource] ~= values[i] then
                 values[i] = conflictBlue .. L["Entry %i"]:format(i)
               end
               i = i + 1
@@ -2413,7 +2413,7 @@ local function mergeOptions(mergedOptions, data, options, config, prepath, paren
               -- check if nextToMerge.nameSource was merged in the same spot as mergedOption.nameSource
               local subMergedOption = mergedOption.subOptions[mergedOption.nameSource]
               local optionData = subMergedOption.references[data.id]
-              if not optionData or optionData.optionIndex ~= nextToMerge.nameSource then
+              if not optionData or optionData.index ~= nextToMerge.nameSource then
                 -- either an option was not merged at the name source's index, or the wrong option was.
                 -- in both cases, the name source is conflicted. Fallback to "Entry #" as entry names
                 mergedOption.nameSource = nil


### PR DESCRIPTION
# Description

Aura-Groups containing an "Array"-type option group were not editable properly from the Aura-Groups "Custom Options" section. To recreate do the following:
- Create a new group
- Create 2 or more children
- Navigate into the groups (top-level aura) `Custom Options`-Section in Author-Mode
- Add a `Option Group` with the `Group Type` of `Array`
- Create at least one sub option that can be used as the `Entry Name Source` (for example `String`)
- Select some `Entry Name Source` for the `Option Group`

The following issues occur:
- In Author-Mode the `Entry Name Source` will always remain on `Entry Order` despite all auras within the group being updated properly
- In User-Mode all entries will be named as `Entry 1`, `Entry 2` etc. and not by the selected `Entry Name Source` as it is when opening the options within a child

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

- [x] Create, edit and delete multiple entries from the Aura-Group
  - All changes were properly propagated to all childs
- [x] Create differing entries within the childs
  - All entries that are present in all childs are editable from the Aura-Group
  - Mismatching entries fall back to the `Entry %i` naming scheme and are still editable properly from within the childs

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Double-check the changes to ensure it will not break functionality for other cases (someone who is more familiar with the code)
  - I did my best to test the cases I could imagine being affected, but it took my hours to understand the code good enough to figure out the fix, so a pair of eyes familiar with the code certainly would not hurt.
