### PR TITLE
merge loaded/unload, add loaded filter button and deep data search

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -51,6 +51,8 @@ globals = {
 	"WeakAurasSaved",
 	"WeakAurasTimers",
 	"WeakAurasArchive",
+	"WeakAurasSearchMenuFrame",
+	"WeakAurasFilterInput",
 
 	-- Third Party Addons/Libs
 	"BigWigs",

--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -134,6 +134,7 @@ end
 
 local encounter_list = ""
 local zoneId_list = ""
+Private.encounter_table = {}
 function Private.InitializeEncounterAndZoneLists()
   if encounter_list ~= "" then
     return
@@ -241,6 +242,7 @@ function Private.InitializeEncounterAndZoneLists()
         }
       }
     }
+    Private.encounter_table = classic_raids
     for _, raid in ipairs(classic_raids) do
       encounter_list = ("%s|cffffd200%s|r\n"):format(encounter_list, raid[1])
       for _, boss in ipairs(raid[2]) do
@@ -346,6 +348,7 @@ function Private.InitializeEncounterAndZoneLists()
         }
       },
     }
+    Private.encounter_table = bcc_raids
     for _, raid in ipairs(bcc_raids) do
       encounter_list = ("%s|cffffd200%s|r\n"):format(encounter_list, raid[1])
       for _, boss in ipairs(raid[2]) do
@@ -355,13 +358,13 @@ function Private.InitializeEncounterAndZoneLists()
     end
   else
     EJ_SelectTier(EJ_GetCurrentTier())
-
+    Private.zoneId_table = {}
     for _, inRaid in ipairs({false, true}) do
       local instance_index = 1
       local instance_id = EJ_GetInstanceByIndex(instance_index, inRaid)
       local title = inRaid and L["Raids"] or L["Dungeons"]
       zoneId_list = ("%s|cffffd200%s|r\n"):format(zoneId_list, title)
-
+      tinsert(Private.zoneId_table, {title, {}})
       while instance_id do
         EJ_SelectInstance(instance_id)
         local instance_name, _, _, _, _, _, dungeonAreaMapID = EJ_GetInstanceInfo(instance_id)
@@ -373,24 +376,31 @@ function Private.InitializeEncounterAndZoneLists()
           local mapGroupId = C_Map.GetMapGroupID(dungeonAreaMapID)
           if mapGroupId then -- If there's a group id, only list that one
             zoneId_list = ("%s%s: g%d\n"):format(zoneId_list, instance_name, mapGroupId)
+            tinsert(Private.zoneId_table[#Private.zoneId_table][2], {instance_name, "g"..mapGroupId})
           else
             zoneId_list = ("%s%s: %d\n"):format(zoneId_list, instance_name, dungeonAreaMapID)
+            tinsert(Private.zoneId_table[#Private.zoneId_table][2], {instance_name, dungeonAreaMapID})
           end
         end
 
         -- Encounter ids
         if inRaid then
+          local encounter_table = {}
           while boss do
             if encounter_id then
               if instance_name then
                 encounter_list = ("%s|cffffd200%s|r\n"):format(encounter_list, instance_name)
+                tinsert(encounter_table, instance_name)
+                tinsert(encounter_table, {})
                 instance_name = nil -- Only add it once per section
               end
               encounter_list = ("%s%s: %d\n"):format(encounter_list, boss, encounter_id)
+              tinsert(encounter_table[2], {boss, encounter_id})
             end
             ej_index = ej_index + 1
             boss, _, _, _, _, _, encounter_id = EJ_GetEncounterInfoByIndex(ej_index, instance_id)
           end
+          tinsert(Private.encounter_table, encounter_table)
           encounter_list = encounter_list .. "\n"
         end
         instance_index = instance_index + 1
@@ -425,7 +435,7 @@ local function get_zoneId_list()
                                          L["Current Zone Group\n"], currentmap_name, mapGroupId)
 
     -- if map is in a group, its real name is (or should be?) found in GetMapGroupMembersInfo
-    for k, map in ipairs(C_Map.GetMapGroupMembersInfo(mapGroupId)) do
+    for _, map in ipairs(C_Map.GetMapGroupMembersInfo(mapGroupId)) do
       if map.mapID and map.mapID == currentmap_id and map.name then
         currentmap_name = map.name
         break

--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -1328,6 +1328,7 @@ Private.load_prototype = {
       display = L["Group Type"],
       type = "multiselect",
       width = WeakAuras.normalWidth,
+      optional = true,
       init = "arg",
       values = "group_types",
       events = {"GROUP_ROSTER_UPDATE"}
@@ -1415,6 +1416,7 @@ Private.load_prototype = {
         end
       end,
       init = "arg",
+      optional = true,
       enable = WeakAuras.IsRetail(),
       hidden = not WeakAuras.IsRetail(),
       events = {"PLAYER_TALENT_UPDATE"}
@@ -1440,6 +1442,7 @@ Private.load_prototype = {
         -- Check for multi select!
         return load.talent_extraOption == 2 or load.talent_extraOption == 3
       end,
+      optional = true,
       extraOption = {
         display = "",
         values = function()
@@ -1460,6 +1463,7 @@ Private.load_prototype = {
       inverse = function(load)
         return load.talent2_extraOption == 2 or load.talent2_extraOption == 3
       end,
+      optional = true,
       extraOption = {
         display = "",
         values = function()
@@ -1480,6 +1484,7 @@ Private.load_prototype = {
       inverse = function(load)
         return load.talent3_extraOption == 2 or load.talent3_extraOption == 3
       end,
+      optional = true,
       extraOption = {
         display = "",
         values = function()
@@ -1546,6 +1551,7 @@ Private.load_prototype = {
         end
       end,
       test = "WeakAuras.CheckPvpTalentByIndex(%d)",
+      optional = true,
       enable = WeakAuras.IsRetail(),
       hidden = not WeakAuras.IsRetail(),
       events = {"PLAYER_PVP_TALENT_UPDATE"}
@@ -1556,6 +1562,7 @@ Private.load_prototype = {
       type = "spell",
       test = "WeakAuras.IsSpellKnownForLoad(%s, %s)",
       events = {"SPELLS_CHANGED"},
+      optional = true,
       showExactOption = true
     },
     {
@@ -1564,6 +1571,7 @@ Private.load_prototype = {
       type = "multiselect",
       values = "covenant_types",
       init = "arg",
+      optional = true,
       enable = WeakAuras.IsRetail(),
       hidden = not WeakAuras.IsRetail(),
       events = {"COVENANT_CHOSEN"}
@@ -1587,13 +1595,15 @@ Private.load_prototype = {
       display = L["Player Level"],
       type = "number",
       init = "arg",
-      events = {"PLAYER_LEVEL_UP"}
+      events = {"PLAYER_LEVEL_UP"},
+      optional = true,
     },
     {
       name = "effectiveLevel",
       display = L["Player Effective Level"],
       type = "number",
       init = "arg",
+      optional = true,
       desc = L["The effective level differs from the level in e.g. Time Walking dungeons."],
       enable = WeakAuras.IsRetail(),
       hidden = not WeakAuras.IsRetail(),
@@ -1604,6 +1614,7 @@ Private.load_prototype = {
       display = L["Zone Name"],
       type = "string",
       init = "arg",
+      optional = true,
       preamble = "local checker = WeakAuras.ParseStringCheck(%q)",
       test = "checker:Check(zone)",
       events = {"ZONE_CHANGED", "ZONE_CHANGED_INDOORS", "ZONE_CHANGED_NEW_AREA", "VEHICLE_UPDATE"},
@@ -1613,6 +1624,7 @@ Private.load_prototype = {
       name = "zoneId",
       hidden = true,
       init = "arg",
+      optional = true,
       test = "true",
       enable = not WeakAuras.IsClassic(),
     },
@@ -1620,6 +1632,7 @@ Private.load_prototype = {
       name = "zonegroupId",
       hidden = true,
       init = "arg",
+      optional = true,
       test = "true",
       enable = not WeakAuras.IsClassic(),
     },
@@ -1630,6 +1643,7 @@ Private.load_prototype = {
       enable = not WeakAuras.IsClassic(),
       hidden = WeakAuras.IsClassic(),
       events = {"ZONE_CHANGED", "ZONE_CHANGED_INDOORS", "ZONE_CHANGED_NEW_AREA", "VEHICLE_UPDATE"},
+      optional = true,
       desc = get_zoneId_list,
       preamble = "local zoneChecker = WeakAuras.ParseZoneCheck(%q)",
       test = "zoneChecker:Check(zoneId, zonegroupId)"
@@ -1639,6 +1653,7 @@ Private.load_prototype = {
       display = L["Encounter ID(s)"],
       type = "string",
       init = "arg",
+      optional = true,
       desc = get_encounters_list,
       test = "WeakAuras.CheckNumericIds(%q, encounterid)",
       events = {"ENCOUNTER_START", "ENCOUNTER_END"}
@@ -1649,6 +1664,7 @@ Private.load_prototype = {
       type = "multiselect",
       values = "instance_types",
       init = "arg",
+      optional = true,
       control = "WeakAurasSortedDropdown",
       events = {"ZONE_CHANGED", "ZONE_CHANGED_INDOORS", "ZONE_CHANGED_NEW_AREA"}
     },
@@ -1658,6 +1674,7 @@ Private.load_prototype = {
       type = "multiselect",
       values = "difficulty_types",
       init = "arg",
+      optional = true,
       enable = not WeakAuras.IsClassic(),
       hidden = WeakAuras.IsClassic(),
       events = {"PLAYER_DIFFICULTY_CHANGED", "ZONE_CHANGED", "ZONE_CHANGED_INDOORS", "ZONE_CHANGED_NEW_AREA"}
@@ -1668,6 +1685,7 @@ Private.load_prototype = {
       type = "multiselect",
       values = "instance_difficulty_types",
       init = "arg",
+      optional = true,
       control = "WeakAurasSortedDropdown",
       events = {"PLAYER_DIFFICULTY_CHANGED", "ZONE_CHANGED", "ZONE_CHANGED_INDOORS", "ZONE_CHANGED_NEW_AREA"},
     },
@@ -1677,6 +1695,7 @@ Private.load_prototype = {
       type = "multiselect",
       values = "role_types",
       init = "arg",
+      optional = true,
       enable = WeakAuras.IsRetail(),
       hidden = not WeakAuras.IsRetail(),
       events = {"PLAYER_ROLES_ASSIGNED", "PLAYER_TALENT_UPDATE"}
@@ -1687,6 +1706,7 @@ Private.load_prototype = {
       type = "multiselect",
       values = "raid_role_types",
       init = "arg",
+      optional = true,
       enable = WeakAuras.IsClassic() or WeakAuras.IsBCC(),
       hidden = WeakAuras.IsRetail(),
       events = {"PLAYER_ROLES_ASSIGNED"}
@@ -1697,6 +1717,7 @@ Private.load_prototype = {
       type = "multiselect",
       values = "mythic_plus_affixes",
       init = "arg",
+      optional = true,
       test = "WeakAuras.CheckMPlusAffixIds(%d, affixes)",
       enable = WeakAuras.IsRetail(),
       hidden = not WeakAuras.IsRetail(),
@@ -1706,6 +1727,7 @@ Private.load_prototype = {
       name = "itemequiped",
       display = L["Item Equipped"],
       type = "item",
+      optional = true,
       test = "IsEquippedItem(GetItemInfo(%s))",
       events = { "UNIT_INVENTORY_CHANGED", "PLAYER_EQUIPMENT_CHANGED"}
     },
@@ -1713,6 +1735,7 @@ Private.load_prototype = {
       name = "itemtypeequipped",
       display = WeakAuras.newFeatureString .. L["Item Type Equipped"],
       type = "multiselect",
+      optional = true,
       test = "IsEquippedItemType(WeakAuras.GetItemSubClassInfo(%s))",
       events = { "UNIT_INVENTORY_CHANGED", "PLAYER_EQUIPMENT_CHANGED"},
       values = "item_weapon_types"
@@ -1721,6 +1744,7 @@ Private.load_prototype = {
       name = "item_bonusid_equipped",
       display =  WeakAuras.newFeatureString .. L["Item Bonus Id Equipped"],
       type = "string",
+      optional = true,
       test = "WeakAuras.CheckForItemBonusId(%q)",
       events = { "UNIT_INVENTORY_CHANGED", "PLAYER_EQUIPMENT_CHANGED"},
       desc = function()
@@ -1732,6 +1756,7 @@ Private.load_prototype = {
       name = "not_item_bonusid_equipped",
       display =  WeakAuras.newFeatureString .. L["|cFFFF0000Not|r Item Bonus Id Equipped"],
       type = "string",
+      optional = true,
       test = "not WeakAuras.CheckForItemBonusId(%q)",
       events = { "UNIT_INVENTORY_CHANGED", "PLAYER_EQUIPMENT_CHANGED"},
       desc = function()

--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -131,10 +131,6 @@ function WeakAuras.SpellSchool(school)
   return Private.combatlog_spell_school_types[school] or ""
 end
 
-function WeakAuras.TestSchool(spellSchool, test)
-  print(spellSchool, test, type(spellSchool), type(test))
-  return spellSchool == test
-end
 
 local encounter_list = ""
 local zoneId_list = ""
@@ -248,9 +244,7 @@ function Private.InitializeEncounterAndZoneLists()
     for _, raid in ipairs(classic_raids) do
       encounter_list = ("%s|cffffd200%s|r\n"):format(encounter_list, raid[1])
       for _, boss in ipairs(raid[2]) do
-        for _, boss in ipairs(raid[2]) do
-          encounter_list = ("%s%s: %d\n"):format(encounter_list, boss[1], boss[2])
-        end
+        encounter_list = ("%s%s: %d\n"):format(encounter_list, boss[1], boss[2])
       end
       encounter_list = encounter_list .. "\n"
     end

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -5335,14 +5335,16 @@ function WeakAuras.ParseZoneCheck(input)
 
   local start = input:find('%d', 1)
   local last = input:find('%D', start)
-  while (last) do
+  while (start and last) do
     matcher:AddId(input, start, last - 1)
     start = input:find('%d', last + 1)
     last = input:find('%D', start)
   end
 
   last = #input
-  matcher:AddId(input, start, last)
+  if start and last then
+    matcher:AddId(input, start, last)
+  end
   return matcher
 end
 

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -565,7 +565,7 @@ local function ConstructFunction(prototype, trigger, skipOptional)
   else
     init = "";
   end
-  for index, arg in pairs(prototype.args) do
+  for _, arg in pairs(prototype.args) do
     local enable = arg.type ~= "collpase";
     if(type(arg.enable) == "function") then
       enable = arg.enable(trigger);
@@ -2721,7 +2721,7 @@ local function pAdd(data, simpleChange)
       end
 
       local loadFuncStr, events = ConstructFunction(load_prototype, data.load);
-      for event, eventData in pairs(loadEvents) do
+      for _, eventData in pairs(loadEvents) do
         eventData[id] = nil
       end
       for event in pairs(events) do

--- a/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasDisplayButton.lua
+++ b/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasDisplayButton.lua
@@ -1493,8 +1493,7 @@ local methods = {
       local parentButton = WeakAuras.GetDisplayButton(self.data.parent)
       parentButton:RecheckVisibility()
     else
-      WeakAuras.OptionsFrame().loadedButton:RecheckVisibility()
-      WeakAuras.OptionsFrame().unloadedButton:RecheckVisibility()
+      WeakAuras.OptionsFrame().allAurasButton:RecheckVisibility()
     end
   end,
   ["RecheckVisibility"] = function(self)

--- a/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasDisplayButton.lua
+++ b/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasDisplayButton.lua
@@ -915,13 +915,11 @@ local methods = {
       func = function() WeakAuras_DropDownMenu:Hide() end
     });
     if(self.data.controlledChildren) then
-      self.loaded:Hide();
       self.expand:Show();
       self.callbacks.UpdateExpandButton();
       self:SetOnExpandCollapse(function() OptionsPrivate.SortDisplayButtons(nil, true) end);
     else
       self:SetViewRegion(WeakAuras.regions[self.data.id].region);
-      self.loaded:Show();
       self.expand:Hide();
     end
     self.group:Show();
@@ -1134,7 +1132,6 @@ local methods = {
     self.frame:SetScript("OnClick", nil)
     self.view:Hide()
     self.expand:Hide()
-    self.loaded:Hide()
     Hide_Tooltip()
     if picked then
       self.frame:EnableKeyboard(true)
@@ -1229,8 +1226,6 @@ local methods = {
     self.view:Show()
     if self.data.controlledChildren then
       self.expand:Show()
-    else
-      self.loaded:Show()
     end
     self:Enable()
 
@@ -1417,16 +1412,6 @@ local methods = {
   ["GetGroupOrder"] = function(self)
     return self.frame.dgrouporder;
   end,
-  ["DisableLoaded"] = function(self)
-    self.loaded.title = L["Not Loaded"];
-    self.loaded.desc = L["This display is not currently loaded"];
-    self.loaded:SetNormalTexture("Interface\\BUTTONS\\UI-GuildButton-OfficerNote-Disabled.blp");
-  end,
-  ["EnableLoaded"] = function(self)
-    self.loaded.title = L["Loaded"];
-    self.loaded.desc = L["This display is currently loaded"];
-    self.loaded:SetNormalTexture("Interface\\BUTTONS\\UI-GuildButton-OfficerNote-Up.blp");
-  end,
   ["Pick"] = function(self)
     self.frame:LockHighlight();
     self:PriorityShow(1);
@@ -1543,7 +1528,6 @@ local methods = {
     self.view:Disable();
     self.group:Disable();
     self.ungroup:Disable();
-    self.loaded:Disable();
     self.expand:Disable();
     self:UpdateUpDownButtons()
   end,
@@ -1553,7 +1537,6 @@ local methods = {
     self.view:Enable();
     self.group:Enable();
     self.ungroup:Enable();
-    self.loaded:Enable();
     self:UpdateUpDownButtons()
     if not(self.expand.disabled) then
       self.expand:Enable();
@@ -1723,20 +1706,6 @@ local function Constructor()
 
   view.visibility = 0;
 
-  local loaded = CreateFrame("Button", nil, button);
-  button.loaded = loaded;
-  loaded:SetWidth(16);
-  loaded:SetHeight(16);
-  loaded:SetPoint("BOTTOM", button, "BOTTOM");
-  loaded:SetPoint("LEFT", icon, "RIGHT", 0, 0);
-  loaded:SetNormalTexture("Interface\\BUTTONS\\UI-GuildButton-OfficerNote-Up.blp");
-  loaded:SetDisabledTexture("Interface\\BUTTONS\\UI-GuildButton-OfficerNote-Disabled.blp");
-  --loaded:SetHighlightTexture("Interface\\BUTTONS\\UI-Panel-MinimizeButton-Highlight.blp");
-  loaded.title = L["Loaded"];
-  loaded.desc = L["This display is currently loaded"];
-  loaded:SetScript("OnEnter", function() Show_Tooltip(button, loaded.title, loaded.desc) end);
-  loaded:SetScript("OnLeave", Hide_Tooltip);
-
   local renamebox = CreateFrame("EditBox", nil, button, "InputBoxTemplate");
   renamebox:SetHeight(14);
   renamebox:SetPoint("TOP", button, "TOP");
@@ -1862,7 +1831,6 @@ local function Constructor()
     ungroup = ungroup,
     upgroup = upgroup,
     downgroup = downgroup,
-    loaded = loaded,
     background = background,
     expand = expand,
     warning = warning,

--- a/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasLoadedHeaderButton.lua
+++ b/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasLoadedHeaderButton.lua
@@ -117,6 +117,13 @@ local methods = {
       self:UpdateViewTexture()
     end
   end,
+  ["UpdateLoadedTexture"] = function(self)
+    if self.loaded.mode == 0 then -- all
+      self.loaded:SetNormalTexture("Interface\\BUTTONS\\UI-GuildButton-OfficerNote-Disabled.blp");
+    elseif self.loaded.mode == 1 then -- loaded only
+      self.loaded:SetNormalTexture("Interface\\BUTTONS\\UI-GuildButton-OfficerNote-Up.blp");
+    end
+  end,
   ["UpdateViewTexture"] = function(self)
     local visibility = self.view.visibility
     if(visibility == 2) then

--- a/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasLoadedHeaderButton.lua
+++ b/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasLoadedHeaderButton.lua
@@ -93,6 +93,9 @@ local methods = {
       self:Collapse();
     end
   end,
+  ["SetLoadedClick"] = function(self, func)
+    self.loaded:SetScript("OnClick", func);
+  end,
   ["SetViewClick"] = function(self, func)
     self.view:SetScript("OnClick", func);
   end,
@@ -172,7 +175,7 @@ local function Constructor()
   expand:SetScript("OnEnter", function() Show_Tooltip(button, expand.title, expand.desc) end);
   expand:SetScript("OnLeave", Hide_Tooltip);
 
-  local view = CreateFrame("Button", nil, button);
+  local view = CreateFrame("BUTTON", nil, button);
   button.view = view;
   view:SetWidth(16);
   view:SetHeight(16);

--- a/WeakAurasOptions/OptionsFrames/OptionsFrame.lua
+++ b/WeakAurasOptions/OptionsFrames/OptionsFrame.lua
@@ -587,24 +587,30 @@ function OptionsPrivate.CreateFrame()
   local searchMenuFrame = CreateFrame("Frame", "WeakAurasSearchMenuFrame", filterInput, "UIDropDownMenuTemplate")
   searchMenuFrame:Hide()
 
+  local function addSearch(s)
+    local prevText = filterInput:GetText()
+    local newText = prevText and prevText ~= "" and (prevText .. " " .. s) or s
+    filterInput:SetText(newText)
+  end
+
   local filterInputMenuEntries = {
     { text = L["Load"], notCheckable = true, hasArrow = true,
       menuList = {
         { text = L["Class"], notCheckable = true, hasArrow = true, menuList = {} },
         { text = L["Encounters"], notCheckable = true, hasArrow = true, menuList = {} },
-        { text = L["Never"], notCheckable = true, func = function() filterInput:SetText("load.use_never:true") end },
-        { text = L["In Combat"], notCheckable = true, func = function() filterInput:SetText("load.use_combat:true") end },
+        { text = L["Never"], notCheckable = true, func = function() addSearch("load.use_never:true") end },
+        { text = L["In Combat"], notCheckable = true, func = function() addSearch("load.use_combat:true") end },
       }
     },
     { text = L["Type"], notCheckable = true, hasArrow = true,
       menuList = {
-        { text = L["Icon"], notCheckable = true, func = function() filterInput:SetText("regionType:icon") end },
-        { text = L["Text"], notCheckable = true, func = function() filterInput:SetText("regionType:text") end },
-        { text = L["Progress Bar"], notCheckable = true, func = function() filterInput:SetText("regionType:aurabar") end },
-        { text = L["Texture"], notCheckable = true, func = function() filterInput:SetText("regionType:texture") end },
-        { text = L["Progress Texture"], notCheckable = true, func = function() filterInput:SetText("regionType:progresstexture") end },
-        { text = L["Model"], notCheckable = true, func = function() filterInput:SetText("regionType:model") end },
-        { text = L["Stop Motion"], notCheckable = true, func = function() filterInput:SetText("regionType:stopmotion") end },
+        { text = L["Icon"], notCheckable = true, func = function() addSearch("regionType:icon") end },
+        { text = L["Text"], notCheckable = true, func = function() addSearch("regionType:text") end },
+        { text = L["Progress Bar"], notCheckable = true, func = function() addSearch("regionType:aurabar") end },
+        { text = L["Texture"], notCheckable = true, func = function() addSearch("regionType:texture") end },
+        { text = L["Progress Texture"], notCheckable = true, func = function() addSearch("regionType:progresstexture") end },
+        { text = L["Model"], notCheckable = true, func = function() addSearch("regionType:model") end },
+        { text = L["Stop Motion"], notCheckable = true, func = function() addSearch("regionType:stopmotion") end },
       }
     },
   }
@@ -632,7 +638,7 @@ function OptionsPrivate.CreateFrame()
     for _, raid in ipairs(OptionsPrivate.Private.encounter_table) do
       local raidMenu = { text = raid[1], notCheckable = true, hasArrow = true, menuList = {} }
       for _, boss in ipairs(raid[2]) do
-        tinsert(raidMenu.menuList, { text = boss[1], notCheckable = true, func = function() filterInput:SetText("load.encounterid:"..boss[2]) end })
+        tinsert(raidMenu.menuList, { text = boss[1], notCheckable = true, func = function() addSearch("load.encounterid:"..boss[2]) end })
       end
       tinsert(encounterMenu, raidMenu)
     end
@@ -642,7 +648,7 @@ function OptionsPrivate.CreateFrame()
       for _, zoneCategory in ipairs(OptionsPrivate.Private.zoneId_table) do
         local dungeonOrRaidMenu = { text = zoneCategory[1], notCheckable = true, hasArrow = true, menuList = {} }
         for _, zone in ipairs(zoneCategory[2]) do
-          tinsert(dungeonOrRaidMenu.menuList, { text = zone[1], notCheckable = true, func = function() filterInput:SetText("load.zoneIds:"..zone[2]) end })
+          tinsert(dungeonOrRaidMenu.menuList, { text = zone[1], notCheckable = true, func = function() addSearch("load.zoneIds:"..zone[2]) end })
         end
         tinsert(zoneIdMenu.menuList, dungeonOrRaidMenu)
       end
@@ -652,7 +658,7 @@ function OptionsPrivate.CreateFrame()
     if not WeakAuras.IsClassic() then
       local zoneIdMenu = { text = L["Instance Difficulty"], notCheckable = true, hasArrow = true, menuList = {} }
       for difficulty, localeName in pairs(OptionsPrivate.Private.difficulty_types) do
-        tinsert(zoneIdMenu.menuList, { text = localeName, notCheckable = true, func = function() filterInput:SetText("load.difficulty:"..difficulty) end })
+        tinsert(zoneIdMenu.menuList, { text = localeName, notCheckable = true, func = function() addSearch("load.difficulty:"..difficulty) end })
       end
       tinsert(loadMenu, 3, zoneIdMenu)
     end

--- a/WeakAurasOptions/OptionsFrames/OptionsFrame.lua
+++ b/WeakAurasOptions/OptionsFrames/OptionsFrame.lua
@@ -688,7 +688,7 @@ function OptionsPrivate.CreateFrame()
         text = class[2],
         notCheckable = true,
         func = function()
-          input:SetText("load.class:"..class[1]:lower())
+          addSearch("load.class:"..class[1]:lower())
         end
       })
     end

--- a/WeakAurasOptions/OptionsFrames/OptionsFrame.lua
+++ b/WeakAurasOptions/OptionsFrames/OptionsFrame.lua
@@ -594,12 +594,70 @@ function OptionsPrivate.CreateFrame()
   end
 
   local filterInputMenuEntries = {
+    { text = L["Filters"], notCheckable = true, isTitle = true},
     { text = L["Load"], notCheckable = true, hasArrow = true,
       menuList = {
         { text = L["Class"], notCheckable = true, hasArrow = true, menuList = {} },
         { text = L["Encounters"], notCheckable = true, hasArrow = true, menuList = {} },
         { text = L["Never"], notCheckable = true, func = function() addSearch("load.use_never:true") end },
         { text = L["In Combat"], notCheckable = true, func = function() addSearch("load.use_combat:true") end },
+      }
+    },
+    { text = L["Actions"], notCheckable = true, hasArrow = true,
+      menuList = {
+        { text = L["On Show"], notCheckable = true, hasArrow = true,
+          menuList = {
+            { text = L["Glow"], notCheckable = true, hasArrow = true,
+              menuList = {
+                { text = L["Unit Frame"], notCheckable = true, func = function() addSearch("actions.start.do_glow:true") addSearch("actions.start.glow_frame_type:unitframe") end },
+                { text = L["Nameplate"], notCheckable = true, func = function() addSearch("actions.start.do_glow:true") addSearch("actions.start.glow_frame_type:nameplate") end },
+              }
+            },
+            { text = L["Sound"], notCheckable = true, func = function() addSearch("actions.start.do_sound:true") end },
+            { text = L["Message"], notCheckable = true, func = function() addSearch("actions.start.do_message:true") end },
+          }
+        }
+      }
+    },
+    { text = L["Conditions"], notCheckable = true, hasArrow = true,
+      menuList = {
+        { text = L["Glow"], notCheckable = true, hasArrow = true,
+          menuList = {
+            { text = L["Unit Frame"], notCheckable = true, func = function() addSearch("conditions.*.changes.*.property:glowexternal") addSearch("conditions.*.changes.*.value.glow_frame_type:unitframe") end },
+            { text = L["Nameplate"], notCheckable = true, func = function() addSearch("conditions.*.changes.*.property:glowexternal") addSearch("conditions.*.changes.*.value.glow_frame_type:nameplate") end },
+          }
+        },
+        { text = L["Sound"], notCheckable = true, func = function() addSearch("conditions.*.changes.*.property:sound") end },
+        { text = L["Message"], notCheckable = true, func = function() addSearch("conditions.*.changes.*.property:chat") end },
+        { text = L["Range Check"], notCheckable = true, func = function() addSearch("conditions.*.check.variable:rangecheck") end },
+      }
+    },
+    { text = L["Triggers"], notCheckable = true, hasArrow = true,
+      menuList = {
+        { text = L["Any Aura"], notCheckable = true, func = function() addSearch("triggers.*.trigger.type:aura2") end },
+        { text = L["Trigger 1 Aura"], notCheckable = true, func = function() addSearch("triggers.1.trigger.type:aura2") end },
+        { text = L["Trigger 1 Cast"], notCheckable = true, func = function() addSearch("triggers.1.trigger.type:unit") addSearch("triggers.1.trigger.event:cast") end },
+      }
+    },
+    { text = L["Display"], notCheckable = true, hasArrow = true,
+      menuList = {
+        { text = L["Anchor"], notCheckable = true, hasArrow = true,
+          menuList = {
+            { text = L["Group"], notCheckable = true, hasArrow = true,
+              menuList = {
+                { text = L["Nameplate"], notCheckable = true, func = function() addSearch("useAnchorPerUnit:true") addSearch("anchorPerUnit:nameplate") end },
+                { text = L["Unit Frame"], notCheckable = true, func = function() addSearch("useAnchorPerUnit:true") addSearch("anchorPerUnit:unitframe") end },
+              }
+            },
+            { text = L["Aura"], notCheckable = true, hasArrow = true,
+              menuList = {
+                { text = L["Nameplate"], notCheckable = true, func = function() addSearch("anchorFrameType:nameplate") end },
+                { text = L["Unit Frame"], notCheckable = true, func = function() addSearch("anchorFrameType:unitframe") end },
+                { text = L["Mouse Cursor"], notCheckable = true, func = function() addSearch("anchorFrameType:mouse") end },
+              }
+            }
+          }
+        },
       }
     },
     { text = L["Type"], notCheckable = true, hasArrow = true,
@@ -613,25 +671,10 @@ function OptionsPrivate.CreateFrame()
         { text = L["Stop Motion"], notCheckable = true, func = function() addSearch("regionType:stopmotion") end },
       }
     },
-    { text = L["Triggers"], notCheckable = true, hasArrow = true,
-      menuList = {
-        { text = L["Any Aura"], notCheckable = true, func = function() addSearch("triggers.*.trigger.type:aura2") end },
-        { text = L["Trigger 1 Aura"], notCheckable = true, func = function() addSearch("triggers.1.trigger.type:aura2") end },
-        { text = L["Trigger 1 Cast"], notCheckable = true, func = function() addSearch("triggers.1.trigger.type:unit") addSearch("triggers.1.trigger.event:cast") end },
-      }
-    },
-    { text = L["Anchor"], notCheckable = true, hasArrow = true,
-      menuList = {
-        { text = L["Nameplate Aura"], notCheckable = true, func = function() addSearch("anchorFrameType:nameplate") end },
-        { text = L["Nameplate Group"], notCheckable = true, func = function() addSearch("useAnchorPerUnit:true") addSearch("anchorPerUnit:nameplate") end },
-        { text = L["Unit Frame Aura"], notCheckable = true, func = function() addSearch("anchorFrameType:unitframe") end },
-        { text = L["Unit Frame Group"], notCheckable = true, func = function() addSearch("useAnchorPerUnit:true") addSearch("anchorPerUnit:unitframe") end },
-      }
-    }
   }
 
   local function fillFilterInputMenuEntries(menu, input)
-    local loadMenu = menu[1].menuList
+    local loadMenu = menu[2].menuList
     local classMenu = loadMenu[1].menuList
     local encounterMenu = loadMenu[2].menuList
 
@@ -671,11 +714,11 @@ function OptionsPrivate.CreateFrame()
     end
 
     if not WeakAuras.IsClassic() then
-      local zoneIdMenu = { text = L["Instance Difficulty"], notCheckable = true, hasArrow = true, menuList = {} }
+      local difficultyMenu = { text = L["Instance Difficulty"], notCheckable = true, hasArrow = true, menuList = {} }
       for difficulty, localeName in pairs(OptionsPrivate.Private.difficulty_types) do
-        tinsert(zoneIdMenu.menuList, { text = localeName, notCheckable = true, func = function() addSearch("load.difficulty:"..difficulty) end })
+        tinsert(difficultyMenu.menuList, { text = localeName, notCheckable = true, func = function() addSearch("load.difficulty:"..difficulty) end })
       end
-      tinsert(loadMenu, 3, zoneIdMenu)
+      tinsert(loadMenu, 4, difficultyMenu)
     end
   end
 

--- a/WeakAurasOptions/OptionsFrames/OptionsFrame.lua
+++ b/WeakAurasOptions/OptionsFrames/OptionsFrame.lua
@@ -691,7 +691,7 @@ function OptionsPrivate.CreateFrame()
   filterInput:SetPoint("RIGHT", container.frame, "LEFT", -5, 0)
   filterInput:SetFont(STANDARD_TEXT_FONT, 10)
   filterInput:SetScript("OnEditFocusGained", function()
-    EasyMenu(filterInputMenuEntries, WeakAurasSearchMenuFrame, WeakAurasFilterInput, 20 , -30)
+    EasyMenu(filterInputMenuEntries, WeakAurasSearchMenuFrame, WeakAurasFilterInput, 20 , -30, "MENU")
     searchMenuFrame:SetPoint("TOPLEFT", WeakAurasFilterInput, "BOTTOMLEFT")
   end)
   frame.filterInput = filterInput

--- a/WeakAurasOptions/OptionsFrames/OptionsFrame.lua
+++ b/WeakAurasOptions/OptionsFrames/OptionsFrame.lua
@@ -613,6 +613,21 @@ function OptionsPrivate.CreateFrame()
         { text = L["Stop Motion"], notCheckable = true, func = function() addSearch("regionType:stopmotion") end },
       }
     },
+    { text = L["Triggers"], notCheckable = true, hasArrow = true,
+      menuList = {
+        { text = L["Any Aura"], notCheckable = true, func = function() addSearch("triggers.*.trigger.type:aura2") end },
+        { text = L["Trigger 1 Aura"], notCheckable = true, func = function() addSearch("triggers.1.trigger.type:aura2") end },
+        { text = L["Trigger 1 Cast"], notCheckable = true, func = function() addSearch("triggers.1.trigger.type:unit") addSearch("triggers.1.trigger.event:cast") end },
+      }
+    },
+    { text = L["Anchor"], notCheckable = true, hasArrow = true,
+      menuList = {
+        { text = L["Nameplate Aura"], notCheckable = true, func = function() addSearch("anchorFrameType:nameplate") end },
+        { text = L["Nameplate Group"], notCheckable = true, func = function() addSearch("useAnchorPerUnit:true") addSearch("anchorPerUnit:nameplate") end },
+        { text = L["Unit Frame Aura"], notCheckable = true, func = function() addSearch("anchorFrameType:unitframe") end },
+        { text = L["Unit Frame Group"], notCheckable = true, func = function() addSearch("useAnchorPerUnit:true") addSearch("anchorPerUnit:unitframe") end },
+      }
+    }
   }
 
   local function fillFilterInputMenuEntries(menu, input)

--- a/WeakAurasOptions/WeakAurasOptions.lua
+++ b/WeakAurasOptions/WeakAurasOptions.lua
@@ -939,15 +939,14 @@ local function searchData(filter, id)
           end
           local is_path_with_checknumericids = path_with_checknumericids[path]
           local is_path_wih_zoneChecker = path_with_zoneChecker[path]
-          -- TO FIX
-          --local zoneChecker = is_path_wih_zoneChecker and toggle_check == true and value ~= "" and WeakAuras.ParseZoneCheck(tostring(data))
+          local zoneChecker = (is_path_wih_zoneChecker and toggle_check == true and type(data) == "string" and data ~= "") and WeakAuras.ParseZoneCheck(data)
           if
           (
             (is_path_with_toggles == false or toggle_check == true or isToggle)
             and (
               data == value
               or (is_path_with_checknumericids and WeakAuras.CheckNumericIds(data, value))
-              or (is_path_wih_zoneChecker and zoneChecker and zoneChecker:Check(value:lower(), value:lower()))
+              or (zoneChecker and zoneChecker:Check(tonumber(value), value:lower():sub(1,1) == "g" and tonumber(value:sub(2,#value))))
               or (type(data) == "string" and data:upper() == value)
               or (data == true and value == "TRUE")
               or (data == false and value == "FALSE")

--- a/WeakAurasOptions/WeakAurasOptions.lua
+++ b/WeakAurasOptions/WeakAurasOptions.lua
@@ -1168,12 +1168,6 @@ function OptionsPrivate.SortDisplayButtons(filter, overrideReset, loadMode)
   local visible = {}
 
   for id, child in pairs(displayButtons) do
-    if(OptionsPrivate.Private.loaded[id] ~= nil) then
-      child:EnableLoaded();
-    else
-      child:DisableLoaded();
-    end
-
     if loadMode == nil then
       loadMode = previousLoadMode
     end

--- a/WeakAurasOptions/WeakAurasOptions.lua
+++ b/WeakAurasOptions/WeakAurasOptions.lua
@@ -920,7 +920,7 @@ local function searchData(filter, id)
   local functionReturn = false
   for search in filter:gmatch("[^ ]+") do
     local loopReturn = false
-    local operator, path, value = search:match("^(+?)([%w%d_%.%*]+):([%w%d]+)$")
+    local operator, path, value = search:match("^([+-]?)([%w%d_%.%*]+):([%w%d]+)$")
     if path and value then
       -- search in data
       value = value:upper()
@@ -1011,6 +1011,9 @@ local function searchData(filter, id)
         end
 
         local result = recurse(AuraData, path)
+        if operator == "-" then
+          result = not result
+        end
         if result == true or (operator == "+" and result ~= false) then
           loopReturn = true
           functionReturn = true

--- a/WeakAurasOptions/WeakAurasOptions.lua
+++ b/WeakAurasOptions/WeakAurasOptions.lua
@@ -920,7 +920,7 @@ local function searchData(filter, id)
   local functionReturn = false
   for search in filter:gmatch("[^ ]+") do
     local loopReturn = false
-    local operator, path, value = search:match("^([+-]?)([%w%d_%.%*]+):([%w%d]+)$")
+    local operator, path, value = search:match("^([+-]?)([^: ]+):([^: ]+)$")
     if path and value then
       -- search in data
       value = value:upper()
@@ -969,7 +969,7 @@ local function searchData(filter, id)
         -- if path exists and test is not valid: return false
         -- if path does not exists or is toggled off: return nil
         local function recurse(data, recurse_path, toggle_for_field, field_is_a_toggle)
-          local field, next_path = recurse_path:match("^([%w%d_%*]+)%.?(.*)")
+          local field, next_path = recurse_path:match("^([^. ]+)%.?(.*)")
           if field == nil then
             -- return nil if path is a toggled off
             if not field_is_a_toggle then

--- a/WeakAurasOptions/WeakAurasOptions.lua
+++ b/WeakAurasOptions/WeakAurasOptions.lua
@@ -905,16 +905,16 @@ local function addButton(button, aurasMatchingFilter, visible)
   end
 end
 
-local path_with_toggles = {
+local pathWithToggles = {
   "^load",
 }
-local path_with_checknumericids = {
+local pathWithChecknumericids = {
   ["load.encounterid"] = true
 }
-local path_with_zoneChecker = {
+local pathWithZoneChecker = {
   ["load.zoneIds"] = true
 }
-local path_with_namerealm = {
+local pathWithNamerealm = {
   ["load.namerealm"] = true,
   ["load.ignoreNameRealm"] = true
 }
@@ -931,25 +931,25 @@ local function searchData(filter, id)
       local AuraData = WeakAuras.GetData(id)
 
       if AuraData then
-        local function test(data, toggle_for_field, field_is_a_toggle)
-          local is_path_with_toggles = false
-          for _, check in ipairs(path_with_toggles) do
+        local function test(data, toggleForField, fieldIsToggle)
+          local isPathWithToggles = false
+          for _, check in ipairs(pathWithToggles) do
             if path:match(check) then
-              is_path_with_toggles = true
+              isPathWithToggles = true
               break
             end
           end
-          local is_path_with_checknumericids = path_with_checknumericids[path]
-          local is_path_wih_zoneChecker = path_with_zoneChecker[path]
-          local zoneChecker = (is_path_wih_zoneChecker and toggle_for_field == true and type(data) == "string" and data ~= "") and WeakAuras.ParseZoneCheck(data)
-          local is_path_with_namerealm = path_with_namerealm[path]
-          local namerealmChecker = (is_path_with_namerealm and toggle_for_field == true and type(data) == "string" and data ~= "") and WeakAuras.ParseNameCheck(data)
+          local isPathWithChecknumericids = pathWithChecknumericids[path]
+          local isPathWihZoneChecker = pathWithZoneChecker[path]
+          local zoneChecker = (isPathWihZoneChecker and toggleForField == true and type(data) == "string" and data ~= "") and WeakAuras.ParseZoneCheck(data)
+          local isPathWithNamerealm = pathWithNamerealm[path]
+          local namerealmChecker = (isPathWithNamerealm and toggleForField == true and type(data) == "string" and data ~= "") and WeakAuras.ParseNameCheck(data)
           if
           (
-            (not is_path_with_toggles or (is_path_with_toggles and toggle_for_field == true) or field_is_a_toggle == true)
+            (not isPathWithToggles or (isPathWithToggles and toggleForField == true) or fieldIsToggle == true)
             and (
               data == value
-              or (is_path_with_checknumericids and WeakAuras.CheckNumericIds(data, value))
+              or (isPathWithChecknumericids and WeakAuras.CheckNumericIds(data, value))
               or (zoneChecker and zoneChecker:Check(tonumber(value), value:lower():sub(1,1) == "g" and tonumber(value:sub(2,#value))))
               or (namerealmChecker and namerealmChecker:Check(strsplit("-", data), select(2, strsplit("-", data))))
               or (type(data) == "string" and data:upper() == value)
@@ -959,8 +959,8 @@ local function searchData(filter, id)
             )
           )
           or (
-            is_path_with_toggles == true
-            and toggle_for_field == false
+            isPathWithToggles == true
+            and toggleForField == false
             and (
               type(data) == "table" and data.multi and (data.multi[value] == true)
             )
@@ -975,21 +975,21 @@ local function searchData(filter, id)
         -- if path exists and test is valid: return true
         -- if path exists and test is not valid: return false
         -- if path does not exists or is toggled off: return nil
-        local function recurse(data, recurse_path, toggle_for_field, field_is_a_toggle)
-          local field, next_path = recurse_path:match("^([^. ]+)%.?(.*)")
+        local function recurse(data, recursePath, toggleForField, fieldIsToggle)
+          local field, next_path = recursePath:match("^([^. ]+)%.?(.*)")
           if field == nil then
             -- return nil if path is a toggled off
-            if not field_is_a_toggle then
-              for _, check in ipairs(path_with_toggles) do
+            if not fieldIsToggle then
+              for _, check in ipairs(pathWithToggles) do
                 if path:match(check) then
-                  if toggle_for_field == nil then
+                  if toggleForField == nil then
                     return
                   end
                   break
                 end
               end
             end
-            return test(data, toggle_for_field, field_is_a_toggle)
+            return test(data, toggleForField, fieldIsToggle)
           elseif type(data) ~= "table" then
             return nil
           elseif field == "*" then -- wildcard explore list

--- a/WeakAurasOptions/WeakAurasOptions.lua
+++ b/WeakAurasOptions/WeakAurasOptions.lua
@@ -1108,7 +1108,7 @@ function OptionsPrivate.SortDisplayButtons(filter, overrideReset, loadMode)
   local lowerFilter = filter:lower();
 
   for id, child in pairs(displayButtons) do
-    if(OptionsPrivate.Private.loaded[id]) then
+    if(OptionsPrivate.Private.loaded[id] ~= nil) then
       child:EnableLoaded();
     else
       child:DisableLoaded();
@@ -1131,7 +1131,9 @@ function OptionsPrivate.SortDisplayButtons(filter, overrideReset, loadMode)
       loadMode = previousLoadMode
     end
     previousLoadMode = loadMode
-    if loadMode and not OptionsPrivate.Private.loaded[id] then
+    if (loadMode == 1 and not OptionsPrivate.Private.loaded[id])
+    or (loadMode == 2 and OptionsPrivate.Private.loaded[id] ~= nil)
+    then
       aurasMatchingFilter[id] = nil
     end
 

--- a/WeakAurasOptions/WeakAurasOptions.lua
+++ b/WeakAurasOptions/WeakAurasOptions.lua
@@ -969,26 +969,28 @@ local function searchData(filter, id)
           local field, rest = rec_path:match("^([%w%d_%*]+)%.?(.*)")
           if field == nil then
             return test(data)
-          elseif field == "*" and type(data) == "table" then
+          elseif type(data) ~= "table" then
+            return false
+          elseif field == "*" then -- wildcard explore list
             for _, element in ipairs(data) do
               local ret = recurse(element, rest)
               if ret then
                 return true
               end
             end
-          elseif tonumber(field) and type(data) == "table" then
+          elseif tonumber(field) then -- explore list at index
             field = tonumber(field)
             if data[field] then
               return recurse(data[field], rest)
             end
           else
-            if data[field] == nil then
+            if data[field] == nil then -- path does not match
               return false
             end
-            if data[field] then
+            if data[field] then --  a toggle is checked for for this field
               toggle_check = data["use_"..field]
             end
-            isToggle = field:sub(1,4) == "use_"
+            isToggle = field:sub(1,4) == "use_" -- field is a toggle
             return recurse(data[field], rest)
           end
         end

--- a/WeakAurasOptions/WeakAurasOptions.lua
+++ b/WeakAurasOptions/WeakAurasOptions.lua
@@ -914,68 +914,83 @@ local path_with_checknumericids = {
 local path_with_zoneChecker = {
   ["load.zoneIds"] = true
 }
+
 local function searchData(filter, id)
-  local path, value = filter:match("^([%w%d_%.]+):([%w%d]+)$")
-  if path and value then
-    -- search in data
-    value = value:upper()
-    local data = WeakAuras.GetData(id)
-    if data then
-      local path_ok
-      local toggle_check -- value of a field starting with "use_" for last key of the path
-      local isToggle -- true if last key of the path start with "use_"
+  if not filter or filter == "" then return end
+  local functionReturn = false
+  for search in filter:gmatch("[^ ]+") do
+    local loopReturn = false
+    local path, value = search:match("^([%w%d_%.]+):([%w%d]+)$")
+    if path and value then
+      -- search in data
+      value = value:upper()
+      local data = WeakAuras.GetData(id)
+      if data then
+        local path_ok
+        local toggle_check -- value of a field starting with "use_" for last key of the path
+        local isToggle -- true if last key of the path start with "use_"
 
-      for field in path:gmatch("[%w%d_]+") do
-        if data[field] == nil then
-          path_ok = false
-          break
-        end
-        path_ok = true
-        if data[field] then
-          toggle_check = data["use_"..field]
-        end
-        data = data[field]
-        isToggle = field:sub(1,4) == "use_"
-      end
-
-      if path_ok then
-        local is_path_with_toggles = false
-        for _, check in ipairs(path_with_toggles) do
-          if path:match(check) then
-            is_path_with_toggles = true
+        for field in path:gmatch("[%w%d_]+") do
+          if data[field] == nil then
+            path_ok = false
             break
           end
+          path_ok = true
+          if data[field] then
+            toggle_check = data["use_"..field]
+          end
+          data = data[field]
+          isToggle = field:sub(1,4) == "use_"
         end
-        local is_path_with_checknumericids = path_with_checknumericids[path]
-        local is_path_wih_zoneChecker = path_with_zoneChecker[path]
-        local zoneChecker = is_path_wih_zoneChecker and toggle_check == true and value ~= "" and WeakAuras.ParseZoneCheck(tostring(data))
 
-        if
-        (
-          (is_path_with_toggles == false or toggle_check == true or isToggle)
-          and (
-            data == value
-            or (is_path_with_checknumericids and WeakAuras.CheckNumericIds(data, value))
-            or (is_path_wih_zoneChecker and zoneChecker and zoneChecker:Check(value:lower(), value:lower()))
-            or (type(data) == "string" and data:upper() == value)
-            or (data == true and value == "TRUE")
-            or (data == false and value == "FALSE")
-            or (type(data) == "table" and data.single and data.single:upper() == value)
+        if path_ok then
+          local is_path_with_toggles = false
+          for _, check in ipairs(path_with_toggles) do
+            if path:match(check) then
+              is_path_with_toggles = true
+              break
+            end
+          end
+          local is_path_with_checknumericids = path_with_checknumericids[path]
+          local is_path_wih_zoneChecker = path_with_zoneChecker[path]
+          -- TO FIX
+          --local zoneChecker = is_path_wih_zoneChecker and toggle_check == true and value ~= "" and WeakAuras.ParseZoneCheck(tostring(data))
+
+          if
+          (
+            (is_path_with_toggles == false or toggle_check == true or isToggle)
+            and (
+              data == value
+              or (is_path_with_checknumericids and WeakAuras.CheckNumericIds(data, value))
+              or (is_path_wih_zoneChecker and zoneChecker and zoneChecker:Check(value:lower(), value:lower()))
+              or (type(data) == "string" and data:upper() == value)
+              or (data == true and value == "TRUE")
+              or (data == false and value == "FALSE")
+              or (type(data) == "table" and data.single and data.single:upper() == value)
+            )
           )
-        )
-        or (
-          is_path_with_toggles == true
-          and toggle_check == false
-          and (
-            type(data) == "table" and data.multi and (data.multi[value] == true)
+          or (
+            is_path_with_toggles == true
+            and toggle_check == false
+            and (
+              type(data) == "table" and data.multi and (data.multi[value] == true)
+            )
           )
-        )
-        then
-          return true
+          then
+            loopReturn = true
+            functionReturn = true
+          end
         end
       end
+    else
+      if id:lower():find(search:lower(), 1, true) then
+        loopReturn = true
+        functionReturn = true
+      end
     end
+    if not loopReturn then return false end
   end
+  return functionReturn
 end
 
 local previousFilter;
@@ -1117,7 +1132,6 @@ function OptionsPrivate.SortDisplayButtons(filter, overrideReset, loadMode)
   local useTextFilter = filter and filter ~= ""
   local topLevelAuras = {}
   local visible = {}
-  local lowerFilter = filter:lower();
 
   for id, child in pairs(displayButtons) do
     if(OptionsPrivate.Private.loaded[id] ~= nil) then
@@ -1126,27 +1140,24 @@ function OptionsPrivate.SortDisplayButtons(filter, overrideReset, loadMode)
       child:DisableLoaded();
     end
 
-    if useTextFilter then
-      if searchData(filter, id)
-      or id:lower():find(lowerFilter, 1, true)
-      then
-        aurasMatchingFilter[id] = true
-        for parent in OptionsPrivate.Private.TraverseParents(child.data) do
-          aurasMatchingFilter[parent.id] = true
-        end
-      end
-    else
-      aurasMatchingFilter[id] = true
-    end
-
     if loadMode == nil then
       loadMode = previousLoadMode
     end
     previousLoadMode = loadMode
-    if (loadMode == 1 and not OptionsPrivate.Private.loaded[id])
-    or (loadMode == 2 and OptionsPrivate.Private.loaded[id] ~= nil)
-    then
+
+    if loadMode and OptionsPrivate.Private.loaded[id] == nil then
       aurasMatchingFilter[id] = nil
+    else
+      if useTextFilter then
+        if searchData(filter, id) then
+          aurasMatchingFilter[id] = true
+          for parent in OptionsPrivate.Private.TraverseParents(child.data) do
+            aurasMatchingFilter[parent.id] = true
+          end
+        end
+      else
+        aurasMatchingFilter[id] = true
+      end
     end
 
     if not child:GetGroup() then


### PR DESCRIPTION
# Description

Experiment changes on aura list

- Merged Loaded & Unloaded
- Added button to filter out unloaded auras
- Changed what an "unloaded aura" means for UI, it is now aura with "never", or wrong character class, race, name,  or realm
- Search can explore data, with an helper menu with premade filters

Search in data use this format:
`path:value`

Working examples:
`load.class:shaman`
`load.encounter:123`
`load.use_never:true` (need to prefix with "use_" for pure toggles
`regionType:text`
`actions.start.do_sound:true`

Idea for improvement:
- ~~support lists, something like `triggers.*.type:aura2` maybe~~ done => support triggers.*.trigger or triggers.1.trigger (works also with conditions)
- ~~handle multiple filters at once~~ done
- partial matching like `:~contains`
- ~~autocompletion?~~ added menu with premade filters

Known Issues
- with change made to what is considered loaded, opening weakauras options may show too much auras => important
- show all displays button (top green eye) doesn't account for what is filtered => important
- nested conditions are not supported
- search for a "Cast" trigger require to check both "type" and "event", when searching in all triggers with "*" can return false positive with a type=aura2 trigger with unused "event" field not cleaned up (can't do much about it)


## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update
