### PR TITLE
Custom triggers: Add support for Ace3 CallbackHandler style events in custom triggers

### DIFF
--- a/WeakAuras/GenericTrigger.lua
+++ b/WeakAuras/GenericTrigger.lua
@@ -1183,6 +1183,9 @@ function GenericTrigger.LoadDisplays(toLoad, loadEvent, ...)
       -- TODO: Probably display a warning somehow asking for an UI reload?
       if addonStub.UnregisterAllCallbacks ~= nil then
         addonStub.UnregisterAllCallbacks(WeakAuras)
+      else if addonStub.UnregisterCallback ~= nil then
+        for event in pairs(events) do
+          addonStub.UnregisterCallback(WeakAuras, event)
       end
 
       if addonStub.RegisterCallback ~= nil then

--- a/WeakAuras/GenericTrigger.lua
+++ b/WeakAuras/GenericTrigger.lua
@@ -1186,6 +1186,7 @@ function GenericTrigger.LoadDisplays(toLoad, loadEvent, ...)
       else if addonStub.UnregisterCallback ~= nil then
         for event in pairs(events) do
           addonStub.UnregisterCallback(WeakAuras, event)
+        end
       end
 
       if addonStub.RegisterCallback ~= nil then

--- a/WeakAuras/Types.lua
+++ b/WeakAuras/Types.lua
@@ -2054,7 +2054,8 @@ Private.rune_specific_types = {
 Private.custom_trigger_types = {
   ["event"] = L["Event"],
   ["status"] = L["Status"],
-  ["stateupdate"] = L["Trigger State Updater (Advanced)"]
+  ["stateupdate"] = L["Trigger State Updater (Advanced)"],
+  ["addOnEvent"] = L["AddOn Callback"]
 }
 
 Private.eventend_types = {


### PR DESCRIPTION
# Description

Added the ability for aura writers to listen to custom events by addons that use the machinery provided by Ace3's `CallbackHandler` library:

`MyAddon.callbacks = LibStub("CallbackHandler-1.0"):New(MyAddon)`

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested

My Retail sub is currently inactive; this has been backported from a Legion era WeakAura I used to track AP. I did my best to backport (upport?) it, however there are some changes to WeakAura's own code that makes me not completely sure this is going to work out of the box. To test, you could install this addon:

```lua
local MAJOR, MINOR = "LibDummyTest-1.0", 1
local lib = LibStub(MAJOR, MINOR)
if not lib then return end
lib.callbacks = lib.callbacks or LibStub("CallbackHandler-1.0"):New(lib)

lib:StupidFunction()
    lib.callbacks:Fire("DUMMY_TEST_EVENT", 42)
end
```

And then, write a WeakAura listening to `DUMMY_TEST_EVENT` on `LibDummyTest-1.0` with the following custom trigger:
```lua
function(event, value) 
    print("triggered by", event, value) 
    return true
end
```
Hopefully, you should see `triggered by DUMMY_TEST_EVENT 42` in your chat, once you've executed the following line:
```
/run (IsAddOnLoaded("LibDummyTest-1.0") or LoadAddOn("LibDummyTest-1.0")) and LibStub("LibDummyTest-1.0"):StupidFunction()
```

In any case, I'd appreciate if some generous soul would test this on retail and report any possible error. It'll take me several days to redownload Shadowlands (or even classic), and get this running on a class trial or low level character (can they even run addons?)

## Known issues and TODOs

- [ ] There is some amount of duplication in the code handling regular events and these custom events; I considered refactoring it, but I think for a first implementation, having it separate is better.
- [ ] Ace3 library writers have the ability to provide custom names for `RegisterCallback` and affiliates. There really isn't any way to work around this besides having aura developers provide hook names. I'm not sure this is common practise however
- [ ] There likely is a bug in this implementation if someone uses this new trigger, but provides unit events.
- [ ] Auras developers will likely need to be aware they have to reload their UI if they change the addon hooked to from one to another.
- [ ] Missing documentation and translations.
- [ ] Probably other gotchas I missed.