### PR TITLE
Add a framework for built in trigger updates to fire into custom triggers

### DIFF
--- a/WeakAuras/BuffTrigger2.lua
+++ b/WeakAuras/BuffTrigger2.lua
@@ -71,7 +71,7 @@ local timer = WeakAuras.timer
 local BuffTrigger = {}
 local triggerInfos = {}
 
-local TTC_events = Private.TTC_events -- trigger to custom
+local trigger_to_custom_events = Private.trigger_to_custom_events -- trigger to custom
 
 local UnitGroupRolesAssigned = WeakAuras.IsWrathOrRetail() and UnitGroupRolesAssigned or function() return "DAMAGER" end
 
@@ -1470,8 +1470,8 @@ local function UpdateTriggerState(time, id, triggernum)
 
   -- if the trigger has updated then check to see if it is flagged for trigger_to_custom and send to queue if it is
   if updated then
-    if TTC_events[id] and TTC_events[id][triggernum] then
-      Private.AddTriggerToCustomQueue(id, triggernum)
+    if trigger_to_custom_events[id] and trigger_to_custom_events[id][triggernum] then
+      Private.AddToTriggerToCustomDelay(id, triggernum)
     end
   end
   return updated

--- a/WeakAuras/BuffTrigger2.lua
+++ b/WeakAuras/BuffTrigger2.lua
@@ -71,7 +71,7 @@ local timer = WeakAuras.timer
 local BuffTrigger = {}
 local triggerInfos = {}
 
-local trigger_to_custom_events = Private.trigger_to_custom_events
+local watched_trigger_events = Private.watched_trigger_events
 
 local UnitGroupRolesAssigned = WeakAuras.IsWrathOrRetail() and UnitGroupRolesAssigned or function() return "DAMAGER" end
 
@@ -1468,10 +1468,10 @@ local function UpdateTriggerState(time, id, triggernum)
     triggerInfo.nextScheduledCheck = nil
   end
 
-  -- if the trigger has updated then check to see if it is flagged for trigger_to_custom and send to queue if it is
+  -- if the trigger has updated then check to see if it is flagged for WatchedTrigger and send to queue if it is
   if updated then
-    if trigger_to_custom_events[id] and trigger_to_custom_events[id][triggernum] then
-      Private.AddToTriggerToCustomDelay(id, triggernum)
+    if watched_trigger_events[id] and watched_trigger_events[id][triggernum] then
+      Private.AddToWatchedTriggerDelay(id, triggernum)
     end
   end
   return updated

--- a/WeakAuras/BuffTrigger2.lua
+++ b/WeakAuras/BuffTrigger2.lua
@@ -71,7 +71,7 @@ local timer = WeakAuras.timer
 local BuffTrigger = {}
 local triggerInfos = {}
 
-local trigger_to_custom_events = Private.trigger_to_custom_events -- trigger to custom
+local trigger_to_custom_events = Private.trigger_to_custom_events
 
 local UnitGroupRolesAssigned = WeakAuras.IsWrathOrRetail() and UnitGroupRolesAssigned or function() return "DAMAGER" end
 

--- a/WeakAuras/BuffTrigger2.lua
+++ b/WeakAuras/BuffTrigger2.lua
@@ -1466,6 +1466,13 @@ local function UpdateTriggerState(time, id, triggernum)
     triggerInfo.nextScheduledCheck = nil
   end
 
+  -- if the trigger has updated then check to see if it is flagged for trigger_to_custom and send to queue if it is
+  if updated then
+    local data = WeakAuras.GetData(id)
+    if data.triggers[triggernum].trigger.trigger_to_custom then
+      Private.AddTriggerToCustomQueue(id, triggernum)
+    end
+  end
   return updated
 end
 

--- a/WeakAuras/BuffTrigger2.lua
+++ b/WeakAuras/BuffTrigger2.lua
@@ -71,6 +71,8 @@ local timer = WeakAuras.timer
 local BuffTrigger = {}
 local triggerInfos = {}
 
+local TTC_events = Private.TTC_events -- trigger to custom
+
 local UnitGroupRolesAssigned = WeakAuras.IsWrathOrRetail() and UnitGroupRolesAssigned or function() return "DAMAGER" end
 
 -- keyed on unit, debuffType, spellname, with a scan object value
@@ -1468,8 +1470,7 @@ local function UpdateTriggerState(time, id, triggernum)
 
   -- if the trigger has updated then check to see if it is flagged for trigger_to_custom and send to queue if it is
   if updated then
-    local data = WeakAuras.GetData(id)
-    if data.triggers[triggernum].trigger.trigger_to_custom then
+    if TTC_events[id] and TTC_events[id][triggernum] then
       Private.AddTriggerToCustomQueue(id, triggernum)
     end
   end

--- a/WeakAuras/GenericTrigger.lua
+++ b/WeakAuras/GenericTrigger.lua
@@ -761,15 +761,15 @@ function WeakAuras.ScanEventsInternal(event_list, event, arg1, arg2, ... )
   end
 end
 
-function WeakAuras.ScanEventsInternalToCustom(id, triggernum)
+function Private.ScanEventsInternalToCustom(id, triggernum)
   Private.StartProfileAura(id);
   Private.ActivateAuraEnvironment(id);
   local updateTriggerState = false
   if trigger_to_custom_events[id] and trigger_to_custom_events[id][triggernum] then
+    local updatedTriggerStates = WeakAuras.GetTriggerStateForTrigger(id, triggernum)
     for requestingTrigger, bool in pairs(trigger_to_custom_events[id][triggernum]) do
       if bool then
         local data = events and events[id] and events[id][requestingTrigger]
-        local updatedTriggerStates = WeakAuras.GetTriggerStateForTrigger(id, triggernum)
         local allstates = WeakAuras.GetTriggerStateForTrigger(id, requestingTrigger)
         if data and allstates and updatedTriggerStates then
           if RunTriggerFunc(allstates, data, id, requestingTrigger, "TRIGGER", triggernum, updatedTriggerStates) then

--- a/WeakAuras/GenericTrigger.lua
+++ b/WeakAuras/GenericTrigger.lua
@@ -710,10 +710,6 @@ function WeakAuras.ScanEvents(event, arg1, arg2, ...)
     end
     WeakAuras.ScanEventsInternal(event_list, event, CombatLogGetCurrentEventInfo());
   else
-    -- is the event is one of our "trigger to custom" events then change the event string to the one the user wwill expect
-    if (event:sub(1,11) == "WA_TRIGGER_") then
-      event = "TRIGGER:"..event:match("%d+$")
-    end
     WeakAuras.ScanEventsInternal(event_list, event, arg1, arg2, ...);
   end
   Private.StopProfileSystem("generictrigger " .. orgEvent )

--- a/WeakAuras/GenericTrigger.lua
+++ b/WeakAuras/GenericTrigger.lua
@@ -772,7 +772,7 @@ function WeakAuras.ScanEventsInternalToCustom(id, triggernum)
         local updatedTriggerStates = WeakAuras.GetTriggerStateForTrigger(id, triggernum)
         local allstates = WeakAuras.GetTriggerStateForTrigger(id, requestingTrigger)
         if data and allstates and updatedTriggerStates then
-          if RunTriggerFunc(allstates, data, id, requestingTrigger, "TRIGGER:"..triggernum, updatedTriggerStates) then
+          if RunTriggerFunc(allstates, data, id, requestingTrigger, "TRIGGER", triggernum, updatedTriggerStates) then
             updateTriggerState = true
           end
         end
@@ -936,6 +936,9 @@ function GenericTrigger.UnloadDisplays(toUnload)
         auras[id] = nil;
       end
     end
+    if trigger_to_custom_events[id] then
+      trigger_to_custom_events[id] = nil
+    end
     Private.UnregisterEveryFrameUpdate(id);
   end
 end
@@ -979,6 +982,9 @@ function GenericTrigger.Rename(oldid, newid)
       auras[oldid] = nil
     end
   end
+
+  trigger_to_custom_events[newid] = trigger_to_custom_events[oldid]
+  trigger_to_custom_events[oldid] = nil
 
   Private.EveryFrameUpdateRename(oldid, newid)
 end

--- a/WeakAuras/GenericTrigger.lua
+++ b/WeakAuras/GenericTrigger.lua
@@ -764,7 +764,6 @@ end
 function WeakAuras.ScanEventsInternalToCustom(id, triggernum)
   Private.StartProfileAura(id);
   Private.ActivateAuraEnvironment(id);
-  local data = events and events[id] and events[id][triggernum]
   local updateTriggerState = false
   if trigger_to_custom_events[id] and trigger_to_custom_events[id][triggernum] then
     for requestingTrigger, bool in pairs(trigger_to_custom_events[id][triggernum]) do

--- a/WeakAuras/GenericTrigger.lua
+++ b/WeakAuras/GenericTrigger.lua
@@ -761,18 +761,19 @@ function WeakAuras.ScanEventsInternal(event_list, event, arg1, arg2, ... )
   end
 end
 
-function Private.ScanEventsWatchedTrigger(id, triggernum)
+function Private.ScanEventsWatchedTrigger(id, watchedTriggernums)
   Private.StartProfileAura(id);
   Private.ActivateAuraEnvironment(id);
   local updateTriggerState = false
-  if watched_trigger_events[id] and watched_trigger_events[id][triggernum] then
-    local updatedTriggerStates = WeakAuras.GetTriggerStateForTrigger(id, triggernum)
-    for requestingTrigger, bool in pairs(watched_trigger_events[id][triggernum]) do
-      if bool then
-        local data = events and events[id] and events[id][requestingTrigger]
-        local allstates = WeakAuras.GetTriggerStateForTrigger(id, requestingTrigger)
+
+  for _, wathcedTrigger in ipairs(watchedTriggernums) do
+    if watched_trigger_events[id] and watched_trigger_events[id][wathcedTrigger] then
+      local updatedTriggerStates = WeakAuras.GetTriggerStateForTrigger(id, wathcedTrigger)
+      for observerTrigger in pairs(watched_trigger_events[id][wathcedTrigger]) do
+        local data = events and events[id] and events[id][observerTrigger]
+        local allstates = WeakAuras.GetTriggerStateForTrigger(id, observerTrigger)
         if data and allstates and updatedTriggerStates then
-          if RunTriggerFunc(allstates, data, id, requestingTrigger, "TRIGGER", triggernum, updatedTriggerStates) then
+          if RunTriggerFunc(allstates, data, id, observerTrigger, "TRIGGER", wathcedTrigger, updatedTriggerStates) then
             updateTriggerState = true
           end
         end
@@ -935,9 +936,6 @@ function GenericTrigger.UnloadDisplays(toUnload)
       for eventname, auras in pairs(events) do
         auras[id] = nil;
       end
-    end
-    if watched_trigger_events[id] then
-      watched_trigger_events[id] = nil
     end
     Private.UnregisterEveryFrameUpdate(id);
   end

--- a/WeakAuras/GenericTrigger.lua
+++ b/WeakAuras/GenericTrigger.lua
@@ -756,8 +756,8 @@ function WeakAuras.ScanEventsInternal(event_list, event, arg1, arg2, ... )
     if (updateTriggerState) then
       Private.UpdatedTriggerState(id);
     end
-    Private.StartProfileAura(id);
-    Private.ActivateAuraEnvironment(id);
+    Private.StopProfileAura(id);
+    Private.ActivateAuraEnvironment(nil);
   end
 end
 
@@ -783,8 +783,8 @@ function WeakAuras.ScanEventsInternalToCustom(id, triggernum)
   if (updateTriggerState) then
     Private.UpdatedTriggerState(id)
   end
-  Private.StartProfileAura(id)
-  Private.ActivateAuraEnvironment(id)
+  Private.StopProfileAura(id)
+  Private.ActivateAuraEnvironment(nil)
 end
 
 local function AddFakeTime(state)

--- a/WeakAuras/GenericTrigger.lua
+++ b/WeakAuras/GenericTrigger.lua
@@ -777,7 +777,7 @@ function WeakAuras.ScanEventsInternalToCustom(id, triggernum)
         local updatedTriggerStates = WeakAuras.GetTriggerStateForTrigger(id, triggernum)
         local allstates = WeakAuras.GetTriggerStateForTrigger(id, requestingTrigger)
         if data and allstates and updatedTriggerStates then
-          if RunTriggerFunc(allStates, data, id, requestingTrigger, "TRIGGER:"..triggernum, updatedTriggerStates) then
+          if RunTriggerFunc(allstates, data, id, requestingTrigger, "TRIGGER:"..triggernum, updatedTriggerStates) then
             updateTriggerState = true
           end
         end

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -4021,11 +4021,16 @@ end
 -- we need the id and triggernum that's changing, but can't send the ScanEvents to the custom trigger until after UpdatedTriggerState has fired
 local trigger_to_custom_delayed = {}
 function Private.AddToTriggerToCustomDelay(id, triggernum)
-  trigger_to_custom_delayed[id] = triggernum
+  trigger_to_custom_delayed[id] = trigger_to_custom_delayed[id] or {}
+  tinsert(trigger_to_custom_delayed[id], triggernum)
 end
 function Private.SendDelayedTriggerToCustom()
-  for id,triggernum in pairs(trigger_to_custom_delayed) do
-    WeakAuras.ScanEventsInternalToCustom(id, triggernum)
+  for id,triggernums in pairs(trigger_to_custom_delayed) do
+    for i = #triggernums, 1, -1 do
+      local triggernum = triggernums[i]
+      tremove(triggernums, i)
+      Private.ScanEventsInternalToCustom(id, triggernum)
+    end
   end
   wipe(trigger_to_custom_delayed)
 end

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -33,7 +33,7 @@ LibStub("AceTimer-3.0"):Embed(WeakAurasTimers)
 Private.maxTimerDuration = 604800; -- A week, in seconds
 local maxUpTime = 4294967; -- 2^32 / 1000
 
-Private.TTC_events = {} -- trigger to custom
+Private.trigger_to_custom_events = {} -- trigger to custom
 
 -- The worlds simplest callback system.
 -- That supports 1:N, but no deregistration and breaks if registrating in a callback
@@ -4019,15 +4019,15 @@ end
 
 -- handle trigger updates that have been requested to be sent into custom
 -- we need the id and triggernum that's changing, but can't send the ScanEvents to the custom trigger until after UpdatedTriggerState has fired
-local TTC_Queue = {}
-function Private.AddTriggerToCustomQueue(id, triggernum)
-  TTC_Queue[id] = triggernum
+local trigger_to_custom_delayed = {}
+function Private.AddToTriggerToCustomDelay(id, triggernum)
+  trigger_to_custom_delayed[id] = triggernum
 end
-function Private.SendQueuedTriggers()
-  for id,triggernum in pairs(TTC_Queue) do
-    WeakAuras.ScanEvents("WA_TRIGGER_"..id.."_"..triggernum, triggerState[id][triggernum])
+function Private.SendDelayedTriggerToCustom()
+  for id,triggernum in pairs(trigger_to_custom_delayed) do
+    WeakAuras.ScanEventsInternalToCustom(id, triggernum)
   end
-  wipe(TTC_Queue)
+  wipe(trigger_to_custom_delayed)
 end
 
 function Private.UpdatedTriggerState(id)
@@ -4133,7 +4133,7 @@ function Private.UpdatedTriggerState(id)
     end
   end
   -- once updatedTriggerStates is complete, and empty states removed, etc., then check for queued trigger_to_custom updates
-  Private.SendQueuedTriggers()
+  Private.SendDelayedTriggerToCustom()
 end
 
 function Private.RunCustomTextFunc(region, customFunc)

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -33,6 +33,8 @@ LibStub("AceTimer-3.0"):Embed(WeakAurasTimers)
 Private.maxTimerDuration = 604800; -- A week, in seconds
 local maxUpTime = 4294967; -- 2^32 / 1000
 
+Private.TTC_events = {} -- trigger to custom
+
 -- The worlds simplest callback system.
 -- That supports 1:N, but no deregistration and breaks if registrating in a callback
 Private.callbacks = {}
@@ -4017,15 +4019,15 @@ end
 
 -- handle trigger updates that have been requested to be sent into custom
 -- we need the id and triggernum that's changing, but can't send the ScanEvents to the custom trigger until after UpdatedTriggerState has fired
-local trigger_to_custom_Queue = {}
+local TTC_Queue = {}
 function Private.AddTriggerToCustomQueue(id, triggernum)
-  trigger_to_custom_Queue[id] = triggernum
+  TTC_Queue[id] = triggernum
 end
 function Private.SendQueuedTriggers()
-  for id,triggernum in pairs(trigger_to_custom_Queue) do
+  for id,triggernum in pairs(TTC_Queue) do
     WeakAuras.ScanEvents("WA_TRIGGER_"..id.."_"..triggernum, triggerState[id][triggernum])
   end
-  trigger_to_custom_Queue = {}
+  wipe(TTC_Queue)
 end
 
 function Private.UpdatedTriggerState(id)

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -33,7 +33,7 @@ LibStub("AceTimer-3.0"):Embed(WeakAurasTimers)
 Private.maxTimerDuration = 604800; -- A week, in seconds
 local maxUpTime = 4294967; -- 2^32 / 1000
 
-Private.watched_trigger_events = {} -- trigger to custom
+Private.watched_trigger_events = {}
 
 -- The worlds simplest callback system.
 -- That supports 1:N, but no deregistration and breaks if registrating in a callback
@@ -4024,15 +4024,15 @@ function Private.AddToWatchedTriggerDelay(id, triggernum)
   delayed_watched_trigger[id] = delayed_watched_trigger[id] or {}
   tinsert(delayed_watched_trigger[id], triggernum)
 end
+
 function Private.SendDelayedWatchedTriggers()
-  for id,triggernums in pairs(delayed_watched_trigger) do
-    for i = #triggernums, 1, -1 do
-      local triggernum = triggernums[i]
-      tremove(triggernums, i)
-      Private.ScanEventsWatchedTrigger(id, triggernum)
-    end
+  for id in pairs(delayed_watched_trigger) do
+    local watched = delayed_watched_trigger[id]
+    -- Since the observers are themselves observable, we set the list of observers to
+    -- empty here.
+    delayed_watched_trigger[id] = {}
+    Private.ScanEventsWatchedTrigger(id, watched)
   end
-  wipe(delayed_watched_trigger)
 end
 
 function Private.UpdatedTriggerState(id)

--- a/WeakAurasOptions/GenericTrigger.lua
+++ b/WeakAurasOptions/GenericTrigger.lua
@@ -122,9 +122,9 @@ local function GetCustomTriggerOptions(data, triggernum)
             elseif trueEvent == "TRIGGER" then
               local requestedTriggernum = tonumber(i)
               if requestedTriggernum then
-                if OptionsPrivate.Private.trigger_to_custom_events[data.id]
-                and OptionsPrivate.Private.trigger_to_custom_events[data.id][triggernum]
-                and OptionsPrivate.Private.trigger_to_custom_events[data.id][triggernum][requestedTriggernum] then
+                if OptionsPrivate.Private.watched_trigger_events[data.id]
+                and OptionsPrivate.Private.watched_trigger_events[data.id][triggernum]
+                and OptionsPrivate.Private.watched_trigger_events[data.id][triggernum][requestedTriggernum] then
                   return "|cFFFF0000"..L["Reciprocal trigger requests will be ignored!"]
                 end
               end
@@ -162,9 +162,9 @@ local function GetCustomTriggerOptions(data, triggernum)
             elseif trueEvent == "TRIGGER" then
               local requestedTriggernum = tonumber(i)
               if requestedTriggernum then
-                if OptionsPrivate.Private.trigger_to_custom_events[data.id]
-                and OptionsPrivate.Private.trigger_to_custom_events[data.id][triggernum]
-                and OptionsPrivate.Private.trigger_to_custom_events[data.id][triggernum][requestedTriggernum] then
+                if OptionsPrivate.Private.watched_trigger_events[data.id]
+                and OptionsPrivate.Private.watched_trigger_events[data.id][triggernum]
+                and OptionsPrivate.Private.watched_trigger_events[data.id][triggernum][requestedTriggernum] then
                   return false
                 end
               end

--- a/WeakAurasOptions/GenericTrigger.lua
+++ b/WeakAurasOptions/GenericTrigger.lua
@@ -119,6 +119,15 @@ local function GetCustomTriggerOptions(data, triggernum)
               if not OptionsPrivate.Private.baseUnitId[unit] and not OptionsPrivate.Private.multiUnitId[unit] then
                 return "|cFFFF0000"..L["Unit %s is not a valid unit for RegisterUnitEvent"]:format(unit)
               end
+            elseif trueEvent == "TRIGGER" then
+              local requestedTriggernum = tonumber(i)
+              if requestedTriggernum then
+                if OptionsPrivate.Private.trigger_to_custom_events[data.id]
+                and OptionsPrivate.Private.trigger_to_custom_events[data.id][triggernum]
+                and OptionsPrivate.Private.trigger_to_custom_events[data.id][triggernum][requestedTriggernum] then
+                  return "|cFFFF0000"..L["Reciprocal trigger requests will be ignored!"]
+                end
+              end
             end
           end
         end
@@ -149,6 +158,15 @@ local function GetCustomTriggerOptions(data, triggernum)
               local unit = string.lower(i)
               if not OptionsPrivate.Private.baseUnitId[unit] then
                 return false
+              end
+            elseif trueEvent == "TRIGGER" then
+              local requestedTriggernum = tonumber(i)
+              if requestedTriggernum then
+                if OptionsPrivate.Private.trigger_to_custom_events[data.id]
+                and OptionsPrivate.Private.trigger_to_custom_events[data.id][triggernum]
+                and OptionsPrivate.Private.trigger_to_custom_events[data.id][triggernum][requestedTriggernum] then
+                  return false
+                end
               end
             end
           end

--- a/WeakAurasOptions/GenericTrigger.lua
+++ b/WeakAurasOptions/GenericTrigger.lua
@@ -125,7 +125,7 @@ local function GetCustomTriggerOptions(data, triggernum)
                 if OptionsPrivate.Private.watched_trigger_events[data.id]
                 and OptionsPrivate.Private.watched_trigger_events[data.id][triggernum]
                 and OptionsPrivate.Private.watched_trigger_events[data.id][triggernum][requestedTriggernum] then
-                  return "|cFFFF0000"..L["Reciprocal trigger requests will be ignored!"]
+                  return "|cFFFF0000"..L["Reciprocal TRIGGER:# requests will be ignored!"]
                 end
               end
             end

--- a/WeakAurasOptions/Locales/enUS.lua
+++ b/WeakAurasOptions/Locales/enUS.lua
@@ -106,19 +106,26 @@ L["Crusader"] = "Crusader"
 L["Custom Code"] = "Custom Code"
 L["Custom Trigger"] = "Custom Trigger"
 L["Custom trigger event tooltip"] = [=[
-Choose which events cause the custom trigger to be checked.
-Multiple events can be specified using commas or spaces.
+Choose which events cause the custom trigger to be checked. Multiple events can be specified using commas or spaces.
+
+• "UNIT" events can use colons to define which unitIDs will be registered. In addition to UnitIDs Unit types can be used, they include "nameplate", "group", "raid", "party", "arena", "boss".
+• "CLEU" can be used instead of COMBAT_LOG_EVENT_UNFILTERED and colons can be used to separate specific "subEvents" you want to recieve.
+• The keyword "TRIGGER" can be used, with colons separating trigger numbers, to have the custom trigger get updated when the specified trigger(s) update.
 
 |cFF4444FFFor example:|r
-UNIT_POWER_UPDATE, UNIT_AURA PLAYER_TARGET_CHANGED
+UNIT_POWER_UPDATE:player, UNIT_AURA:nameplate:group PLAYER_TARGET_CHANGED CLEU:SPELL_CAST_SUCCESS TRIGGER:3:1
 ]=]
 L["Custom trigger status tooltip"] = [=[
-Choose which events cause the custom trigger to be checked.
+Choose which events cause the custom trigger to be checked. Multiple events can be specified using commas or spaces.
+
+• "UNIT" events can use colons to define which unitIDs will be registered. In addition to UnitIDs Unit types can be used, they include "nameplate", "group", "raid", "party", "arena", "boss".
+• "CLEU" can be used instead of COMBAT_LOG_EVENT_UNFILTERED and colons can be used to separate specific "subEvents" you want to recieve.
+• The keyword "TRIGGER" can be used, with colons separating trigger numbers, to have the custom trigger get updated when the specified trigger(s) update.
+
 Since this is a status-type trigger, the specified events may be called by WeakAuras without the expected arguments.
-Multiple events can be specified using commas or spaces.
 
 |cFF4444FFFor example:|r
-UNIT_POWER_UPDATE, UNIT_AURA PLAYER_TARGET_CHANGED
+UNIT_POWER_UPDATE:player, UNIT_AURA:nameplate:group PLAYER_TARGET_CHANGED CLEU:SPELL_CAST_SUCCESS TRIGGER:3:1
 ]=]
 L["Custom Untrigger"] = "Custom Untrigger"
 L["Custom untrigger event tooltip"] = [=[


### PR DESCRIPTION
# Description

When triggers are added catch the format "TRIGGER:#" where `#` is a trigger number and flag those triggers. On trigger updates, check for the flag and send a ScanEvents into the custom trigger that requested them, along with that trigger's allstates

This needs thorough testing but I wanted to get opinions (and some more people trying to find ways to break it)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Checklist
<!-- These can be checked off after the pull request is submitted, in case you want discussion before they are completely ready -->

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

<!-- Is there any additional work that needs to be done? If so, add it to the above list -->
