### PR TITLE
Fixes loss of mouse control in code editbox

### DIFF
--- a/WeakAurasOptions/OptionsFrames/TextEditor.lua
+++ b/WeakAurasOptions/OptionsFrames/TextEditor.lua
@@ -188,9 +188,8 @@ local function ConstructTextEditor(frame)
   -- Fixes a ACEGUI issue where HitRectInsets are not reset in some cases
   -- Causing inability to use the mouse to select any text.
   editor.editBox:HookScript("OnHide",function(self)
-    self:SetHitRectInsets(0,0,0,0);
-  end);
-
+    self:SetHitRectInsets(0,0,0,0)
+  end)
 
   -- The indention lib overrides GetText, but for the line number
   -- display we ned the original, so save it here.

--- a/WeakAurasOptions/OptionsFrames/TextEditor.lua
+++ b/WeakAurasOptions/OptionsFrames/TextEditor.lua
@@ -185,6 +185,13 @@ local function ConstructTextEditor(frame)
     originalOnCursorChanged(self, ...)
   end)
 
+  -- Fixes a ACEGUI issue where HitRectInsets are not reset in some cases
+  -- Causing inability to use the mouse to select any text.
+  editor.editBox:HookScript("OnHide",function(self)
+    self:SetHitRectInsets(0,0,0,0);
+  end);
+
+
   -- The indention lib overrides GetText, but for the line number
   -- display we ned the original, so save it here.
   local originalGetText = editor.editBox.GetText


### PR DESCRIPTION
## Description
Fixes a dreaded problem where script editbox stops behaving.
Resulting in inability to select any text with the mouse cursor.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested
To replicate this bug you do the following:

1. Open a WA code field that has a longish editbox
2. Scroll down that editbox
3. Close the editbox
4. Reopen that same code field but don't scroll
5. Open any code field that DOESENT have the scrollbar enabled
6. ???
7. Profit

Root cause of the problem is that in some cases HitRectInsets is not reset.
