### PR TITLE
Fix an error on SetTextureOrAtlas behavior

### DIFF
--- a/WeakAuras/RegionTypes/RegionPrototype.lua
+++ b/WeakAuras/RegionTypes/RegionPrototype.lua
@@ -979,15 +979,11 @@ function WeakAuras.SetTextureOrAtlas(texture, path, wrapModeH, wrapModeV)
   if type(path) == "string" and GetAtlasInfo(path) then
     return texture:SetAtlas(path);
   else
-    local needToClear = true
     if (texture.wrapModeH and texture.wrapModeH ~= wrapModeH) or (texture.wrapModeV and texture.wrapModeV ~= wrapModeV) then
-      needToClear = true
+      texture:SetTexture(nil)
     end
     texture.wrapModeH = wrapModeH
     texture.wrapModeV = wrapModeV
-    if needToClear then
-      texture:SetTexture(nil)
-    end
     return texture:SetTexture(path, wrapModeH, wrapModeV);
   end
 end


### PR DESCRIPTION
# Description

Spot an error with `needToClear` initialised as `true` in place of `false` making the if unconsequential.
Also remove `needToClear` variable and put the `texture:SetTexture(nil)` directly inside the if as the assignation of  `wrapModeH` and `wrapModeV` to `texture` can occure after the `texture:SetTexture(nil)` making `needToClear` unnecessary.

The error seem to come from the following commit, when the function has been moved from ProgressTexture.lua to RegionPrototype.lua:
https://github.com/hexaheart/WeakAuras2/commit/a9ef1ff9c2a81d32f078c17c89bebd324b9d281d#diff-1b4576ed275670b486caa9bee1dc9c714518abe2f0017a5be16da9479b3a1f17L704

For the checklist:
I did not make any comment as the changes are quite modest.
I don't think the changes imply a documentation change.
Not sure what kind of warning is involved here, did not get lua error in-game.


Motivation and Context (not quite sure what I'm supposed to say here, can be ignored if it feel irrelevant)  :
Put at profit the remaining time before 10.0 to get more acquainted with wow API and lua in general.
As i like playing around with Weakauras it was a natural choice to go there and take a look under the hood.
I may put more pull request in the future (no promises though), don't hesitate to point out if I miss something, what I can change to make pull request esier on your side or if you want me to go in deep into something to have a fresh view on it (reminder I'm new to lua, not to programming and working with others though).

<!-- A #ticketNumber will be sufficient. -->
Fixes # none

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

 - [ ] Replace the function inside AddOns\WeakAuras\RegionTypes\RegionPrototype.lua
 - [ ] Made a weakaura that cycle through wrap mode (switch when player start moving) https://wago.io/yiPvIhd4X

## Checklist
<!-- These can be checked off after the pull request is submitted, in case you want discussion before they are completely ready -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

<!-- Is there any additional work that needs to be done? If so, add it to the above list -->
