### PR TITLE
Adds font size setting for code editor

### DIFF
--- a/WeakAurasOptions/OptionsFrames/TextEditor.lua
+++ b/WeakAurasOptions/OptionsFrames/TextEditor.lua
@@ -315,7 +315,7 @@ local function ConstructTextEditor(frame)
         level)
       end
     elseif menu == "sizes" then
-      local sizes = {12,14,16,18,20,22,24}
+      local sizes = {10, 12, 14, 16}
       for _, i in pairs(sizes) do
         UIDropDownMenu_AddButton(
           {

--- a/WeakAurasOptions/OptionsFrames/TextEditor.lua
+++ b/WeakAurasOptions/OptionsFrames/TextEditor.lua
@@ -55,6 +55,7 @@ local editor_themes = {
 }
 
 if not WeakAurasSaved.editor_tab_spaces then WeakAurasSaved.editor_tab_spaces = 4 end
+if not WeakAurasSaved.editor_font_size then WeakAurasSaved.editor_font_size = 12 end -- set default font size if missing
 local color_scheme = {[0] = "|r"}
 local function set_scheme()
   if not WeakAurasSaved.editor_theme then
@@ -168,7 +169,7 @@ local function ConstructTextEditor(frame)
   editor:DisableButton(true)
   local fontPath = SharedMedia:Fetch("font", "Fira Mono Medium")
   if (fontPath) then
-    editor.editBox:SetFont(fontPath, 12)
+    editor.editBox:SetFont(fontPath, WeakAurasSaved.editor_font_size)
   end
   group:AddChild(editor)
   editor.frame:SetClipsChildren(true)
@@ -286,6 +287,14 @@ local function ConstructTextEditor(frame)
           menuList = "spaces"
         },
       level)
+      UIDropDownMenu_AddButton(
+        {
+          text = WeakAuras.newFeatureString .. L["Font Size"],
+          hasArrow = true,
+          notCheckable = true,
+          menuList = "sizes"
+        },
+      level)
     elseif menu == "spaces" then
       local spaces = {2,4}
       for _, i in pairs(spaces) do
@@ -301,6 +310,23 @@ local function ConstructTextEditor(frame)
               IndentationLib.enable(editor.editBox, color_scheme, WeakAurasSaved.editor_tab_spaces)
               editor.editBox:SetText(editor.editBox:GetText().."\n")
               IndentationLib.indentEditbox(editor.editBox)
+            end
+          },
+        level)
+      end
+    elseif menu == "sizes" then
+      local sizes = {12,14,16,18,20,22,24}
+      for _, i in pairs(sizes) do
+        UIDropDownMenu_AddButton(
+          {
+            text = i,
+            isNotRadio = false,
+            checked = function()
+              return WeakAurasSaved.editor_font_size == i
+            end,
+            func = function()
+              WeakAurasSaved.editor_font_size = i
+              editor.editBox:SetFont(fontPath, WeakAurasSaved.editor_font_size)
             end
           },
         level)


### PR DESCRIPTION
# Description

Edited to incorporate feedback.

Adds a dropdown menue in the "Settings" button, allowing for the font size in the code editor to change. Starting from the default 12, up to 24, increasing by 2 each time.

There are no additional dependencies added. 

I did this because I asked a question in the Discord channel and was advised to open an issue requesting the feature. I started playing around with a group sorting function last night as I didn't find what I wanted. I found that I had a lot of fun making it. Today I wasn't particularly busy and decided to try my hand at actually implementing it as I've never contributed to an open source project before. 

I appreciate any feedback, I've probably made some mistakes as this is my first time.

Here is a preview:

![PgdTW9y](https://user-images.githubusercontent.com/27210954/185181072-6c6fc801-2d84-477a-b0f1-729182392ade.png)

<!-- A #ticketNumber will be sufficient. -->
Fixes #3742

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested

I have tested this out in-game. The tests were simple. I changed the font size to see if it was working. I also reloaded to see if it would get saved as it wouldn't be very appealing if it reset after reloading the UI or restarting the game, etc. It's only had manual testing. I'm not familiar with any other way to test addons. 

## Checklist
<!-- These can be checked off after the pull request is submitted, in case you want discussion before they are completely ready -->

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

<!-- Is there any additional work that needs to be done? If so, add it to the above list -->