### PR TITLE
Add raid marks as a text replacement on combat log triggers

### DIFF
--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -136,6 +136,10 @@ function WeakAuras.TestSchool(spellSchool, test)
   return spellSchool == test
 end
 
+function WeakAuras.RaidFlagToIndex(flag)
+  return Private.combatlog_raidFlags[flag] or 0
+end
+
 local function get_zoneId_list()
   if WeakAuras.IsClassic() then return "" end
   local currentmap_id = C_Map.GetBestMapForUnit("player")
@@ -3455,6 +3459,22 @@ Private.event_prototypes = {
         end
       },
       {
+        name = "sourceRaidMarkIndex",
+        display = L["Source Raid Mark Index"],
+        init = "WeakAuras.RaidFlagToIndex(sourceRaidFlags)",
+        test = "true",
+        store = true,
+        hidden = true,
+      },
+      {
+        name = "sourceRaidMark",
+        display = L["Source Raid Mark"],
+        test = "true",
+        init = "sourceRaidMarkIndex > 0 and '{rt'..sourceRaidMarkIndex..'}' or ''",
+        store = true,
+        hidden = true,
+      },
+      {
         name = "destGUID",
         init = "arg",
         hidden = "true",
@@ -3571,6 +3591,22 @@ Private.event_prototypes = {
         enable = function(trigger)
           return (trigger.subeventPrefix == "SPELL" and trigger.subeventSuffix == "_CAST_START");
         end
+      },
+      {
+        name = "destRaidMarkIndex",
+        display = L["Dest Raid Mark Index"],
+        init = "WeakAuras.RaidFlagToIndex(destRaidFlags)",
+        test = "true",
+        store = true,
+        hidden = true,
+      },
+      {
+        name = "destRaidMark",
+        display = L["Dest Raid Mark"],
+        test = "true",
+        init = "destRaidMarkIndex > 0 and '{rt'..destRaidMarkIndex..'}' or ''",
+        store = true,
+        hidden = true,
       },
       {
         name = "spellId",

--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -3460,7 +3460,7 @@ Private.event_prototypes = {
       },
       {
         name = "sourceRaidMarkIndex",
-        display = L["Source Raid Mark Index"],
+        display = WeakAuras.newFeatureString .. L["Source Raid Mark Index"],
         init = "WeakAuras.RaidFlagToIndex(sourceRaidFlags)",
         test = "true",
         store = true,
@@ -3468,7 +3468,7 @@ Private.event_prototypes = {
       },
       {
         name = "sourceRaidMark",
-        display = L["Source Raid Mark"],
+        display = WeakAuras.newFeatureString .. L["Source Raid Mark"],
         test = "true",
         init = "sourceRaidMarkIndex > 0 and '{rt'..sourceRaidMarkIndex..'}' or ''",
         store = true,
@@ -3594,7 +3594,7 @@ Private.event_prototypes = {
       },
       {
         name = "destRaidMarkIndex",
-        display = L["Dest Raid Mark Index"],
+        display = WeakAuras.newFeatureString .. L["Dest Raid Mark Index"],
         init = "WeakAuras.RaidFlagToIndex(destRaidFlags)",
         test = "true",
         store = true,
@@ -3602,7 +3602,7 @@ Private.event_prototypes = {
       },
       {
         name = "destRaidMark",
-        display = L["Dest Raid Mark"],
+        display = WeakAuras.newFeatureString .. L["Dest Raid Mark"],
         test = "true",
         init = "destRaidMarkIndex > 0 and '{rt'..destRaidMarkIndex..'}' or ''",
         store = true,

--- a/WeakAuras/Types.lua
+++ b/WeakAuras/Types.lua
@@ -1314,6 +1314,18 @@ Private.combatlog_raid_mark_check_type = {
   L["Any"]
 }
 
+Private.combatlog_raidFlags = {
+  [0] = 0,
+  [1] = 1,
+  [2] = 2,
+  [4] = 3,
+  [8] = 4,
+  [16] = 5,
+  [32] = 6,
+  [64] = 7,
+  [128] = 8,
+}
+
 Private.raid_mark_check_type = CopyTable(Private.combatlog_raid_mark_check_type)
 Private.raid_mark_check_type[9] = nil
 


### PR DESCRIPTION
# Description

Combat log triggers have a raidFlags value that doesn't directly translate to a raidTargetIndex, meaning custom text functions would be needed for someone to show source/dest raid markers on a combat log trigger.  This PR provides and index value as well as a formatted "{rt}" text replacement. 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Checklist
<!-- These can be checked off after the pull request is submitted, in case you want discussion before they are completely ready -->

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

<!-- Is there any additional work that needs to be done? If so, add it to the above list -->
