### PR TITLE
Add raid marks to combatlog trigger

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -2958,6 +2958,7 @@ globals = {
 	"IsWorldQuestWatched",
 	"IsXPUserDisabled",
 	"IsZoomOutAvailable",
+	"Item",
 	"ItemAddedToArtifact",
 	"ItemCanTargetGarrisonFollowerAbility",
 	"ItemHasRange",

--- a/WeakAuras/GenericTrigger.lua
+++ b/WeakAuras/GenericTrigger.lua
@@ -4206,6 +4206,17 @@ WeakAuras.GetBonusIdInfo = function(ids, specificSlot)
   end
 end
 
+WeakAuras.CheckForItemEquipped = function(itemName, specificSlot)
+  if not specificSlot then
+    return IsEquippedItem(itemName)
+  else
+    local item = Item:CreateFromEquipmentSlot(specificSlot)
+    if item and not item:IsItemEmpty() then
+      return itemName == item:GetItemName()
+    end
+  end
+end
+
 WeakAuras.GetItemSubClassInfo = function(i)
   local subClassId = i % 256
   local classId = (i - subClassId) / 256

--- a/WeakAuras/GenericTrigger.lua
+++ b/WeakAuras/GenericTrigger.lua
@@ -1476,9 +1476,9 @@ do
       update_frame = CreateFrame("Frame");
     end
     if not(updating) then
-      update_frame:SetScript("OnUpdate", function()
+      update_frame:SetScript("OnUpdate", function(self, elapsed)
         if not(WeakAuras.IsPaused()) then
-          WeakAuras.ScanEvents("FRAME_UPDATE");
+          WeakAuras.ScanEvents("FRAME_UPDATE", elapsed);
         end
       end);
       updating = true;

--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -3451,7 +3451,6 @@ Private.event_prototypes = {
         type = "select",
         values = "combatlog_raid_mark_check_type",
         init = "arg",
-        store = true,
         test = "WeakAuras.CheckRaidFlags(sourceRaidFlags, %q)",
         conditionType = "select",
         conditionTest = function(state, needle)
@@ -3459,18 +3458,18 @@ Private.event_prototypes = {
         end
       },
       {
-        name = "sourceRaidMarkIndex",
-        display = WeakAuras.newFeatureString .. L["Source Raid Mark Index"],
+        name = "sourceMarkIndex",
+        display = WeakAuras.newFeatureString .. L["Source unit's raid mark index"],
         init = "WeakAuras.RaidFlagToIndex(sourceRaidFlags)",
         test = "true",
         store = true,
         hidden = true,
       },
       {
-        name = "sourceRaidMark",
-        display = WeakAuras.newFeatureString .. L["Source Raid Mark"],
+        name = "sourceMarkTexture",
+        display = WeakAuras.newFeatureString .. L["Source unit's raid mark texture"],
         test = "true",
-        init = "sourceRaidMarkIndex > 0 and '{rt'..sourceRaidMarkIndex..'}' or ''",
+        init = "sourceMarkIndex > 0 and '{rt'..sourceMarkIndex..'}' or ''",
         store = true,
         hidden = true,
       },
@@ -3577,7 +3576,6 @@ Private.event_prototypes = {
         type = "select",
         values = "combatlog_raid_mark_check_type",
         init = "arg",
-        store = true,
         test = "WeakAuras.CheckRaidFlags(destRaidFlags, %q)",
         conditionType = "select",
         conditionTest = function(state, needle)
@@ -3593,20 +3591,26 @@ Private.event_prototypes = {
         end
       },
       {
-        name = "destRaidMarkIndex",
-        display = WeakAuras.newFeatureString .. L["Dest Raid Mark Index"],
+        name = "destMarkIndex",
+        display = WeakAuras.newFeatureString .. L["Destination unit's raid mark index"],
         init = "WeakAuras.RaidFlagToIndex(destRaidFlags)",
         test = "true",
         store = true,
         hidden = true,
+        enable = function(trigger)
+          return not (trigger.subeventPrefix == "SPELL" and trigger.subeventSuffix == "_CAST_START");
+        end,
       },
       {
-        name = "destRaidMark",
-        display = WeakAuras.newFeatureString .. L["Dest Raid Mark"],
+        name = "destMarkTexture",
+        display = WeakAuras.newFeatureString .. L["Destination unit's raid mark texture"],
         test = "true",
-        init = "destRaidMarkIndex > 0 and '{rt'..destRaidMarkIndex..'}' or ''",
+        init = "destMarkIndex > 0 and '{rt'..destMarkIndex..'}' or ''",
         store = true,
         hidden = true,
+        enable = function(trigger)
+          return not (trigger.subeventPrefix == "SPELL" and trigger.subeventSuffix == "_CAST_START");
+        end,
       },
       {
         name = "spellId",

--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -136,6 +136,10 @@ function WeakAuras.TestSchool(spellSchool, test)
   return spellSchool == test
 end
 
+function WeakAuras.RaidFlagToIndex(flag)
+  return Private.combatlog_raidFlags[flag] or 0
+end
+
 local function get_zoneId_list()
   if WeakAuras.IsClassic() then return "" end
   local currentmap_id = C_Map.GetBestMapForUnit("player")
@@ -3455,6 +3459,22 @@ Private.event_prototypes = {
         end
       },
       {
+        name = "sourceRaidMarkIndex",
+        display = L["Source Raid Mark Index"],
+        init = "WeakAuras.RaidFlagToIndex(sourceRaidFlags)",
+        test = "true",
+        store = true,
+        hidden = true,
+      },
+      {
+        name = "sourceRaidMark",
+        display = L["Source Raid Mark"],
+        test = "true",
+        init = "sourceRaidMarkIndex > 0 and '{rt'..sourceRaidMarkIndex..'}' or ''",
+        store = true,
+        hidden = true,
+      },
+      {
         name = "destGUID",
         init = "arg",
         hidden = "true",
@@ -3571,6 +3591,22 @@ Private.event_prototypes = {
         enable = function(trigger)
           return (trigger.subeventPrefix == "SPELL" and trigger.subeventSuffix == "_CAST_START");
         end
+      },
+      {
+        name = "destRaidMarkIndex",
+        display = L["Dest Raid Mark Index"],
+        init = "WeakAuras.RaidFlagToIndex(destRaidFlags)",
+        test = "true",
+        store = true,
+        hidden = true,
+      },
+      {
+        name = "destRaidMark",
+        display = L["Dest Raid Mark"],
+        test = "true",
+        init = "destRaidMarkIndex > 0 and '{rt'..destRaidMarkIndex..'}' or ''",
+        store = true,
+        hidden = true,
       },
       {
         name = "spellId",

--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -7095,10 +7095,12 @@ Private.event_prototypes = {
 
       local ret = [[
         local inverse = %s;
-        local equipped = IsEquippedItem(GetItemInfo(%s));
+        local itemName = GetItemInfo(%s);
+        local itemSlot = %s;
+        local equipped = WeakAuras.CheckForItemEquipped(itemName, itemSlot);
       ]];
 
-      return ret:format(trigger.use_inverse and "true" or "false", itemName);
+      return ret:format(trigger.use_inverse and "true" or "false", itemName, trigger.use_itemSlot and trigger.itemSlot or "nil");
     end,
     args = {
       {
@@ -7107,6 +7109,13 @@ Private.event_prototypes = {
         type = "item",
         required = true,
         test = "true"
+      },
+      {
+        name = "itemSlot",
+        display = WeakAuras.newFeatureString .. L["Item Slot"],
+        type = "select",
+        values = "item_slot_types",
+        test = "true",
       },
       {
         name = "inverse",

--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -3460,7 +3460,7 @@ Private.event_prototypes = {
       },
       {
         name = "sourceRaidMarkIndex",
-        display = L["Source Raid Mark Index"],
+        display = WeakAuras.newFeatureString .. L["Source Raid Mark Index"],
         init = "WeakAuras.RaidFlagToIndex(sourceRaidFlags)",
         test = "true",
         store = true,
@@ -3468,7 +3468,7 @@ Private.event_prototypes = {
       },
       {
         name = "sourceRaidMark",
-        display = L["Source Raid Mark"],
+        display = WeakAuras.newFeatureString .. L["Source Raid Mark"],
         test = "true",
         init = "sourceRaidMarkIndex > 0 and '{rt'..sourceRaidMarkIndex..'}' or ''",
         store = true,
@@ -3594,7 +3594,7 @@ Private.event_prototypes = {
       },
       {
         name = "destRaidMarkIndex",
-        display = L["Dest Raid Mark Index"],
+        display = WeakAuras.newFeatureString .. L["Dest Raid Mark Index"],
         init = "WeakAuras.RaidFlagToIndex(destRaidFlags)",
         test = "true",
         store = true,
@@ -3602,7 +3602,7 @@ Private.event_prototypes = {
       },
       {
         name = "destRaidMark",
-        display = L["Dest Raid Mark"],
+        display = WeakAuras.newFeatureString .. L["Dest Raid Mark"],
         test = "true",
         init = "destRaidMarkIndex > 0 and '{rt'..destRaidMarkIndex..'}' or ''",
         store = true,

--- a/WeakAuras/Types.lua
+++ b/WeakAuras/Types.lua
@@ -1314,6 +1314,18 @@ Private.combatlog_raid_mark_check_type = {
   L["Any"]
 }
 
+Private.combatlog_raidFlags = {
+  [0] = 0,
+  [1] = 1,
+  [2] = 2,
+  [4] = 3,
+  [8] = 4,
+  [16] = 5,
+  [32] = 6,
+  [64] = 7,
+  [128] = 8,
+}
+
 Private.raid_mark_check_type = CopyTable(Private.combatlog_raid_mark_check_type)
 Private.raid_mark_check_type[9] = nil
 

--- a/WeakAurasOptions/OptionsFrames/TextEditor.lua
+++ b/WeakAurasOptions/OptionsFrames/TextEditor.lua
@@ -315,7 +315,7 @@ local function ConstructTextEditor(frame)
         level)
       end
     elseif menu == "sizes" then
-      local sizes = {12,14,16,18,20,22,24}
+      local sizes = {10, 12, 14, 16}
       for _, i in pairs(sizes) do
         UIDropDownMenu_AddButton(
           {

--- a/WeakAurasOptions/OptionsFrames/TextEditor.lua
+++ b/WeakAurasOptions/OptionsFrames/TextEditor.lua
@@ -55,6 +55,7 @@ local editor_themes = {
 }
 
 if not WeakAurasSaved.editor_tab_spaces then WeakAurasSaved.editor_tab_spaces = 4 end
+if not WeakAurasSaved.editor_font_size then WeakAurasSaved.editor_font_size = 12 end -- set default font size if missing
 local color_scheme = {[0] = "|r"}
 local function set_scheme()
   if not WeakAurasSaved.editor_theme then
@@ -168,7 +169,7 @@ local function ConstructTextEditor(frame)
   editor:DisableButton(true)
   local fontPath = SharedMedia:Fetch("font", "Fira Mono Medium")
   if (fontPath) then
-    editor.editBox:SetFont(fontPath, 12)
+    editor.editBox:SetFont(fontPath, WeakAurasSaved.editor_font_size)
   end
   group:AddChild(editor)
   editor.frame:SetClipsChildren(true)
@@ -286,6 +287,14 @@ local function ConstructTextEditor(frame)
           menuList = "spaces"
         },
       level)
+      UIDropDownMenu_AddButton(
+        {
+          text = WeakAuras.newFeatureString .. L["Font Size"],
+          hasArrow = true,
+          notCheckable = true,
+          menuList = "sizes"
+        },
+      level)
     elseif menu == "spaces" then
       local spaces = {2,4}
       for _, i in pairs(spaces) do
@@ -301,6 +310,23 @@ local function ConstructTextEditor(frame)
               IndentationLib.enable(editor.editBox, color_scheme, WeakAurasSaved.editor_tab_spaces)
               editor.editBox:SetText(editor.editBox:GetText().."\n")
               IndentationLib.indentEditbox(editor.editBox)
+            end
+          },
+        level)
+      end
+    elseif menu == "sizes" then
+      local sizes = {12,14,16,18,20,22,24}
+      for _, i in pairs(sizes) do
+        UIDropDownMenu_AddButton(
+          {
+            text = i,
+            isNotRadio = false,
+            checked = function()
+              return WeakAurasSaved.editor_font_size == i
+            end,
+            func = function()
+              WeakAurasSaved.editor_font_size = i
+              editor.editBox:SetFont(fontPath, WeakAurasSaved.editor_font_size)
             end
           },
         level)

--- a/WeakAurasTemplates/TriggerTemplatesDataBCC.lua
+++ b/WeakAurasTemplates/TriggerTemplatesDataBCC.lua
@@ -642,6 +642,7 @@ templates.class.WARLOCK = {
       title = L["Debuffs"],
       args = {
         { spell = 172, type = "debuff", unit = "target"}, -- Corruption
+        { spell = 348, type = "debuff", unit = "target"}, -- Immolate
         { spell = 603, type = "debuff", unit = "target"}, -- Curse of Doom
         { spell = 702, type = "debuff", unit = "target"}, -- Curse of Weakness
         { spell = 704, type = "debuff", unit = "target"}, -- Curse of Recklessness

--- a/WeakAurasTemplates/TriggerTemplatesDataClassic.lua
+++ b/WeakAurasTemplates/TriggerTemplatesDataClassic.lua
@@ -580,6 +580,7 @@ templates.class.WARLOCK = {
       title = L["Debuffs"],
       args = {
         { spell = 172, type = "debuff", unit = "target"}, -- Corruption
+        { spell = 348, type = "debuff", unit = "target"}, -- Immolate
         { spell = 603, type = "debuff", unit = "target"}, -- Curse of Doom
         { spell = 702, type = "debuff", unit = "target"}, -- Curse of Weakness
         { spell = 704, type = "debuff", unit = "target"}, -- Curse of Recklessness

--- a/WeakAurasTemplates/TriggerTemplatesDataWrath.lua
+++ b/WeakAurasTemplates/TriggerTemplatesDataWrath.lua
@@ -672,6 +672,7 @@ templates.class.WARLOCK = {
       title = L["Debuffs"],
       args = {
         { spell = 172, type = "debuff", unit = "target"}, -- Corruption
+        { spell = 348, type = "debuff", unit = "target"}, -- Immolate
         { spell = 603, type = "debuff", unit = "target"}, -- Curse of Doom
         { spell = 702, type = "debuff", unit = "target"}, -- Curse of Weakness
         { spell = 704, type = "debuff", unit = "target"}, -- Curse of Recklessness


### PR DESCRIPTION
# Description

Additional changes based on feedback on Discord. 

The Dest stuff can be hidden for Cast Start. And the tooltip texts were ambiguous. 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Checklist
<!-- These can be checked off after the pull request is submitted, in case you want discussion before they are completely ready -->

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

<!-- Is there any additional work that needs to be done? If so, add it to the above list -->
