### PR TITLE
Add "Action Button" as aura anchor & glow external option

### DIFF
--- a/WeakAuras/AuraEnvironment.lua
+++ b/WeakAuras/AuraEnvironment.lua
@@ -140,6 +140,7 @@ WeakAuras.GetUnitNameplate =  function(unit)
     return LGF.GetUnitNameplate(unit)
   end
 end
+WeakAuras.GetActionButtonsById = LGF.GetActionButtonsById
 
 local blockedFunctions = {
   -- Lua functions that may allow breaking out of the environment

--- a/WeakAuras/RegionTypes/RegionPrototype.lua
+++ b/WeakAuras/RegionTypes/RegionPrototype.lua
@@ -909,6 +909,7 @@ function WeakAuras.regionPrototype.AddExpandFunction(data, region, cloneId, pare
     end
     function region:Expand()
       if data.anchorFrameType == "SELECTFRAME"
+      or data.anchorFrameType == "ACTIONBUTTON"
       or data.anchorFrameType == "CUSTOM"
       or data.anchorFrameType == "UNITFRAME"
       or data.anchorFrameType == "NAMEPLATE"

--- a/WeakAuras/SubRegionTypes/SubText.lua
+++ b/WeakAuras/SubRegionTypes/SubText.lua
@@ -188,256 +188,299 @@ local function onRelease(subRegion)
   subRegion:Hide()
 end
 
-local function modify(parent, region, parentData, data, first)
-  region:SetParent(parent)
-  local text = region.text;
+local function CreateModify(isKeybinding)
+  return function(parent, region, parentData, data, first)
+    region:SetParent(parent)
+    local text = region.text;
 
-  -- Legacy members in icon
-  -- Can we remove them with 9.0 ?
-  if parentData.regionType == "icon" then
-    if not parent.stacks then
-      parent.stacks = text
-    elseif not parent.text2 then
-      parent.text2 = text
+    -- Legacy members in icon
+    -- Can we remove them with 9.0 ?
+    if not isKeybinding then
+      if parentData.regionType == "icon" then
+        if not parent.stacks then
+          parent.stacks = text
+        elseif not parent.text2 then
+          parent.text2 = text
+        end
+      elseif parentData.regionType == "aurabar" then
+        if not parent.timer then
+          parent.timer = text
+        elseif not parent.text then
+          parent.text = text
+        elseif not parent.stacks then
+          parent.stacks = text
+        end
+      end
     end
-  elseif parentData.regionType == "aurabar" then
-    if not parent.timer then
-      parent.timer = text
-    elseif not parent.text then
-      parent.text = text
-    elseif not parent.stacks then
-      parent.stacks = text
+
+    local fontPath = SharedMedia:Fetch("font", data.text_font);
+    text:SetFont(fontPath, data.text_fontSize, data.text_fontType);
+    if not text:GetFont() then -- Font invalid, set the font but keep the setting
+      text:SetFont(STANDARD_TEXT_FONT, data.text_fontSize, data.text_fontType);
     end
-  end
 
-  local fontPath = SharedMedia:Fetch("font", data.text_font);
-  text:SetFont(fontPath, data.text_fontSize, data.text_fontType);
-  if not text:GetFont() then -- Font invalid, set the font but keep the setting
-    text:SetFont(STANDARD_TEXT_FONT, data.text_fontSize, data.text_fontType);
-  end
-  if text:GetFont() then
-    text:SetText(WeakAuras.ReplaceRaidMarkerSymbols(data.text_text));
-  end
+    if not isKeybinding then
+      if text:GetFont() then
+        text:SetText(WeakAuras.ReplaceRaidMarkerSymbols(data.text_text));
+      end
+    end
 
-  text:SetTextHeight(data.text_fontSize);
+    text:SetTextHeight(data.text_fontSize);
 
-  text:SetShadowColor(unpack(data.text_shadowColor))
-  text:SetShadowOffset(data.text_shadowXOffset, data.text_shadowYOffset)
-  text:SetJustifyH(data.text_justify or "CENTER")
+    text:SetShadowColor(unpack(data.text_shadowColor))
+    text:SetShadowOffset(data.text_shadowXOffset, data.text_shadowYOffset)
+    text:SetJustifyH(data.text_justify or "CENTER")
 
-  if (data.text_automaticWidth == "Fixed") then
-    if (data.text_wordWrap == "WordWrap") then
+    if (data.text_automaticWidth == "Fixed") then
+      if (data.text_wordWrap == "WordWrap") then
+        text:SetWordWrap(true);
+        text:SetNonSpaceWrap(true);
+      else
+        text:SetWordWrap(false);
+        text:SetNonSpaceWrap(false);
+      end
+
+      text:SetWidth(data.text_fixedWidth);
+      region:SetWidth(data.text_fixedWidth);
+      region.width = data.text_fixedWidth;
+    else
+      text:SetWidth(0);
       text:SetWordWrap(true);
       text:SetNonSpaceWrap(true);
-    else
-      text:SetWordWrap(false);
-      text:SetNonSpaceWrap(false);
     end
 
-    text:SetWidth(data.text_fixedWidth);
-    region:SetWidth(data.text_fixedWidth);
-    region.width = data.text_fixedWidth;
-  else
-    text:SetWidth(0);
-    text:SetWordWrap(true);
-    text:SetNonSpaceWrap(true);
-  end
-
-  if first then
-    local containsCustomText = false
-    for index, subRegion in ipairs(parentData.subRegions) do
-      if subRegion.type == "subtext" and Private.ContainsCustomPlaceHolder(subRegion.text_text) then
-        containsCustomText = true
-        break
-      end
-    end
-
-    if containsCustomText and parentData.customText and parentData.customText ~= "" then
-      parent.customTextFunc = WeakAuras.LoadFunction("return "..parentData.customText)
-    else
-      parent.customTextFunc = nil
-    end
-    parent.values.custom = nil
-  end
-
-  local UpdateText
-  if data.text_text and Private.ContainsAnyPlaceHolders(data.text_text) then
-    local getter = function(key, default)
-      local fullKey = "text_text_format_" .. key
-      if data[fullKey] == nil then
-        data[fullKey] = default
-      end
-      return data[fullKey]
-    end
-    local formatters = Private.CreateFormatters(data.text_text, getter)
-    UpdateText = function()
-      local textStr = data.text_text or ""
-      textStr = Private.ReplacePlaceHolders(textStr, parent, nil, false, formatters)
-
-      if text:GetFont() then
-        text:SetText(WeakAuras.ReplaceRaidMarkerSymbols(textStr))
-      end
-      region:UpdateAnchorOnTextChange()
-    end
-  end
-
-  local Update
-  if first and parent.customTextFunc then
-    if UpdateText then
-      Update = function()
-        parent.values.custom = Private.RunCustomTextFunc(parent, parent.customTextFunc)
-        UpdateText()
-      end
-    else
-      Update = function()
-        parent.values.custom = Private.RunCustomTextFunc(parent, parent.customTextFunc)
-      end
-    end
-  else
-    Update = UpdateText
-  end
-
-  local TimerTick
-  if Private.ContainsPlaceHolders(data.text_text, "p") then
-    TimerTick = UpdateText
-  end
-
-  local FrameTick
-  if parent.customTextFunc and parentData.customTextUpdate == "update" then
-    if first then
-      if Private.ContainsCustomPlaceHolder(data.text_text) then
-        FrameTick = function()
-          parent.values.custom = Private.RunCustomTextFunc(parent, parent.customTextFunc)
-          UpdateText()
+    if not isKeybinding then
+      if first then
+        local containsCustomText = false
+        for index, subRegion in ipairs(parentData.subRegions) do
+          if subRegion.type == "subtext" and Private.ContainsCustomPlaceHolder(subRegion.text_text) then
+            containsCustomText = true
+            break
+          end
         end
-      else
-        FrameTick = function()
-          parent.values.custom = Private.RunCustomTextFunc(parent, parent.customTextFunc)
+
+        if containsCustomText and parentData.customText and parentData.customText ~= "" then
+          parent.customTextFunc = WeakAuras.LoadFunction("return "..parentData.customText)
+        else
+          parent.customTextFunc = nil
+        end
+        parent.values.custom = nil
+      end
+
+      local UpdateText
+      if data.text_text and Private.ContainsAnyPlaceHolders(data.text_text) then
+        local getter = function(key, default)
+          local fullKey = "text_text_format_" .. key
+          if data[fullKey] == nil then
+            data[fullKey] = default
+          end
+          return data[fullKey]
+        end
+        local formatters = Private.CreateFormatters(data.text_text, getter)
+        UpdateText = function()
+          local textStr = data.text_text or ""
+          textStr = Private.ReplacePlaceHolders(textStr, parent, nil, false, formatters)
+
+          if text:GetFont() then
+            text:SetText(WeakAuras.ReplaceRaidMarkerSymbols(textStr))
+          end
+          region:UpdateAnchorOnTextChange()
         end
       end
-    else
-      if Private.ContainsCustomPlaceHolder(data.text_text) then
-        FrameTick = UpdateText
-      end
-    end
-  end
 
-  region.Update = Update
-  region.FrameTick = FrameTick
-  region.TimerTick = TimerTick
-
-  if Update then
-    parent.subRegionEvents:AddSubscriber("Update", region)
-  end
-
-  if FrameTick then
-    parent.subRegionEvents:AddSubscriber("FrameTick", region)
-  end
-
-  if TimerTick then
-    parent.subRegionEvents:AddSubscriber("TimerTick", region)
-  end
-
-  if not UpdateText then
-    if text:GetFont() then
-      local textStr = data.text_text
-      textStr = textStr:gsub("\\n", "\n");
-      text:SetText(WeakAuras.ReplaceRaidMarkerSymbols(textStr))
-    end
-  end
-
-  function region:Color(r, g, b, a)
-    region.color_r = r;
-    region.color_g = g;
-    region.color_b = b;
-    region.color_a = a;
-    if (r or g or b) then
-      a = a or 1;
-    end
-    text:SetTextColor(region.color_anim_r or r, region.color_anim_g or g, region.color_anim_b or b, region.color_anim_a or a);
-  end
-
-  region:Color(data.text_color[1], data.text_color[2], data.text_color[3], data.text_color[4]);
-
-  function region:SetTextHeight(size)
-    local fontPath = SharedMedia:Fetch("font", data.text_font);
-    if not text:GetFont() then -- Font invalid, set the font but keep the setting
-      text:SetFont(STANDARD_TEXT_FONT, size, data.text_fontType);
-    else
-      region.text:SetFont(fontPath, size, data.text_fontType);
-    end
-    region.text:SetTextHeight(size)
-    region:UpdateAnchorOnTextChange();
-  end
-
-  function region:SetVisible(visible)
-    if visible then
-      self:Show()
-    else
-      self:Hide()
-    end
-  end
-
-  region:SetVisible(data.text_visible)
-
-  local selfPoint = data.text_selfPoint
-  if selfPoint == "AUTO" then
-    if parentData.regionType == "icon" then
-      local anchorPoint = data.text_anchorPoint or "CENTER"
-      if anchorPoint:sub(1, 6) == "INNER_" then
-        selfPoint = anchorPoint:sub(7)
-      elseif anchorPoint:sub(1, 6) == "OUTER_" then
-        anchorPoint = anchorPoint:sub(7)
-        selfPoint = Private.inverse_point_types[anchorPoint] or "CENTER"
+      local Update
+      if not isKeybinding and first and parent.customTextFunc then
+        if UpdateText then
+          Update = function()
+            parent.values.custom = Private.RunCustomTextFunc(parent, parent.customTextFunc)
+            UpdateText()
+          end
+        else
+          Update = function()
+            parent.values.custom = Private.RunCustomTextFunc(parent, parent.customTextFunc)
+          end
+        end
       else
-        selfPoint = "CENTER"
+        Update = UpdateText
       end
-    elseif parentData.regionType == "aurabar" then
-      selfPoint = data.text_anchorPoint or "CENTER"
-      if selfPoint:sub(1, 5) == "ICON_" then
-        selfPoint = selfPoint:sub(6)
-      elseif selfPoint:sub(1, 6) == "INNER_" then
-        selfPoint = selfPoint:sub(7)
+
+      local TimerTick
+      if Private.ContainsPlaceHolders(data.text_text, "p") then
+        TimerTick = UpdateText
       end
-      selfPoint = Private.point_types[selfPoint] and selfPoint or "CENTER"
+
+      local FrameTick
+      if parent.customTextFunc and parentData.customTextUpdate == "update" then
+        if first then
+          if Private.ContainsCustomPlaceHolder(data.text_text) then
+            FrameTick = function()
+              parent.values.custom = Private.RunCustomTextFunc(parent, parent.customTextFunc)
+              UpdateText()
+            end
+          else
+            FrameTick = function()
+              parent.values.custom = Private.RunCustomTextFunc(parent, parent.customTextFunc)
+            end
+          end
+        else
+          if Private.ContainsCustomPlaceHolder(data.text_text) then
+            FrameTick = UpdateText
+          end
+        end
+      end
+
+      region.Update = Update
+      region.FrameTick = FrameTick
+      region.TimerTick = TimerTick
+
+      if Update then
+        parent.subRegionEvents:AddSubscriber("Update", region)
+      end
+
+      if FrameTick then
+        parent.subRegionEvents:AddSubscriber("FrameTick", region)
+      end
+
+      if TimerTick then
+        parent.subRegionEvents:AddSubscriber("TimerTick", region)
+      end
+
+      if not UpdateText then
+        if text:GetFont() then
+          local textStr = data.text_text
+          textStr = textStr:gsub("\\n", "\n");
+          text:SetText(WeakAuras.ReplaceRaidMarkerSymbols(textStr))
+        end
+      end
+
     else
-      selfPoint = Private.inverse_point_types[data.text_anchorPoint or "CENTER"] or "CENTER"
+      -- Keybinding
+      local UpdateKeybinding = function()
+        local textStr = ""
+        local actionId, actionType = WeakAuras.GetActionInfoFromRegion(parent)
+        if actionId and actionType then
+          for _, frame in ipairs(WeakAuras.GetActionButtonsById(actionId, actionType)) do
+            if frame and frame.IsVisible and frame:IsVisible() and frame.commandName then
+              local key = GetBindingKey(frame.commandName)
+              if key then
+                textStr = key
+              end
+            end
+          end
+        end
+        if text:GetFont() then
+          if data.shorten then
+            textStr = textStr
+              :gsub("BUTTON", "B")
+              :gsub("CTRL", "C")
+              :gsub("ALT", "A")
+              :gsub("SHIFT", "S")
+          end
+          text:SetText(textStr)
+        end
+        region:UpdateAnchorOnTextChange()
+      end
+
+      region.UpdateKeybinding = UpdateKeybinding
+      parent.subRegionEvents:AddSubscriber("UpdateKeybinding", region)
+
+      region.Update = UpdateKeybinding
+      parent.subRegionEvents:AddSubscriber("Update", region)
     end
-  end
 
-  region.text_anchorXOffset = data.text_anchorXOffset
-  region.text_anchorYOffset = data.text_anchorYOffset
-
-  local textDegrees = data.rotateText == "LEFT" and 90 or data.rotateText == "RIGHT" and -90 or 0;
-
-  region.UpdateAnchor = function(self)
-    local xo, yo = getRotateOffset(text, textDegrees, selfPoint)
-    parent:AnchorSubRegion(text, "point", selfPoint, data.text_anchorPoint, (self.text_anchorXOffset or 0) + xo, (self.text_anchorYOffset or 0) + yo)
-  end
-
-  region:UpdateAnchor()
-  animRotate(text, textDegrees, selfPoint)
-
-  if textDegrees == 0 then
-    region.UpdateAnchorOnTextChange = function() end
-  else
-    region.UpdateAnchorOnTextChange = region.UpdateAnchor
-  end
-
-  region.SetXOffset = function(self, xOffset)
-    if self.text_anchorXOffset == xOffset then
-      return
+    function region:Color(r, g, b, a)
+      region.color_r = r;
+      region.color_g = g;
+      region.color_b = b;
+      region.color_a = a;
+      if (r or g or b) then
+        a = a or 1;
+      end
+      text:SetTextColor(region.color_anim_r or r, region.color_anim_g or g, region.color_anim_b or b, region.color_anim_a or a);
     end
-    self.text_anchorXOffset = xOffset
-    self:UpdateAnchor()
-  end
 
-  region.SetYOffset = function(self, yOffset)
-    if self.text_anchorYOffset == yOffset then
-      return
+    region:Color(data.text_color[1], data.text_color[2], data.text_color[3], data.text_color[4]);
+
+    function region:SetTextHeight(size)
+      local fontPath = SharedMedia:Fetch("font", data.text_font);
+      if not text:GetFont() then -- Font invalid, set the font but keep the setting
+        text:SetFont(STANDARD_TEXT_FONT, size, data.text_fontType);
+      else
+        region.text:SetFont(fontPath, size, data.text_fontType);
+      end
+      region.text:SetTextHeight(size)
+      region:UpdateAnchorOnTextChange();
     end
-    self.text_anchorYOffset = yOffset
-    self:UpdateAnchor()
+
+    function region:SetVisible(visible)
+      if visible then
+        self:Show()
+      else
+        self:Hide()
+      end
+    end
+
+    region:SetVisible(data.text_visible)
+
+    local selfPoint = data.text_selfPoint
+    if selfPoint == "AUTO" then
+      if parentData.regionType == "icon" then
+        local anchorPoint = data.text_anchorPoint or "CENTER"
+        if anchorPoint:sub(1, 6) == "INNER_" then
+          selfPoint = anchorPoint:sub(7)
+        elseif anchorPoint:sub(1, 6) == "OUTER_" then
+          anchorPoint = anchorPoint:sub(7)
+          selfPoint = Private.inverse_point_types[anchorPoint] or "CENTER"
+        else
+          selfPoint = "CENTER"
+        end
+      elseif parentData.regionType == "aurabar" then
+        selfPoint = data.text_anchorPoint or "CENTER"
+        if selfPoint:sub(1, 5) == "ICON_" then
+          selfPoint = selfPoint:sub(6)
+        elseif selfPoint:sub(1, 6) == "INNER_" then
+          selfPoint = selfPoint:sub(7)
+        end
+        selfPoint = Private.point_types[selfPoint] and selfPoint or "CENTER"
+      else
+        selfPoint = Private.inverse_point_types[data.text_anchorPoint or "CENTER"] or "CENTER"
+      end
+    end
+
+    region.text_anchorXOffset = data.text_anchorXOffset
+    region.text_anchorYOffset = data.text_anchorYOffset
+
+    local textDegrees = data.rotateText == "LEFT" and 90 or data.rotateText == "RIGHT" and -90 or 0;
+
+    region.UpdateAnchor = function(self)
+      local xo, yo = getRotateOffset(text, textDegrees, selfPoint)
+      parent:AnchorSubRegion(text, "point", selfPoint, data.text_anchorPoint, (self.text_anchorXOffset or 0) + xo, (self.text_anchorYOffset or 0) + yo)
+    end
+
+    region:UpdateAnchor()
+    animRotate(text, textDegrees, selfPoint)
+
+    if textDegrees == 0 then
+      region.UpdateAnchorOnTextChange = function() end
+    else
+      region.UpdateAnchorOnTextChange = region.UpdateAnchor
+    end
+
+    region.SetXOffset = function(self, xOffset)
+      if self.text_anchorXOffset == xOffset then
+        return
+      end
+      self.text_anchorXOffset = xOffset
+      self:UpdateAnchor()
+    end
+
+    region.SetYOffset = function(self, yOffset)
+      if self.text_anchorYOffset == yOffset then
+        return
+      end
+      self.text_anchorYOffset = yOffset
+      self:UpdateAnchor()
+    end
   end
 end
 
@@ -518,4 +561,8 @@ local function supports(regionType)
          or regionType == "aurabar"
 end
 
-WeakAuras.RegisterSubRegionType("subtext", L["Text"], supports, create, modify, onAcquire, onRelease, default, addDefaultsForNewAura, properties);
+local subtextModify = CreateModify()
+WeakAuras.RegisterSubRegionType("subtext", L["Text"], supports, create, subtextModify, onAcquire, onRelease, default, addDefaultsForNewAura, properties);
+
+local subkeybindingModify = CreateModify(true)
+WeakAuras.RegisterSubRegionType("subkeybinding", L["Keybinding"], supports, create, subkeybindingModify, onAcquire, onRelease, default, addDefaultsForNewAura, properties);

--- a/WeakAuras/Types.lua
+++ b/WeakAuras/Types.lua
@@ -115,6 +115,11 @@ Private.round_types = {
   round = L["Round"]
 }
 
+Private.keybinding_types = {
+  spell = L["Spell"],
+  item = L["Item"]
+}
+
 Private.unit_color_types = {
   none = L["None"],
   class = L["Class"]
@@ -777,6 +782,48 @@ Private.format_types = {
         end
 
         return numberToStringFunc(result / WeakAuras.CalculatedGcdDuration())
+      end
+    end
+  },
+  Keybinding = {
+    display = L["Keybinding"],
+    AddOptions = function(symbol, hidden, addOption, get)
+      addOption(symbol .. "_type", {
+        type = "select",
+        name = L["Type"],
+        width = WeakAuras.normalWidth,
+        values = Private.keybinding_types,
+        hidden = hidden
+      })
+    end,
+    CreateFormatter = function(symbol, get)
+      local actionType = get(symbol .. "_type", false)
+      return function(actionId, state)
+        if actionType == "spell" then
+          if type(actionId) == "string" then
+            actionId = select(7, GetSpellInfo(actionId))
+          end
+          if tonumber(actionId) then
+            actionId = tonumber(actionId)
+          end
+        elseif actionType == "item" then
+          if type(actionId) == "string" then
+            actionId = GetItemInfoInstant(actionId)
+          end
+          if tonumber(actionId) then
+            actionId = tonumber(actionId)
+          end
+        end
+        if actionId and actionType then
+          for _, frame in ipairs(WeakAuras.GetActionButtonsById(actionId, actionType)) do
+            if frame and frame.IsVisible and frame:IsVisible() and frame.commandName then
+              local key = GetBindingKey(frame.commandName)
+              if key then
+                return key
+              end
+            end
+          end
+        end
       end
     end
   }

--- a/WeakAuras/Types.lua
+++ b/WeakAuras/Types.lua
@@ -1064,6 +1064,7 @@ Private.anchor_frame_types = {
   PRD = L["Personal Resource Display"],
   MOUSE = L["Mouse Cursor"],
   SELECTFRAME = L["Select Frame"],
+  ACTIONBUTTON = L["Action Button"],
   NAMEPLATE = L["Nameplates"],
   UNITFRAME = L["Unit Frames"],
   CUSTOM = L["Custom"]
@@ -1074,6 +1075,7 @@ Private.anchor_frame_types_group = {
   PRD = L["Personal Resource Display"],
   MOUSE = L["Mouse Cursor"],
   SELECTFRAME = L["Select Frame"],
+  ACTIONBUTTON = L["Action Button"],
   CUSTOM = L["Custom"]
 }
 

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -3332,9 +3332,9 @@ do
     end
   end
 
-  LGF.RegisterCallback("WeakAuras", "FRAME_UNIT_UPDATE", frame_monitor_callback)
-  LGF.RegisterCallback("WeakAuras", "FRAME_UNIT_REMOVED", frame_monitor_callback)
-  LGF.RegisterCallback("WeakAuras", "ACTIONBAR_SLOT_CHANGED", actionbar_slot_callback)
+  LGF.RegisterCallback("WeakAuras_FRAME_UNIT_UPDATE", "FRAME_UNIT_UPDATE", frame_monitor_callback)
+  LGF.RegisterCallback("WeakAuras_FRAME_UNIT_REMOVED", "FRAME_UNIT_REMOVED", frame_monitor_callback)
+  LGF.RegisterCallback("WeakAuras_ACTIONBAR_SLOT_CHANGED", "ACTIONBAR_SLOT_CHANGED", actionbar_slot_callback)
 end
 
 function Private.HandleGlowAction(actions, region)

--- a/WeakAurasOptions/ActionOptions.lua
+++ b/WeakAurasOptions/ActionOptions.lua
@@ -276,7 +276,8 @@ function OptionsPrivate.GetActionOptions(data)
         values = {
           UNITFRAME = L["Unit Frame"],
           NAMEPLATE = L["Nameplate"],
-          FRAMESELECTOR = L["Frame Selector"]
+          FRAMESELECTOR = L["Frame Selector"],
+          ACTIONBUTTON = L["Action Button"]
         },
         hidden = function()
           return not data.actions.start.do_glow
@@ -670,7 +671,8 @@ function OptionsPrivate.GetActionOptions(data)
         values = {
           UNITFRAME = L["Unit Frame"],
           NAMEPLATE = L["Nameplate"],
-          FRAMESELECTOR = L["Frame Selector"]
+          FRAMESELECTOR = L["Frame Selector"],
+          ACTIONBUTTON = L["Action Button"]
         },
         hidden = function()
           return not data.actions.finish.do_glow

--- a/WeakAurasOptions/ConditionOptions.lua
+++ b/WeakAurasOptions/ConditionOptions.lua
@@ -1063,7 +1063,8 @@ local function addControlsForChange(args, order, data, conditionVariable, totalA
       desc = descIfNoValue2(data, conditions[i].changes[j], "value", "glow_frame_type", propertyType, {
         UNITFRAME = L["Unit Frame"],
         NAMEPLATE = L["Nameplate"],
-        FRAMESELECTOR = L["Frame Selector"]
+        FRAMESELECTOR = L["Frame Selector"],
+        ACTIONBUTTON = L["Action Button"]
       }),
       order = order,
       get = function()

--- a/WeakAurasOptions/SubRegionOptions/SubText.lua
+++ b/WeakAurasOptions/SubRegionOptions/SubText.lua
@@ -18,481 +18,496 @@ local self_point_types = {
   AUTO = L["Automatic"]
 }
 
-local function createOptions(parentData, data, index, subIndex)
-  -- The toggles for font flags is intentionally not keyed on the id
-  -- So that all auras share the state of that toggle
-  local hiddenFontExtra = function()
-    return OptionsPrivate.IsCollapsed("subtext", "subtext", "fontflags" .. index, true)
-  end
+local function createCreateOptions(isKeybinding)
+  return function(parentData, data, index, subIndex)
+    -- The toggles for font flags is intentionally not keyed on the id
+    -- So that all auras share the state of that toggle
+    local hiddenFontExtra = function()
+      return OptionsPrivate.IsCollapsed("subtext", "subtext", "fontflags" .. index, true)
+    end
 
-  local indentWidth = 0.15
+    local indentWidth = 0.15
 
-  local options = {
-    __title = L["Text %s"]:format(subIndex),
-    __order = 1,
-    text_visible = {
-      type = "toggle",
-      width = WeakAuras.halfWidth,
-      order = 9,
-      name = L["Show Text"],
-    },
-    text_color = {
-      type = "color",
-      width = WeakAuras.halfWidth,
-      name = L["Color"],
-      hasAlpha = true,
-      order = 10,
-    },
-    text_text = {
-      type = "input",
-      width = WeakAuras.normalWidth,
-      desc = function()
-        return L["Dynamic text tooltip"] .. OptionsPrivate.Private.GetAdditionalProperties(parentData)
-      end,
-      name = L["Display Text"],
-      order = 11,
-      set = function(info, v)
-        data.text_text = OptionsPrivate.Private.ReplaceLocalizedRaidMarkers(v)
-        WeakAuras.Add(parentData)
-        WeakAuras.ClearAndUpdateOptions(parentData.id)
-      end
-    },
-    text_font = {
-      type = "select",
-      width = WeakAuras.normalWidth,
-      dialogControl = "LSM30_Font",
-      name = L["Font"],
-      order = 13,
-      values = AceGUIWidgetLSMlists.font,
-    },
-    text_fontSize = {
-      type = "range",
-      width = WeakAuras.normalWidth,
-      name = L["Size"],
-      order = 14,
-      min = 6,
-      softMax = 72,
-      step = 1,
-    },
-    text_fontFlagsDescription = {
+    local options = {
+      __title = isKeybinding and L["Keybinding %s"]:format(subIndex) or L["Text %s"]:format(subIndex),
+      __order = 1,
+      text_visible = {
+        type = "toggle",
+        width = isKeybinding and WeakAuras.normalWidth or WeakAuras.halfWidth,
+        order = 9,
+        name = isKeybinding and L["Show Keybinding"] or L["Show Text"],
+      },
+      text_color = {
+        type = "color",
+        width = WeakAuras.halfWidth,
+        name = L["Color"],
+        hasAlpha = true,
+        order = 10,
+      },
+      text_text = not isKeybinding and {
+        type = "input",
+        width = WeakAuras.normalWidth,
+        desc = function()
+          return L["Dynamic text tooltip"] .. OptionsPrivate.Private.GetAdditionalProperties(parentData)
+        end,
+        name = L["Display Text"],
+        order = 11,
+        set = function(info, v)
+          data.text_text = OptionsPrivate.Private.ReplaceLocalizedRaidMarkers(v)
+          WeakAuras.Add(parentData)
+          WeakAuras.ClearAndUpdateOptions(parentData.id)
+        end
+      } or nil,
+      shorten = isKeybinding and {
+        type = "toggle",
+        width = WeakAuras.doubleWidth,
+        name = L["Shorten Text"],
+        order = 11
+      } or nil,
+      text_font = {
+        type = "select",
+        width = WeakAuras.normalWidth,
+        dialogControl = "LSM30_Font",
+        name = L["Font"],
+        order = 13,
+        values = AceGUIWidgetLSMlists.font,
+      },
+      text_fontSize = {
+        type = "range",
+        width = WeakAuras.normalWidth,
+        name = L["Size"],
+        order = 14,
+        min = 6,
+        softMax = 72,
+        step = 1,
+      },
+      text_fontFlagsDescription = {
+        type = "execute",
+        control = "WeakAurasExpandSmall",
+        name = function()
+          local textFlags = OptionsPrivate.Private.font_flags[data.text_fontType]
+          local color = format("%02x%02x%02x%02x",
+                              data.text_shadowColor[4] * 255, data.text_shadowColor[1] * 255,
+                              data.text_shadowColor[2] * 255, data.text_shadowColor[3]*255)
+
+          local textJustify = ""
+          if data.text_justify == "CENTER" then
+            -- CENTER is default
+          elseif data.text_justify == "LEFT" then
+            textJustify = " " .. L["and aligned left"]
+          elseif data.text_justify == "RIGHT" then
+            textJustify = " " ..  L["and aligned right"]
+          end
+
+          local textRotate = ""
+          if data.rotateText == "LEFT" then
+            textRotate = " " .. L["and rotated left"]
+          elseif data.rotateText == "RIGHT" then
+            textRotate = " " .. L["and rotated right"]
+          end
+
+          local textWidth = ""
+          if data.text_automaticWidth == "Fixed" then
+            local wordWarp = ""
+            if data.text_wordWrap == "WordWrap" then
+              wordWarp = L["wrapping"]
+            else
+              wordWarp = L["eliding"]
+            end
+            textWidth = " "..L["and with width |cFFFF0000%s|r and %s"]:format(data.text_fixedWidth, wordWarp)
+          end
+
+          local secondline = L["|cFFffcc00Font Flags:|r |cFFFF0000%s|r and shadow |c%sColor|r with offset |cFFFF0000%s/%s|r%s%s%s"]:format(textFlags, color, data.text_shadowXOffset, data.text_shadowYOffset, textRotate, textJustify, textWidth)
+
+          return secondline
+        end,
+        width = WeakAuras.doubleWidth,
+        order = 44,
+        func = function(info, button)
+          local collapsed = OptionsPrivate.IsCollapsed("subtext", "subtext", "fontflags" .. index, true)
+          OptionsPrivate.SetCollapsed("subtext", "subtext", "fontflags" .. index, not collapsed)
+        end,
+        image = function()
+          local collapsed = OptionsPrivate.IsCollapsed("subtext", "subtext", "fontflags" .. index, true)
+          return collapsed and "collapsed" or "expanded"
+        end,
+        imageWidth = 15,
+        imageHeight = 15,
+        arg = {
+          expanderName = "subtext" .. index .. "#" .. subIndex
+        }
+      },
+
+      text_font_space = {
+        type = "description",
+        name = "",
+        order = 45,
+        hidden = hiddenFontExtra,
+        width = indentWidth
+      },
+
+      text_fontType = {
+        type = "select",
+        width = WeakAuras.normalWidth - indentWidth,
+        name = L["Outline"],
+        order = 46,
+        values = OptionsPrivate.Private.font_flags,
+        hidden = hiddenFontExtra
+      },
+      text_shadowColor = {
+        type = "color",
+        hasAlpha = true,
+        width = WeakAuras.normalWidth,
+        name = L["Shadow Color"],
+        order = 47,
+        hidden = hiddenFontExtra
+      },
+
+      text_font_space3 = {
+        type = "description",
+        name = "",
+        order = 47.5,
+        hidden = hiddenFontExtra,
+        width = indentWidth
+      },
+      text_shadowXOffset = {
+        type = "range",
+        width = WeakAuras.normalWidth - indentWidth,
+        name = L["Shadow X Offset"],
+        softMin = -15,
+        softMax = 15,
+        bigStep = 1,
+        order = 48,
+        hidden = hiddenFontExtra
+      },
+      text_shadowYOffset = {
+        type = "range",
+        width = WeakAuras.normalWidth,
+        name = L["Shadow Y Offset"],
+        softMin = -15,
+        softMax = 15,
+        bigStep = 1,
+        order = 49,
+        hidden = hiddenFontExtra
+      },
+
+      text_font_space4 = {
+        type = "description",
+        name = "",
+        order = 49.5,
+        hidden = hiddenFontExtra,
+        width = indentWidth
+      },
+      rotateText = {
+        type = "select",
+        width = WeakAuras.normalWidth - indentWidth,
+        name = L["Rotate Text"],
+        values = OptionsPrivate.Private.text_rotate_types,
+        order = 50,
+        hidden = hiddenFontExtra
+      },
+      text_justify = {
+        type = "select",
+        width = WeakAuras.normalWidth,
+        name = L["Alignment"],
+        values = OptionsPrivate.Private.justify_types,
+        order = 50.5,
+        hidden = hiddenFontExtra
+      },
+      text_font_space5 = {
+        type = "description",
+        name = "",
+        order = 51,
+        hidden = hiddenFontExtra,
+        width = indentWidth
+      },
+      text_automaticWidth = {
+        type = "select",
+        width = WeakAuras.normalWidth - indentWidth,
+        name = L["Width"],
+        order = 51.5,
+        values = OptionsPrivate.Private.text_automatic_width,
+        hidden = hiddenFontExtra
+      },
+      text_font_space6 = {
+        type = "description",
+        name = "",
+        order = 52,
+        hidden = hiddenFontExtra,
+        width = WeakAuras.normalWidth
+      },
+      text_font_space7 = {
+        type = "description",
+        name = "",
+        order = 52.5,
+        width = indentWidth,
+        hidden = function() return hiddenFontExtra() or data.text_automaticWidth ~= "Fixed" end
+      },
+      text_fixedWidth = {
+        name = L["Width"],
+        width = WeakAuras.normalWidth - indentWidth,
+        order = 53,
+        type = "range",
+        min = 1,
+        softMax = 200,
+        bigStep = 1,
+        hidden = function() return hiddenFontExtra() or data.text_automaticWidth ~= "Fixed" end
+      },
+      text_wordWrap = {
+        type = "select",
+        width = WeakAuras.normalWidth,
+        name = L["Overflow"],
+        order = 54,
+        values = OptionsPrivate.Private.text_word_wrap,
+        hidden = function() return hiddenFontExtra() or data.text_automaticWidth ~= "Fixed" end
+      },
+
+      text_anchor = {
+        type = "description",
+        name = "",
+        order = 55,
+        hidden = hiddenFontExtra,
+        control = "WeakAurasExpandAnchor",
+        arg = {
+          expanderName = "subtext" .. index .. "#" .. subIndex
+        }
+      }
+    }
+
+    -- Note: Anchor Options need to be generalized once there are multiple sub regions
+    -- While every sub region will have anchor options, the initial
+    -- design I had for anchor options proved to be not general enough for
+    -- what SubText needed. So, I removed it, and postponed making it work for unknown future
+    -- sub regions
+    local anchors = {}
+    for child in OptionsPrivate.Private.TraverseLeafsOrAura(parentData) do
+      Mixin(anchors, OptionsPrivate.Private.GetAnchorsForData(child, "point"))
+    end
+
+    -- Anchor Options
+    options.text_anchorsDescription = {
       type = "execute",
       control = "WeakAurasExpandSmall",
       name = function()
-        local textFlags = OptionsPrivate.Private.font_flags[data.text_fontType]
-        local color = format("%02x%02x%02x%02x",
-                             data.text_shadowColor[4] * 255, data.text_shadowColor[1] * 255,
-                             data.text_shadowColor[2] * 255, data.text_shadowColor[3]*255)
+        local selfPoint = data.text_selfPoint ~= "AUTO" and self_point_types[data.text_selfPoint]
+        local anchorPoint = anchors[data.text_anchorPoint or "CENTER"] or anchors["CENTER"]
 
-        local textJustify = ""
-        if data.text_justify == "CENTER" then
-          -- CENTER is default
-        elseif data.text_justify == "LEFT" then
-          textJustify = " " .. L["and aligned left"]
-        elseif data.text_justify == "RIGHT" then
-          textJustify = " " ..  L["and aligned right"]
+        local xOffset = data.text_anchorXOffset or 0
+        local yOffset = data.text_anchorYOffset or 0
+
+        if (type(anchorPoint) == "table") then
+          anchorPoint = anchorPoint[1] .. "/" .. anchorPoint[2]
         end
 
-        local textRotate = ""
-        if data.rotateText == "LEFT" then
-          textRotate = " " .. L["and rotated left"]
-        elseif data.rotateText == "RIGHT" then
-          textRotate = " " .. L["and rotated right"]
-        end
-
-        local textWidth = ""
-        if data.text_automaticWidth == "Fixed" then
-          local wordWarp = ""
-          if data.text_wordWrap == "WordWrap" then
-            wordWarp = L["wrapping"]
+        if selfPoint then
+          if xOffset == 0 and yOffset == 0 then
+            return L["|cFFffcc00Anchors:|r Anchored |cFFFF0000%s|r to frame's |cFFFF0000%s|r"]:format(selfPoint, anchorPoint)
           else
-            wordWarp = L["eliding"]
+            return L["|cFFffcc00Anchors:|r Anchored |cFFFF0000%s|r to frame's |cFFFF0000%s|r with offset |cFFFF0000%s/%s|r"]:format(selfPoint, anchorPoint, xOffset, yOffset)
           end
-          textWidth = " "..L["and with width |cFFFF0000%s|r and %s"]:format(data.text_fixedWidth, wordWarp)
+        else
+          if xOffset == 0 and yOffset == 0 then
+            return L["|cFFffcc00Anchors:|r Anchored to frame's |cFFFF0000%s|r"]:format(anchorPoint)
+          else
+            return L["|cFFffcc00Anchors:|r Anchored to frame's |cFFFF0000%s|r with offset |cFFFF0000%s/%s|r"]:format(anchorPoint, xOffset, yOffset)
+          end
         end
-
-        local secondline = L["|cFFffcc00Font Flags:|r |cFFFF0000%s|r and shadow |c%sColor|r with offset |cFFFF0000%s/%s|r%s%s%s"]:format(textFlags, color, data.text_shadowXOffset, data.text_shadowYOffset, textRotate, textJustify, textWidth)
-
-        return secondline
       end,
       width = WeakAuras.doubleWidth,
-      order = 44,
-      func = function(info, button)
-        local collapsed = OptionsPrivate.IsCollapsed("subtext", "subtext", "fontflags" .. index, true)
-        OptionsPrivate.SetCollapsed("subtext", "subtext", "fontflags" .. index, not collapsed)
-      end,
+      order = 60,
       image = function()
-        local collapsed = OptionsPrivate.IsCollapsed("subtext", "subtext", "fontflags" .. index, true)
+        local collapsed = OptionsPrivate.IsCollapsed("subregion", "text_anchors", tostring(index), true)
         return collapsed and "collapsed" or "expanded"
       end,
       imageWidth = 15,
       imageHeight = 15,
+      func = function(info, button)
+        local collapsed = OptionsPrivate.IsCollapsed("subregion", "text_anchors", tostring(index), true)
+        OptionsPrivate.SetCollapsed("subregion", "text_anchors", tostring(index), not collapsed)
+      end,
       arg = {
-        expanderName = "subtext" .. index .. "#" .. subIndex
+        expanderName = "subtext_anchor" .. index .. "#" .. subIndex
       }
-    },
+    }
 
-    text_font_space = {
+    local hiddenFunction = function()
+      return OptionsPrivate.IsCollapsed("subregion", "text_anchors", tostring(index), true)
+    end
+
+    options.text_anchor_space = {
       type = "description",
       name = "",
-      order = 45,
-      hidden = hiddenFontExtra,
+      order = 60.15,
+      hidden = hiddenFunction,
       width = indentWidth
-    },
+    }
 
-    text_fontType = {
+    options.text_selfPoint = {
       type = "select",
       width = WeakAuras.normalWidth - indentWidth,
-      name = L["Outline"],
-      order = 46,
-      values = OptionsPrivate.Private.font_flags,
-      hidden = hiddenFontExtra
-    },
-    text_shadowColor = {
-      type = "color",
-      hasAlpha = true,
-      width = WeakAuras.normalWidth,
-      name = L["Shadow Color"],
-      order = 47,
-      hidden = hiddenFontExtra
-    },
+      name = L["Anchor"],
+      order = 60.2,
+      values = self_point_types,
+      hidden = hiddenFunction
+    }
 
-    text_font_space3 = {
+    options.text_anchorPoint = {
+      type = "select",
+      width = WeakAuras.normalWidth,
+      name = function()
+        return L["To Frame's"]
+      end,
+      order = 60.3,
+      values = anchors,
+      hidden = hiddenFunction,
+      control = "WeakAurasTwoColumnDropdown"
+    }
+
+    options.text_anchor_space2 = {
       type = "description",
       name = "",
-      order = 47.5,
-      hidden = hiddenFontExtra,
+      order = 60.35,
+      hidden = hiddenFunction,
       width = indentWidth
-    },
-    text_shadowXOffset = {
+    }
+
+    options.text_anchorXOffset = {
       type = "range",
       width = WeakAuras.normalWidth - indentWidth,
-      name = L["Shadow X Offset"],
-      softMin = -15,
-      softMax = 15,
-      bigStep = 1,
-      order = 48,
-      hidden = hiddenFontExtra
-    },
-    text_shadowYOffset = {
+      name = L["X Offset"],
+      order = 60.4,
+      softMin = (-1 * screenWidth),
+      softMax = screenWidth,
+      bigStep = 10,
+      hidden = hiddenFunction
+    }
+
+    options.text_anchorYOffset = {
       type = "range",
       width = WeakAuras.normalWidth,
-      name = L["Shadow Y Offset"],
-      softMin = -15,
-      softMax = 15,
-      bigStep = 1,
-      order = 49,
-      hidden = hiddenFontExtra
-    },
+      name = L["Y Offset"],
+      order = 60.5,
+      softMin = (-1 * screenHeight),
+      softMax = screenHeight,
+      bigStep = 10,
+      hidden = hiddenFunction
+    }
 
-    text_font_space4 = {
+    options.text_anchor_anchor = {
       type = "description",
       name = "",
-      order = 49.5,
-      hidden = hiddenFontExtra,
-      width = indentWidth
-    },
-    rotateText = {
-      type = "select",
-      width = WeakAuras.normalWidth - indentWidth,
-      name = L["Rotate Text"],
-      values = OptionsPrivate.Private.text_rotate_types,
-      order = 50,
-      hidden = hiddenFontExtra
-    },
-    text_justify = {
-      type = "select",
-      width = WeakAuras.normalWidth,
-      name = L["Alignment"],
-      values = OptionsPrivate.Private.justify_types,
-      order = 50.5,
-      hidden = hiddenFontExtra
-    },
-    text_font_space5 = {
-      type = "description",
-      name = "",
-      order = 51,
-      hidden = hiddenFontExtra,
-      width = indentWidth
-    },
-    text_automaticWidth = {
-      type = "select",
-      width = WeakAuras.normalWidth - indentWidth,
-      name = L["Width"],
-      order = 51.5,
-      values = OptionsPrivate.Private.text_automatic_width,
-      hidden = hiddenFontExtra
-    },
-    text_font_space6 = {
-      type = "description",
-      name = "",
-      order = 52,
-      hidden = hiddenFontExtra,
-      width = WeakAuras.normalWidth
-    },
-    text_font_space7 = {
-      type = "description",
-      name = "",
-      order = 52.5,
-      width = indentWidth,
-      hidden = function() return hiddenFontExtra() or data.text_automaticWidth ~= "Fixed" end
-    },
-    text_fixedWidth = {
-      name = L["Width"],
-      width = WeakAuras.normalWidth - indentWidth,
-      order = 53,
-      type = "range",
-      min = 1,
-      softMax = 200,
-      bigStep = 1,
-      hidden = function() return hiddenFontExtra() or data.text_automaticWidth ~= "Fixed" end
-    },
-    text_wordWrap = {
-      type = "select",
-      width = WeakAuras.normalWidth,
-      name = L["Overflow"],
-      order = 54,
-      values = OptionsPrivate.Private.text_word_wrap,
-      hidden = function() return hiddenFontExtra() or data.text_automaticWidth ~= "Fixed" end
-    },
-
-    text_anchor = {
-      type = "description",
-      name = "",
-      order = 55,
-      hidden = hiddenFontExtra,
+      order = 61,
+      hidden = hiddenFunction,
       control = "WeakAurasExpandAnchor",
       arg = {
-        expanderName = "subtext" .. index .. "#" .. subIndex
+        expanderName = "subtext_anchor" .. index .. "#" .. subIndex
       }
     }
-  }
 
-  -- Note: Anchor Options need to be generalized once there are multiple sub regions
-  -- While every sub region will have anchor options, the initial
-  -- design I had for anchor options proved to be not general enough for
-  -- what SubText needed. So, I removed it, and postponed making it work for unknown future
-  -- sub regions
-  local anchors = {}
-  for child in OptionsPrivate.Private.TraverseLeafsOrAura(parentData) do
-    Mixin(anchors, OptionsPrivate.Private.GetAnchorsForData(child, "point"))
-  end
+    local commonTextOptions
 
-  -- Anchor Options
-  options.text_anchorsDescription = {
-    type = "execute",
-    control = "WeakAurasExpandSmall",
-    name = function()
-      local selfPoint = data.text_selfPoint ~= "AUTO" and self_point_types[data.text_selfPoint]
-      local anchorPoint = anchors[data.text_anchorPoint or "CENTER"] or anchors["CENTER"]
+    if not isKeybinding then
+      local function hideCustomTextOption()
+        if not parentData.subRegions then
+          return true
+        end
 
-      local xOffset = data.text_anchorXOffset or 0
-      local yOffset = data.text_anchorYOffset or 0
-
-      if (type(anchorPoint) == "table") then
-        anchorPoint = anchorPoint[1] .. "/" .. anchorPoint[2]
+        for index, subRegion in ipairs(parentData.subRegions) do
+          if subRegion.type == "subtext" and OptionsPrivate.Private.ContainsCustomPlaceHolder(subRegion.text_text) then
+            return false
+          end
+        end
+        return true
       end
 
-      if selfPoint then
-        if xOffset == 0 and yOffset == 0 then
-          return L["|cFFffcc00Anchors:|r Anchored |cFFFF0000%s|r to frame's |cFFFF0000%s|r"]:format(selfPoint, anchorPoint)
-        else
-          return L["|cFFffcc00Anchors:|r Anchored |cFFFF0000%s|r to frame's |cFFFF0000%s|r with offset |cFFFF0000%s/%s|r"]:format(selfPoint, anchorPoint, xOffset, yOffset)
+      commonTextOptions = {
+        __title = L["Common Text"],
+        __hidden = function() return hideCustomTextOption() end,
+        text_customTextUpdate = {
+          type = "select",
+          width = WeakAuras.doubleWidth,
+          hidden = hideCustomTextOption,
+          name = L["Update Custom Text On..."],
+          values = OptionsPrivate.Private.text_check_types,
+          order = 3,
+          get = function() return parentData.customTextUpdate or "event" end,
+          set = function(info, v)
+            parentData.customTextUpdate = v
+            WeakAuras.Add(parentData)
+            WeakAuras.ClearAndUpdateOptions(parentData.id)
+          end
+        },
+      }
+
+      OptionsPrivate.commonOptions.AddCodeOption(commonTextOptions, parentData, L["Custom Function"], "customText", "https://github.com/WeakAuras/WeakAuras2/wiki/Custom-Code-Blocks#custom-text",
+                              4,  hideCustomTextOption, {"customText"}, false)
+
+                                  -- Add Text Format Options
+      local hidden = function()
+        return OptionsPrivate.IsCollapsed("format_option", "text", "text_text" .. index, true)
+      end
+
+      local setHidden = function(hidden)
+        OptionsPrivate.SetCollapsed("format_option", "text", "text_text" .. index, hidden)
+      end
+
+      local order = 12
+      local function addOption(key, option)
+        option.order = order
+        order = order + 0.01
+        if option.reloadOptions then
+          option.reloadOptions = nil
+          option.set = function(info, v)
+            data["text_text_format_" .. key] = v
+            WeakAuras.Add(parentData)
+            WeakAuras.ClearAndUpdateOptions(parentData.id, true)
+          end
+        end
+        options["text_text_format_" .. key] = option
+      end
+
+      if parentData.controlledChildren then
+        local list = {}
+        for child in OptionsPrivate.Private.TraverseLeafs(parentData) do
+          if child.subRegions then
+            local childSubRegion = child.subRegions[index]
+            if childSubRegion then
+              tinsert(list, childSubRegion)
+            end
+          end
+        end
+
+        for listIndex, childSubRegion in ipairs(list) do
+          local get = function(key)
+            return childSubRegion["text_text_format_" .. key]
+          end
+          local input = childSubRegion["text_text"]
+          OptionsPrivate.AddTextFormatOption(input, true, get, addOption, hidden, setHidden, false, listIndex, #list)
         end
       else
-        if xOffset == 0 and yOffset == 0 then
-          return L["|cFFffcc00Anchors:|r Anchored to frame's |cFFFF0000%s|r"]:format(anchorPoint)
-        else
-          return L["|cFFffcc00Anchors:|r Anchored to frame's |cFFFF0000%s|r with offset |cFFFF0000%s/%s|r"]:format(anchorPoint, xOffset, yOffset)
+        local get = function(key)
+          return data["text_text_format_" .. key]
         end
+        local input = data["text_text"]
+        OptionsPrivate.AddTextFormatOption(input, true, get, addOption, hidden, setHidden, false)
       end
-    end,
-    width = WeakAuras.doubleWidth,
-    order = 60,
-    image = function()
-      local collapsed = OptionsPrivate.IsCollapsed("subregion", "text_anchors", tostring(index), true)
-      return collapsed and "collapsed" or "expanded"
-    end,
-    imageWidth = 15,
-    imageHeight = 15,
-    func = function(info, button)
-      local collapsed = OptionsPrivate.IsCollapsed("subregion", "text_anchors", tostring(index), true)
-      OptionsPrivate.SetCollapsed("subregion", "text_anchors", tostring(index), not collapsed)
-    end,
-    arg = {
-      expanderName = "subtext_anchor" .. index .. "#" .. subIndex
-    }
-  }
 
-
-  local hiddenFunction = function()
-    return OptionsPrivate.IsCollapsed("subregion", "text_anchors", tostring(index), true)
-  end
-
-  options.text_anchor_space = {
-    type = "description",
-    name = "",
-    order = 60.15,
-    hidden = hiddenFunction,
-    width = indentWidth
-  }
-
-  options.text_selfPoint = {
-    type = "select",
-    width = WeakAuras.normalWidth - indentWidth,
-    name = L["Anchor"],
-    order = 60.2,
-    values = self_point_types,
-    hidden = hiddenFunction
-  }
-
-  options.text_anchorPoint = {
-    type = "select",
-    width = WeakAuras.normalWidth,
-    name = function()
-      return L["To Frame's"]
-    end,
-    order = 60.3,
-    values = anchors,
-    hidden = hiddenFunction,
-    control = "WeakAurasTwoColumnDropdown"
-  }
-
-  options.text_anchor_space2 = {
-    type = "description",
-    name = "",
-    order = 60.35,
-    hidden = hiddenFunction,
-    width = indentWidth
-  }
-
-  options.text_anchorXOffset = {
-    type = "range",
-    width = WeakAuras.normalWidth - indentWidth,
-    name = L["X Offset"],
-    order = 60.4,
-    softMin = (-1 * screenWidth),
-    softMax = screenWidth,
-    bigStep = 10,
-    hidden = hiddenFunction
-  }
-
-  options.text_anchorYOffset = {
-    type = "range",
-    width = WeakAuras.normalWidth,
-    name = L["Y Offset"],
-    order = 60.5,
-    softMin = (-1 * screenHeight),
-    softMax = screenHeight,
-    bigStep = 10,
-    hidden = hiddenFunction
-  }
-
-  options.text_anchor_anchor = {
-    type = "description",
-    name = "",
-    order = 61,
-    hidden = hiddenFunction,
-    control = "WeakAurasExpandAnchor",
-    arg = {
-      expanderName = "subtext_anchor" .. index .. "#" .. subIndex
-    }
-  }
-
-  local function hideCustomTextOption()
-    if not parentData.subRegions then
-      return true
+      addOption("footer", {
+        type = "description",
+        name = "",
+        width = WeakAuras.doubleWidth,
+        hidden = hidden
+      })
     end
 
-    for index, subRegion in ipairs(parentData.subRegions) do
-      if subRegion.type == "subtext" and OptionsPrivate.Private.ContainsCustomPlaceHolder(subRegion.text_text) then
-        return false
-      end
-    end
-    return true
+    OptionsPrivate.AddUpDownDeleteDuplicate(options, parentData, index, isKeybinding and "subkeybinding" or "subtext")
+
+    return options, commonTextOptions
   end
-
-  local commonTextOptions = {
-    __title = L["Common Text"],
-    __hidden = function() return hideCustomTextOption() end,
-    text_customTextUpdate = {
-      type = "select",
-      width = WeakAuras.doubleWidth,
-      hidden = hideCustomTextOption,
-      name = L["Update Custom Text On..."],
-      values = OptionsPrivate.Private.text_check_types,
-      order = 3,
-      get = function() return parentData.customTextUpdate or "event" end,
-      set = function(info, v)
-        parentData.customTextUpdate = v
-        WeakAuras.Add(parentData)
-        WeakAuras.ClearAndUpdateOptions(parentData.id)
-      end
-    },
-  }
-
-  OptionsPrivate.commonOptions.AddCodeOption(commonTextOptions, parentData, L["Custom Function"], "customText", "https://github.com/WeakAuras/WeakAuras2/wiki/Custom-Code-Blocks#custom-text",
-                          4,  hideCustomTextOption, {"customText"}, false)
-
-  -- Add Text Format Options
-  local hidden = function()
-    return OptionsPrivate.IsCollapsed("format_option", "text", "text_text" .. index, true)
-  end
-
-  local setHidden = function(hidden)
-    OptionsPrivate.SetCollapsed("format_option", "text", "text_text" .. index, hidden)
-  end
-
-  local order = 12
-  local function addOption(key, option)
-    option.order = order
-    order = order + 0.01
-    if option.reloadOptions then
-      option.reloadOptions = nil
-      option.set = function(info, v)
-        data["text_text_format_" .. key] = v
-        WeakAuras.Add(parentData)
-        WeakAuras.ClearAndUpdateOptions(parentData.id, true)
-      end
-    end
-    options["text_text_format_" .. key] = option
-  end
-
-  if parentData.controlledChildren then
-    local list = {}
-    for child in OptionsPrivate.Private.TraverseLeafs(parentData) do
-      if child.subRegions then
-        local childSubRegion = child.subRegions[index]
-        if childSubRegion then
-          tinsert(list, childSubRegion)
-        end
-      end
-    end
-
-    for listIndex, childSubRegion in ipairs(list) do
-      local get = function(key)
-        return childSubRegion["text_text_format_" .. key]
-      end
-      local input = childSubRegion["text_text"]
-      OptionsPrivate.AddTextFormatOption(input, true, get, addOption, hidden, setHidden, false, listIndex, #list)
-    end
-  else
-    local get = function(key)
-      return data["text_text_format_" .. key]
-    end
-    local input = data["text_text"]
-    OptionsPrivate.AddTextFormatOption(input, true, get, addOption, hidden, setHidden, false)
-  end
-
-  addOption("footer", {
-    type = "description",
-    name = "",
-    width = WeakAuras.doubleWidth,
-    hidden = hidden
-  })
-
-  OptionsPrivate.AddUpDownDeleteDuplicate(options, parentData, index, "subtext")
-
-  return options, commonTextOptions
 end
 
-WeakAuras.RegisterSubRegionOptions("subtext", createOptions, L["Shows one or more lines of text, which can include dynamic information such as progress or stacks"])
+local subtextCreateOptions = createCreateOptions()
+WeakAuras.RegisterSubRegionOptions("subtext", subtextCreateOptions, L["Shows one or more lines of text, which can include dynamic information such as progress or stacks"])
+
+local subkeybindingCreateOptions = createCreateOptions(true)
+WeakAuras.RegisterSubRegionOptions("subkeybinding", subkeybindingCreateOptions, L["Shows Keybinding"])


### PR DESCRIPTION
# Description

Add "Action Button" as aura anchor & glow external option

Require LibGetFrame-1.0 last version https://github.com/mrbuds/LibGetFrame

PS: No dynamic group anchoring, i don't think this option is relevant for dynamic groups.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested

It was tested with these triggers

- Cast
- Aura
- Combat Log
- Action Usable
- Cooldown Progress (spell)
- Cooldown Progress (item)
- Item Count

## Know Issues
~~External glow may not work on an aura already active after PEW or /reload~~
~~Moving a button on action bars after an aura has been anchored to a button, or a glow active, won't update the glow or anchor.~~
~~I'll have to add a callback tracking action button changes~~