### PR TITLE
don't use 20 as a fallback

### DIFF
--- a/WeakAurasOptions/AuthorOptions.lua
+++ b/WeakAurasOptions/AuthorOptions.lua
@@ -2233,7 +2233,7 @@ local function addUserModeOption(options, args, data, order, prefix, i)
       userOption.get = getUserNumAsString(option)
       userOption.set = setUserNum(data, option)
     elseif optionType == "range" then
-      userOption.softMax = option.softMax or 20
+      userOption.softMax = option.softMax
       userOption.softMin = option.softMin
       userOption.bigStep = option.bigStep
       userOption.min = option.min


### PR DESCRIPTION
if author did not provide a softMax then we should use max as the softMax instead.
indeed, this is what is done further down the procedure, where if max is also nil then we fallback to 100.
Fixes #3834
