### PR TITLE
Added support for ElvUI Cooldown module

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -38,6 +38,7 @@ globals = {
 	"CUSTOM_CLASS_COLORS",
 	"LibStub",
 	"OmniCC",
+	"ElvUI",
 
 	-- WeakAuras
 	"WeakAuras_DropDownMenu",

--- a/WeakAuras/RegionTypes/Icon.lua
+++ b/WeakAuras/RegionTypes/Icon.lua
@@ -261,6 +261,10 @@ local function create(parent, data)
   cooldown.SetDrawSwipeOrg = cooldown.SetDrawSwipe
   cooldown.SetDrawSwipe = function() end
 
+  if ElvUI and ElvUI[1] and ElvUI[1].CooldownEnabled and ElvUI[1].RegisterCooldown and ElvUI[1]:CooldownEnabled() then
+    ElvUI[1]:RegisterCooldown(cooldown, "WeakAuras");
+  end
+
   local SetFrameLevel = region.SetFrameLevel;
 
   function region.SetFrameLevel(self, level)
@@ -385,6 +389,9 @@ local function modify(parent, region, data)
     cooldown:SetHideCountdownNumbers(cooldownTextDisabled);
     if OmniCC and OmniCC.Cooldown and OmniCC.Cooldown.SetNoCooldownCount then
       OmniCC.Cooldown.SetNoCooldownCount(cooldown, cooldownTextDisabled)
+    end
+    if ElvUI and ElvUI[1] and ElvUI[1].CooldownEnabled and ElvUI[1].ToggleCooldown and ElvUI[1]:CooldownEnabled() then
+      ElvUI[1]:ToggleCooldown(cooldown, not cooldownTextDisabled);
     end
   end
   region:SetHideCountdownNumbers(data.cooldownTextDisabled)

--- a/WeakAuras/RegionTypes/Icon.lua
+++ b/WeakAuras/RegionTypes/Icon.lua
@@ -261,7 +261,7 @@ local function create(parent, data)
   cooldown.SetDrawSwipeOrg = cooldown.SetDrawSwipe
   cooldown.SetDrawSwipe = function() end
 
-  if ElvUI and ElvUI[1] and ElvUI[1].CooldownEnabled and ElvUI[1].RegisterCooldown and ElvUI[1]:CooldownEnabled() then
+  if not OmniCC and ElvUI and ElvUI[1] and ElvUI[1].CooldownEnabled and ElvUI[1].RegisterCooldown and ElvUI[1]:CooldownEnabled() then
     ElvUI[1]:RegisterCooldown(cooldown, "WeakAuras");
   end
 
@@ -389,8 +389,7 @@ local function modify(parent, region, data)
     cooldown:SetHideCountdownNumbers(cooldownTextDisabled);
     if OmniCC and OmniCC.Cooldown and OmniCC.Cooldown.SetNoCooldownCount then
       OmniCC.Cooldown.SetNoCooldownCount(cooldown, cooldownTextDisabled)
-    end
-    if ElvUI and ElvUI[1] and ElvUI[1].CooldownEnabled and ElvUI[1].ToggleCooldown and ElvUI[1]:CooldownEnabled() then
+    elseif ElvUI and ElvUI[1] and ElvUI[1].CooldownEnabled and ElvUI[1].ToggleCooldown and ElvUI[1]:CooldownEnabled() then
       ElvUI[1]:ToggleCooldown(cooldown, not cooldownTextDisabled);
     end
   end


### PR DESCRIPTION
# Description

This change allow ElvUI Cooldown module to replace icon cooldowns handled by default Blizzard code or OmniCC.
Feature is enabled by default for all ElvUI users as Cooldown module is enabled by default. It can be controlled by normal WA options (_Hide Timer Text_) or in ElvUI options panel. Where users also can find options to change style of the CD.

As requested code execute extensive nil checks.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested

At the moment code need to be tested with `development` branch of ElvUI. But changes required will be merged and released soon. If somebody is using incompatible version of ElvUI code fail graciously.

ElvUI CD module operate only on text part of the cooldown frame so other elements like swipe are unaffected.

As requested following functions were tested:

- cooldown:SetReverse 
- cooldown:SetDrawBling
- cooldown:SetDrawSwipeOrg
- cooldown:SetDrawEdge 
- cooldown:SetCooldown
- cooldown:Pause
- cooldown:Resume

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings

