### PR TITLE
Zone Id tooltip: show dungeon/raid tiers from current to last one

### DIFF
--- a/WeakAuras/Types_Retail.lua
+++ b/WeakAuras/Types_Retail.lua
@@ -11,50 +11,54 @@ function Private.InitializeEncounterAndZoneLists()
   if encounter_list ~= "" then
     return
   end
-  EJ_SelectTier(EJ_GetCurrentTier())
+	for tier = EJ_GetCurrentTier(), EJ_GetNumTiers() do
+		EJ_SelectTier(tier)
+		local tierName = EJ_GetTierInfo(tier)
+		for _, inRaid in ipairs({false, true}) do
+			local instance_index = 1
+			local instance_id = EJ_GetInstanceByIndex(instance_index, inRaid)
+			local title = ("%s %s"):format(tierName , inRaid and L["Raids"] or L["Dungeons"])
+			local zones = ""
+			while instance_id do
+				EJ_SelectInstance(instance_id)
+				local instance_name, _, _, _, _, _, dungeonAreaMapID = EJ_GetInstanceInfo(instance_id)
+				local ej_index = 1
+				local boss, _, _, _, _, _, encounter_id = EJ_GetEncounterInfoByIndex(ej_index, instance_id)
 
-  for _, inRaid in ipairs({false, true}) do
-    local instance_index = 1
-    local instance_id = EJ_GetInstanceByIndex(instance_index, inRaid)
-    local title = inRaid and L["Raids"] or L["Dungeons"]
-    zoneId_list = ("%s|cffffd200%s|r\n"):format(zoneId_list, title)
+				-- zone ids
+				if dungeonAreaMapID and dungeonAreaMapID ~= 0 then
+					local mapGroupId = C_Map.GetMapGroupID(dungeonAreaMapID)
+					if mapGroupId then -- If there's a group id, only list that one
+						zones = ("%s%s: g%d\n"):format(zones, instance_name, mapGroupId)
+					else
+						zones = ("%s%s: %d\n"):format(zones, instance_name, dungeonAreaMapID)
+					end
+				end
 
-    while instance_id do
-      EJ_SelectInstance(instance_id)
-      local instance_name, _, _, _, _, _, dungeonAreaMapID = EJ_GetInstanceInfo(instance_id)
-      local ej_index = 1
-      local boss, _, _, _, _, _, encounter_id = EJ_GetEncounterInfoByIndex(ej_index, instance_id)
-
-      -- zone ids
-      if dungeonAreaMapID and dungeonAreaMapID ~= 0 then
-        local mapGroupId = C_Map.GetMapGroupID(dungeonAreaMapID)
-        if mapGroupId then -- If there's a group id, only list that one
-          zoneId_list = ("%s%s: g%d\n"):format(zoneId_list, instance_name, mapGroupId)
-        else
-          zoneId_list = ("%s%s: %d\n"):format(zoneId_list, instance_name, dungeonAreaMapID)
-        end
-      end
-
-      -- Encounter ids
-      if inRaid then
-        while boss do
-          if encounter_id then
-            if instance_name then
-              encounter_list = ("%s|cffffd200%s|r\n"):format(encounter_list, instance_name)
-              instance_name = nil -- Only add it once per section
-            end
-            encounter_list = ("%s%s: %d\n"):format(encounter_list, boss, encounter_id)
-          end
-          ej_index = ej_index + 1
-          boss, _, _, _, _, _, encounter_id = EJ_GetEncounterInfoByIndex(ej_index, instance_id)
-        end
-        encounter_list = encounter_list .. "\n"
-      end
-      instance_index = instance_index + 1
-      instance_id = EJ_GetInstanceByIndex(instance_index, inRaid)
-    end
-    zoneId_list = zoneId_list .. "\n"
-  end
+				-- Encounter ids
+				if inRaid then
+					while boss do
+						if encounter_id then
+							if instance_name then
+								encounter_list = ("%s|cffffd200%s|r\n"):format(encounter_list, instance_name)
+								instance_name = nil -- Only add it once per section
+							end
+							encounter_list = ("%s%s: %d\n"):format(encounter_list, boss, encounter_id)
+						end
+						ej_index = ej_index + 1
+						boss, _, _, _, _, _, encounter_id = EJ_GetEncounterInfoByIndex(ej_index, instance_id)
+					end
+					encounter_list = encounter_list .. "\n"
+				end
+				instance_index = instance_index + 1
+				instance_id = EJ_GetInstanceByIndex(instance_index, inRaid)
+			end
+			if zones ~= "" then
+				zoneId_list = ("%s|cffffd200%s|r\n"):format(zoneId_list, title)
+				zoneId_list = zoneId_list .. zones.. "\n"
+			end
+		end
+	end
 
   encounter_list = encounter_list:sub(1, -3) .. "\n\n" .. L["Supports multiple entries, separated by commas\n"]
 end


### PR DESCRIPTION
At the time this is written, on retail it show both shadowlands & dragonflight data, and on DF's beta it show dragonflight dungeons and season 1 dungeons

retail:

![image](https://user-images.githubusercontent.com/189656/198826923-bf453429-d2b1-4904-8e42-463959631765.png)

beta:

![image](https://user-images.githubusercontent.com/189656/198826940-8f64b7a5-c0e6-423b-b91d-35a073af1a64.png)
