### PR TITLE
Enable border settings for custom grow in Dynamic Group

### DIFF
--- a/WeakAuras/RegionTypes/DynamicGroup.lua
+++ b/WeakAuras/RegionTypes/DynamicGroup.lua
@@ -1262,6 +1262,13 @@ local function modify(parent, region, data)
         self:SetHeight(height)
         self.currentWidth = width
         self.currentHeight = height
+
+        local regionLeft = region:GetLeft()
+        local regionBottom = region:GetBottom()
+        self.background:SetPoint("BOTTOMLEFT", region, "BOTTOMLEFT", minX + -1 * data.borderOffset - regionLeft,
+                                                                     minY + -1 * data.borderOffset - regionBottom)
+        self.background:SetPoint("TOPRIGHT", region, "BOTTOMLEFT", maxX + data.borderOffset - regionLeft,
+                                                                   maxY + data.borderOffset - regionBottom)
       else
         self:Hide()
       end

--- a/WeakAuras/RegionTypes/DynamicGroup.lua
+++ b/WeakAuras/RegionTypes/DynamicGroup.lua
@@ -798,7 +798,7 @@ local function modify(parent, region, data)
   region:SetScale(data.scale and data.scale > 0 and data.scale <= 10 and data.scale or 1)
   WeakAuras.regionPrototype.modify(parent, region, data)
 
-  if data.border and (data.grow ~= "CUSTOM" and not data.useAnchorPerUnit) then
+  if data.border and not data.useAnchorPerUnit then
     local background = region.background
     background:SetBackdrop({
       edgeFile = data.borderEdge ~= "None" and SharedMedia:Fetch("border", data.borderEdge) or "",

--- a/WeakAurasOptions/RegionOptions/DynamicGroup.lua
+++ b/WeakAurasOptions/RegionOptions/DynamicGroup.lua
@@ -433,7 +433,7 @@ local function createOptions(id, data)
   OptionsPrivate.commonOptions.AddCodeOption(options, data, L["Custom Anchor"], "custom_anchor_per_unit", "https://github.com/WeakAuras/WeakAuras2/wiki/Custom-Code-Blocks#group-by-frame",
                           1.7, function() return not(data.grow ~= "CUSTOM" and data.useAnchorPerUnit and data.anchorPerUnit == "CUSTOM") end, {"customAnchorPerUnit"}, false, { setOnParent = true })
 
-  local borderHideFunc = function() return data.useAnchorPerUnit or data.grow == "CUSTOM" end
+  local borderHideFunc = function() return data.useAnchorPerUnit end
   local disableSelfPoint = function() return data.grow ~= "CUSTOM" and data.grow ~= "GRID" and not data.useAnchorPerUnit end
 
   for k, v in pairs(OptionsPrivate.commonOptions.BorderOptions(id, data, nil, borderHideFunc, 70)) do


### PR DESCRIPTION
# Description

Currently it is not possible to select a border for a dynamic group if Grow "custom" is selected ( https://i.imgur.com/5leQgy1.png )
Borders set up well to the region if the grow is accuracy centralized
This will work for most cases, and it won't matter if someone uses a custom border binding.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested

Tested on Retail WeakAuras 5.0.5 version. ( https://i.imgur.com/qujg6ml.png )

## Checklist
<!-- These can be checked off after the pull request is submitted, in case you want discussion before they are completely ready -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

<!-- Is there any additional work that needs to be done? If so, add it to the above list -->
