### PR TITLE
Update "Talent Known" trigger on spec changes

### DIFF
--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -5993,7 +5993,7 @@ Private.event_prototypes = {
           "PLAYER_TALENT_UPDATE"
         }
       elseif WeakAuras.IsRetail() then
-        events = { "TRAIT_CONFIG_CREATED", "TRAIT_CONFIG_UPDATED", "PLAYER_TALENT_UPDATE" }
+        events = { "TRAIT_CONFIG_CREATED", "TRAIT_CONFIG_UPDATED", "PLAYER_TALENT_UPDATE", "PLAYER_SPECIALIZATION_CHANGED" }
       end
       return {
         ["events"] = events


### PR DESCRIPTION
Added PLAYER_SPECIALIZATION_CHANGED event so this trigger is updated when the player changes their spec.

# Description

Example: Add icon to display feral druid's Adaptive Swarm cooldown, and set a trigger to only show this icon when that talent is learned. Change to guardian spec. Logout, login. Change back to feral spec.

Before this commit, the icon would not show unless I opened /wa, now it shows up directly after changing the spec.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

See description above for before and after this commit.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
