### PR TITLE
smallfix

### DIFF
--- a/WeakAuras/RegionTypes/Texture.lua
+++ b/WeakAuras/RegionTypes/Texture.lua
@@ -116,7 +116,7 @@ local function modify(parent, region, data)
       mirror_h = not mirror_h;
     end
     local ulx,uly , llx,lly , urx,ury , lrx,lry = 0,0, 0,1, 1,0, 1,1
-    if data.legacyZoomOut then
+    if data.legacyZoomOut and not region.texture.IsAtlas then
       ulx,uly , llx,lly , urx,ury , lrx,lry = GetLegacyFullRotateTexCoord()
     end
     if(mirror_h) then

--- a/WeakAurasOptions/RegionOptions/Texture.lua
+++ b/WeakAurasOptions/RegionOptions/Texture.lua
@@ -37,49 +37,36 @@ local function createOptions(id, data)
       control = "WeakAurasIcon",
       image = "Interface\\AddOns\\WeakAuras\\Media\\Textures\\browse",
     },
-    desaturate = {
-      type = "toggle",
-      width = WeakAuras.normalWidth,
-      name = L["Desaturate"],
-      order = 2,
-    },
-    space2 = {
-      type = "execute",
-      name = "",
-      width = WeakAuras.normalWidth,
-      order = 5,
-      image = function() return "", 0, 0 end,
-    },
     color = {
       type = "color",
       width = WeakAuras.normalWidth,
       name = L["Color"],
       hasAlpha = true,
-      order = 10
+      order = 2
     },
-    blendMode = {
-      type = "select",
-      width = WeakAuras.normalWidth,
-      name = L["Blend Mode"],
-      order = 12,
-      values = OptionsPrivate.Private.blend_types
-    },
-    mirror = {
+    desaturate = {
       type = "toggle",
       width = WeakAuras.normalWidth,
-      name = L["Mirror"],
-      order = 20,
+      name = L["Desaturate"],
+      order = 3,
     },
     alpha = {
       type = "range",
       control = "WeakAurasSpinBox",
       width = WeakAuras.normalWidth,
       name = L["Alpha"],
-      order = 21,
+      order = 4,
       min = 0,
       max = 1,
       bigStep = 0.01,
       isPercent = true
+    },
+    blendMode = {
+      type = "select",
+      width = WeakAuras.normalWidth,
+      name = L["Blend Mode"],
+      order = 5,
+      values = OptionsPrivate.Private.blend_types
     },
     rotation = {
       type = "range",
@@ -90,20 +77,27 @@ local function createOptions(id, data)
       max = 360,
       step = 1,
       bigStep = 3,
-      order = 22,
+      order = 6,
+    },
+    mirror = {
+      type = "toggle",
+      width = WeakAuras.normalWidth,
+      name = L["Mirror"],
+      order = 7,
     },
     legacyZoomOut = {
       type = "toggle",
       width = WeakAuras.normalWidth,
       name = L["Legacy Zoom Out"],
       desc = L["Rotating a texture around arbitary angles used to require a zoom out. This is no longer required, this option only exist for compatibility with previous behaviour."],
-      order = 23,
+      order = 8,
+      hidden = IsAtlas(data.texture)
     },
     textureWrapMode = {
       type = "select",
       width = WeakAuras.normalWidth,
       name = L["Texture Wrap"],
-      order = 36,
+      order = 9,
       values = OptionsPrivate.Private.texture_wrap_types,
       hidden = IsAtlas(data.texture)
     },


### PR DESCRIPTION
Texture: disable legacyZoomOut with atlas texture and reorder options

Fixes #4072

![image](https://user-images.githubusercontent.com/189656/204297404-e1410d17-35fe-4bc2-8d97-788f74c17caa.png)

![image](https://user-images.githubusercontent.com/189656/204297355-cbbb99ae-d3f4-49f3-a7d7-9754c664ff0a.png)

