### PR TITLE
Fix power cost of abilities that change with certain auras.

### DIFF
--- a/WeakAuras/GenericTrigger.lua
+++ b/WeakAuras/GenericTrigger.lua
@@ -3375,7 +3375,8 @@ function WeakAuras.GetSpellCost(powerTypeToCheck)
   if spellID then
     local costTable = GetSpellPowerCost(spellID);
     for _, costInfo in pairs(costTable) do
-      if costInfo.type == powerTypeToCheck then
+      -- When there is no required aura for a power cost, the API returns an aura ID of 0 and false for hasRequiredAura despite being valid.
+      if costInfo.type == powerTypeToCheck and (costInfo.requiredAuraID == 0 or costInfo.hasRequiredAura) then
         return costInfo.cost;
       end
     end


### PR DESCRIPTION
# Description

The original code short circuits when it finds the first relevant power value, however this is not correct in certain scenarios. Using Holy Priest as an example, Flash Heal will return the Discipline Priest cost, as it is the first value found. I'm not sure why Blizzard's API works this way, but this is incorrectly showing 0.

To be precise, this problem shows up when attempting to cast Flash Heal or Smite as a Holy Priest with a progress bar with a default power trigger tracking mana and Overlay Cost of Casts enabled (export below).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

I tested this with plenty of priest and shaman abilities (including the Maelstrom spender Elemental Blast)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

```
!WA:2!1vvtpoXrtyp4iqyjqGtckRekIGcBGOaHSkWB(asWJxBSjl2MXdWses29mDBpDy80T6UN1R3le8HO9SpNdr(CozXpa0(lOL17pGOvr5hWEprP6ESwhqS(Gvvvxv31hp1Z4uT4GI4I4D)8Psos8ShtXQO3FpRCZE9Ke1MoZrPQiMOjxrzjYcIrzhu7opF3J9h5YLBgkjeoVfJMOckxPHFfV52lWJPqMyC4N910VpdtCl9q)MU0qws0yLG2Vprip9QIfI)LRAeN4MMqv8IPsshuGKjcQrqXMG7UVmnGSfjr1oTxp62Z6uUuB)oT9l55V)s3TUUNrxgXgwMjvD9sqdiYchgFlbbI3RDRkBSXeoBiryEyNXsojoUowwWZ6MxlZr6thWJrJiIXM70KCDNBKomUUtXKaiJ8bzrTkB0Q6d3ysAYIIQa)SOqfDlIFMUj9(9Ctn9GoHSyM4E5HFhaDrIibf)iOJanRHtqj0b2(2n9KkKqvvFk3ewczpcssAReKK(QOtmhNkSE1XKjcjbUwSCSXht6Ox1DaIMaXQxv)jNqFz9v0FQE1GE0eQm6nnpoajkBtjNAF)F(Yx(kymNppuDsKY8mKO)le5jotH(PhPVbFCVZPp1Cqnaf(S(cwAcEHHEmbjZWURW)ifzBvh7FGDO86W7OOdGEPGesn1D(jh6YfVeNVYBjGmbptC49ThjjX9S4q9j5VR1cGDzMUxOfz7wcupi7wOBtWwJVyEga(jzvJZE2Z)PuPI2BK(4tfgylXhm62OzJk8p(OY9ysFu4Oo9IzmrK(ucOOnEXVYrfaEeahPHDurccarJXJMA9AjAyYIOsu8Zuvq35cpifHHba6c((8Iz1CecZgUzwYN)1mUOIoFo(foQuyad3Xmq7o3E4qMa)ybIp(XleYAgBbJKGysx(zYAQlx4NwVrJkED2OsvF(hEupsMMZ8dlgdI0TbGHxAQnDhYklMelkgNfpxwXSap64KF33txjV(lV4Ls0Ewd6)N(K6Vs)16V5f6V1rFl9X13w)DaM(oAxBBuxwVUU65ZPRPRRVxx9pmllT9QF3A(VfSvYcbyPO1k6h4OBOBgerO9JaAp(Z)7Fd2hCJziCvxjK3NZBqASIwWfOncpNEZcEHXiP0ifOqXabIrCF7kJlOInR(RvA915Nb4pkHnyncMGVpA7OmE4YhIaS8dTzPIqcmhFd)Pjrtf29olLdc2nHn3dwU7DytRv(RFTBim8pWo6n1xQGlS4RkO)SctSeqskM4zBhITxWV)QB9ZVtotHUdJnWzMnVQz7b3wyAwPcYy3y6o7Ge4fNsXysIxJkpQIxgbHFMF8lx3WQ1dfsEAzeSyL03fjE6dRF1LAxTT9Be2WIMQyHBLra(bo)Y0lsXZUpkbbU5tKQdYGjvfazUPWdAx2RsLgEOyEekV3qZwDT78RH)t3C5o2SEg3aEsyRj)APWnTP)Dx)lQD51UYqyLkX8mKOaOj0J2VWmMGcZllt60An9Q)JnB4xAJPg2uA2haNrtYqhGwHjlPCoErP3nU2Ax76f36)V5)(d```