### PR TITLE
reset font object on acquire

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -121,6 +121,7 @@ globals = {
 	"GameFontNormal",
 	"GameFontNormalHuge",
 	"GameFontHighlight",
+   "GameFontHighlightLarge",
 	"FONT_COLOR_CODE_CLOSE",
 	"ICON_TAG_LIST",
 	"MAX_PVP_TALENT_COLUMNS",

--- a/.luarc.json
+++ b/.luarc.json
@@ -53,6 +53,7 @@
         "FINGER1SLOT_UNIQUE",
         "FONT_COLOR_CODE_CLOSE",
         "GameFontHighlight",
+        "GameFontHighlightLarge",
         "GameFontNormal",
         "GameFontNormalHuge",
         "GameTooltip",

--- a/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasExpand.lua
+++ b/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasExpand.lua
@@ -38,6 +38,7 @@ local methods = {
 		self:SetHeight(110)
 		self:SetWidth(110)
 		self:SetLabel()
+		self:SetFontObject(GameFontHighlightLarge)
 		self:SetImage(nil)
 		self:SetImageSize(64, 64)
 		self:SetDisabled(false)


### PR DESCRIPTION
The update dialog can sometimes set one of these widgets to have GameFontHighlight instead, which is smaller and if that widget is reused elsewhere it looks wrong