### PR TITLE
only run sort/grow when interesting state changes happen

### DIFF
--- a/WeakAuras/Modernize.lua
+++ b/WeakAuras/Modernize.lua
@@ -1631,5 +1631,16 @@ function Private.Modernize(data)
     end
   end
 
+  if data.internalVersion < 62 then
+    if data.regionType == "dynamicgroup" then
+      if data.sort == "CUSTOM" and type(data.sortOn) ~= "string" then
+        data.sortOn = "changed"
+      end
+      if data.grow == "CUSTOM" and type(data.growOn) ~= "string" then
+        data.growOn = "changed"
+      end
+    end
+  end
+
   data.internalVersion = max(data.internalVersion or 0, WeakAuras.InternalVersion())
 end

--- a/WeakAuras/RegionTypes/DynamicGroup.lua
+++ b/WeakAuras/RegionTypes/DynamicGroup.lua
@@ -983,7 +983,7 @@ local function isDifferent(regionData, cache, events)
         cachedState[event] = state[event]
       end
     else
-      local cachedState = cache[regionData.id][regionData.cloneId]
+      local cachedState = cache[id][cloneId]
       for event in pairs(events) do
         if regionData.region.state[event] ~= cachedState[event] then
           cachedState[event] = regionData.region.state[event]

--- a/WeakAuras/RegionTypes/DynamicGroup.lua
+++ b/WeakAuras/RegionTypes/DynamicGroup.lua
@@ -114,6 +114,8 @@ local function create(parent)
   region.sortedChildren = {}
   region.controlledChildren = {}
   region.updatedChildren = {}
+  region.sortStates = {}
+  region.growStates = {}
   local background = CreateFrame("Frame", nil, region, "BackdropTemplate")
   region.background = background
   region.selfPoint = "TOPLEFT"
@@ -274,7 +276,7 @@ local sorters = {
     return WeakAuras.ComposeSorts(
       WeakAuras.SortAscending({"dataIndex"}),
       WeakAuras.SortAscending({"region", "state", "index"})
-    )
+    ), { index = true }
   end,
   hybrid = function(data)
     local sortHybridTable = data.sortHybridTable or {}
@@ -305,23 +307,31 @@ local sorters = {
       sortHybridStatus,
       sortExpirationTime,
       WeakAuras.SortAscending({"dataIndex"})
-    )
+    ), {expirationTime = true}
   end,
   ascending = function(data)
     return WeakAuras.ComposeSorts(
       WeakAuras.SortAscending({"region", "state", "expirationTime"}),
       WeakAuras.SortAscending({"dataIndex"})
-    )
+    ), {expirationTime = true}
   end,
   descending = function(data)
     return WeakAuras.ComposeSorts(
       WeakAuras.SortDescending({"region", "state", "expirationTime"}),
       WeakAuras.SortAscending({"dataIndex"})
-    )
+    ), {expirationTime = true}
   end,
   custom = function(data)
     local sortStr = data.customSort or ""
     local sortFunc = WeakAuras.LoadFunction("return " .. sortStr) or noop
+    local sortOn = nil
+    local events = WeakAuras.split(data.sortOn or "")
+    if #events > 0 then
+      sortOn = {}
+      for _, event in ipairs(events) do
+        events[event] = true
+      end
+    end
     return function(a, b)
       Private.ActivateAuraEnvironment(data.id)
       local ok, result = xpcall(sortFunc, Private.GetErrorHandlerId(data.id, L["Custom Sort"]), a, b)
@@ -329,7 +339,7 @@ local sorters = {
       if ok then
         return result
       end
-    end
+    end, sortOn
   end
 }
 WeakAuras.SortFunctions = sorters
@@ -913,6 +923,14 @@ local growers = {
   CUSTOM = function(data)
     local growStr = data.customGrow or ""
     local growFunc = WeakAuras.LoadFunction("return " .. growStr) or noop
+    local growOn = nil
+    local events = WeakAuras.split(data.growOn or "")
+    if #events > 0 then
+      growOn = {}
+      for _, event in ipairs(events) do
+        events[event] = true
+      end
+    end
     return function(newPositions, activeRegions)
       Private.ActivateAuraEnvironment(data.id)
       local ok = xpcall(growFunc, Private.GetErrorHandlerId(data.id, L["Custom Grow"]), newPositions, activeRegions)
@@ -920,7 +938,7 @@ local growers = {
       if not ok then
         wipe(newPositions)
       end
-    end
+    end, growOn
   end
 }
 WeakAuras.GrowFunctions = growers
@@ -937,6 +955,50 @@ local function SafeGetPos(region, func)
   local ok, value1, value2 = xpcall(func, nullErrorHandler, region)
   if ok then
     return value1, value2
+  end
+end
+
+local function isDifferent(regionData, cache, events)
+  local id = regionData.id
+  local cloneId = regionData.cloneId or ""
+  local state = regionData.region.state
+  if not events then
+    return false
+  elseif events.changed then
+    return true -- escape hatch, not super recommended
+  else
+    local isDifferent = false
+    if not cache[id] then
+      isDifferent = true
+      local cachedState = {}
+      cache[id] = {[cloneId] = cachedState}
+      for event in pairs(events) do
+        cachedState[event] = state[event]
+      end
+    elseif not cache[id][cloneId] then
+      isDifferent = true
+      local cachedState = {}
+      cache[id][cloneId] = cachedState
+      for event in pairs(events) do
+        cachedState[event] = state[event]
+      end
+    else
+      local cachedState = cache[regionData.id][regionData.cloneId]
+      for event in pairs(events) do
+        if regionData.region.state[event] ~= cachedState[event] then
+          cachedState[event] = regionData.region.state[event]
+          isDifferent = true
+        end
+      end
+    end
+    return isDifferent
+  end
+end
+
+local function clearCache(cache, id, cloneId)
+  cloneId = cloneId or ""
+  if cache[id] then
+    cache[id][cloneId] = nil
   end
 end
 
@@ -1067,6 +1129,8 @@ local function modify(parent, region, data)
       Private.StartProfileAura(data.id)
       self.needToReload = false
       self.sortedChildren = {}
+      self.sortStates = {}
+      self.growStates = {}
       self.controlledChildren = {}
       self.updatedChildren = {}
       self.controlPoints:ReleaseAll()
@@ -1130,9 +1194,14 @@ local function modify(parent, region, data)
     -- if it has been, then don't insert it again
     if not regionData.active and self.updatedChildren[regionData] == nil then
       tinsert(self.sortedChildren, regionData)
+      self.updatedChildren[regionData] = true
+      self:SortUpdatedChildren()
+    elseif isDifferent(regionData, self.sortStates, self.sortOn) then
+      self.updatedChildren[regionData] = true
+      self:SortUpdatedChildren()
+    elseif isDifferent(regionData, self.growStates, self.growOn) then
+      self:PositionChildren()
     end
-    self.updatedChildren[regionData] = true
-    self:SortUpdatedChildren()
   end
 
   function region:RemoveChild(childID, cloneID)
@@ -1142,6 +1211,8 @@ local function modify(parent, region, data)
     if not regionData then return end
     releaseRegionData(regionData)
     self.updatedChildren[regionData] = false
+    clearCache(self.sortStates, childID, cloneID)
+    clearCache(self.growStates, childID, cloneID)
     self:SortUpdatedChildren()
   end
 
@@ -1152,10 +1223,12 @@ local function modify(parent, region, data)
     if regionData and not regionData.region.toShow then
       self.updatedChildren[regionData] = false
     end
+    clearCache(self.sortStates, childID, cloneID)
+    clearCache(self.growStates, childID, cloneID)
     self:SortUpdatedChildren()
   end
 
-  region.sortFunc = createSortFunc(data)
+  region.sortFunc, region.sortOn = createSortFunc(data)
 
   function region:SortUpdatedChildren()
     -- iterates through cache to insert all updated children in the right spot
@@ -1200,7 +1273,7 @@ local function modify(parent, region, data)
     end
   end
 
-  region.growFunc = createGrowFunc(data)
+  region.growFunc, region.growOn = createGrowFunc(data)
   region.anchorPerUnit = data.useAnchorPerUnit and data.anchorPerUnit
 
   local animate = data.animate

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -1,7 +1,7 @@
 --- @type string, Private
 local AddonName, Private = ...
 
-local internalVersion = 61
+local internalVersion = 62
 
 -- Lua APIs
 local insert = table.insert

--- a/WeakAurasOptions/RegionOptions/DynamicGroup.lua
+++ b/WeakAurasOptions/RegionOptions/DynamicGroup.lua
@@ -139,6 +139,23 @@ local function createOptions(id, data)
         OptionsPrivate.ResetMoverSizer()
       end,
     },
+    growOn = {
+      type = "input",
+      width = WeakAuras.doubleWidth,
+      name = L["Run on..."],
+      desc = L["WeakAuras will always run custom grow code when a region is added, removed, or re-ordered.\n\nYou can add a comma-separated list of state values here that (when changed) WeakAuras should also run the Grow Code on."],
+      order = 2 - 0.1,
+      get = function()
+        return data.growOn or ""
+      end,
+      hidden = function() return data.grow ~= "CUSTOM" end,
+      set = function(info, v)
+        data.growOn = v
+        WeakAuras.Add(data)
+        WeakAuras.ClearAndUpdateOptions(data.id)
+        OptionsPrivate.ResetMoverSizer()
+      end
+    },
     useAnchorPerUnit = {
       type = "toggle",
       order = 1.5,
@@ -360,6 +377,23 @@ local function createOptions(id, data)
       name = L["Sort"],
       order = 20,
       values = OptionsPrivate.Private.group_sort_types
+    },
+    sortOn = {
+      type = "input",
+      width = WeakAuras.doubleWidth,
+      name = L["Run on..."],
+      desc = L["WeakAuras will always run custom sort code when a region is added or removed.\n\nYou can add a comma-separated list of state values here that (when changed) WeakAuras should also run the sort code on."],
+      order = 21 - 0.1,
+      get = function()
+        return data.sortOn or ""
+      end,
+      hidden = function() return data.sort ~= "CUSTOM" end,
+      set = function(info, v)
+        data.sortOn = v
+        WeakAuras.Add(data)
+        WeakAuras.ClearAndUpdateOptions(data.id)
+        OptionsPrivate.ResetMoverSizer()
+      end
     },
     -- custom sort option added below
     hybridPosition = {

--- a/WeakAurasOptions/RegionOptions/DynamicGroup.lua
+++ b/WeakAurasOptions/RegionOptions/DynamicGroup.lua
@@ -143,7 +143,7 @@ local function createOptions(id, data)
       type = "input",
       width = WeakAuras.doubleWidth,
       name = L["Run on..."],
-      desc = L["WeakAuras will always run custom grow code when a region is added, removed, or re-ordered.\n\nYou can add a comma-separated list of state values here that (when changed) WeakAuras should also run the Grow Code on."],
+      desc = L["You can add a comma-separated list of state values here that (when changed) WeakAuras should also run the Grow Code on.\n\nWeakAuras will always run custom grow code if you include 'changed' in this list, or when a region is added, removed, or re-ordered."],
       order = 2 - 0.1,
       get = function()
         return data.growOn or ""
@@ -382,12 +382,12 @@ local function createOptions(id, data)
       type = "input",
       width = WeakAuras.doubleWidth,
       name = L["Run on..."],
-      desc = L["WeakAuras will always run custom sort code when a region is added or removed.\n\nYou can add a comma-separated list of state values here that (when changed) WeakAuras should also run the sort code on."],
+      desc = L["You can add a comma-separated list of state values here that (when changed) WeakAuras should also run the sort code on.WeakAuras will always run custom sort code if you include 'changed' in this list, or when a region is added, removed."],
       order = 21 - 0.1,
       get = function()
         return data.sortOn or ""
       end,
-      hidden = function() return data.sort ~= "CUSTOM" end,
+      hidden = function() return data.sort ~= "custom" end,
       set = function(info, v)
         data.sortOn = v
         WeakAuras.Add(data)


### PR DESCRIPTION
# Description

from some (very) rough testing, this can in some cases cut time spent managing dynamic groups by upwards of  90%

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

tested this by hitting a dummy on a character with [this](https://wago.io/LuxthosMageDragonflight) installed. On both profiles, I (tried) to perform the same actions as much as possible.

on current main branch, a ~1 minute profile looks like this. Notice the dynamicgroup system time, and also that `Core - LWA - Mage` (a dynamic group which almost never does any significant relayouting) tops aura time.

```
Total time: 65069.13ms 
Time inside WA: 1774.47ms (10.22ms)
Time spent inside WA: 2.73%

Note: Not every aspect of each aura can be tracked.
You can ask on our discord https://discord.gg/weakauras for help interpreting this output.

Auras:
Total time attributed to auras: 
Core - LWA - Mage 206.99ms, 12.52% (0.59ms)
Mana Bar (Arcane) - LWA - Mage 152.83ms, 9.24% (0.30ms)
Cast Bar - LWA - Mage 143.46ms, 8.67% (0.23ms)
Touch of the Magi 142.99ms, 8.65% (0.86ms)
Arcane MIssiles 132.95ms, 8.04% (0.68ms)
Arcane Surge 97.09ms, 5.87% (0.58ms)
Radiant Spark 95.80ms, 5.79% (1.96ms)
Arcane Barrage 90.74ms, 5.49% (0.71ms)
Shifting Power (Arcane) 70.19ms, 4.24% (0.64ms)
Arcane Orb 57.11ms, 3.45% (0.79ms)
Time Warp 56.55ms, 3.42% (0.20ms)
Maintenance - LWA - Mage 46.72ms, 2.82% (1.95ms)
Arcane Charge 4 42.16ms, 2.55% (0.79ms)
Arcane Charge 1 35.76ms, 2.16% (0.65ms)
Arcane Charge 2 34.64ms, 2.09% (0.79ms)
Arcane Charge 3 34.40ms, 2.08% (0.84ms)
Rune of Power (Arcane) 30.67ms, 1.85% (0.75ms)
Arcane Charge - LWA - Mage 17.40ms, 1.05% (0.65ms)
Utilities - LWA - Mage 17.30ms, 1.05% (0.08ms)
Mirror Images 16.62ms, 1.00% (0.06ms)
!Dev 11.02ms, 0.67% (0.12ms)
Presence of Mind 8.86ms, 0.54% (0.72ms)
Prismatic Barrier 7.76ms, 0.47% (0.10ms)
Ring of Frost 7.54ms, 0.46% (0.27ms)
Cone of Cold 7.34ms, 0.44% (0.10ms)
Evocation 6.95ms, 0.42% (0.72ms)
Nether Precision 6.83ms, 0.41% (0.61ms)
Fire Blast (Arcane & Frost) 6.77ms, 0.41% (0.08ms)
Invisibility 6.71ms, 0.41% (0.07ms)
Ice Block 6.53ms, 0.39% (0.09ms)
Greater Invisibility 6.49ms, 0.39% (0.15ms)
Ice Nova (Arcane & Fire) 6.39ms, 0.39% (0.10ms)
Frost Nova 6.35ms, 0.38% (0.07ms)
Blast Wave 6.10ms, 0.37% (0.07ms)
Dynamic Effects - LWA - Mage 5.05ms, 0.31% (0.18ms)
Arcane Tempo 4.50ms, 0.27% (0.91ms)
Trinket 3.95ms, 0.24% (0.25ms)
Counterspell 3.37ms, 0.20% (0.06ms)
Alter Time 3.16ms, 0.19% (0.09ms)
Blink 2.61ms, 0.16% (0.18ms)
Nether Tempest 2.25ms, 0.14% (0.86ms)
General Options - LWA - Mage 2.20ms, 0.13% (0.11ms)
!dev! 1.57ms, 0.10% (0.02ms)
Concentration 1.25ms, 0.08% (0.57ms)

Systems:
dynamic conditions 503.37ms, 28.37% (2.22ms)
generictrigger cd tracking 342.21ms, 19.29% (10.22ms)
dynamicgroup 295.01ms, 16.62% (1.95ms)
generictrigger UNIT_POWER_FREQUENT player 273.68ms, 15.42% (3.02ms)
bufftrigger2 227.26ms, 12.81% (4.33ms)
timer tick 143.54ms, 8.09% (0.07ms)
generictrigger SPELL_COOLDOWN_CHANGED 80.65ms, 4.55% (1.88ms)
generictrigger GCD_START 66.00ms, 3.72% (3.23ms)
generictrigger GCD_END 65.08ms, 3.67% (3.14ms)
generictrigger COMBAT_LOG_EVENT_UNFILTERED 47.76ms, 2.69% (0.63ms)
generictrigger GCD_CHANGE 35.22ms, 1.99% (3.34ms)
generictrigger UNIT_SPELLCAST_SUCCEEDED player 21.59ms, 1.22% (0.27ms)
bufftrigger2 - multi 13.13ms, 0.74% (0.01ms)
generictrigger UNIT_SPELLCAST_START player 9.96ms, 0.56% (0.69ms)
generictrigger UNIT_SPELLCAST_FAILED player 7.85ms, 0.44% (0.24ms)
generictrigger UNIT_HEALTH target 6.67ms, 0.38% (0.06ms)
generictrigger UNIT_SPELLCAST_STOP player 4.94ms, 0.28% (0.42ms)
generictrigger PLAYER_TOTEM_UPDATE 3.18ms, 0.18% (0.71ms)
generictrigger COMBAT_LOG_EVENT_UNFILTERED_CUSTOM 2.71ms, 0.15% (0.01ms)
generictrigger LWA_UPDATE_BAR 2.29ms, 0.13% (0.11ms)
generictrigger UNIT_SPELLCAST_CHANNEL_START player 1.98ms, 0.11% (0.24ms)
generictrigger UNIT_SPELLCAST_CHANNEL_STOP player 1.01ms, 0.06% (0.17ms)
load 1.00ms, 0.06% (0.06ms)
generictrigger SPELL_COOLDOWN_READY 0.69ms, 0.04% (0.06ms)
generictrigger unit change 0.43ms, 0.02% (0.02ms)
generictrigger UNIT_MAXPOWER player 0.37ms, 0.02% (0.12ms)
generictrigger NAME_PLATE_UNIT_REMOVED 0.10ms, 0.01% (0.01ms)
generictrigger NAME_PLATE_UNIT_ADDED 0.10ms, 0.01% (0.01ms)
generictrigger ITEM_SLOT_COOLDOWN_READY 0.07ms, 0.00% (0.07ms)
generictrigger GCD_UPDATE 0.05ms, 0.00% (0.00ms)
sound 0.02ms, 0.00% (0.00ms)
generictrigger UNIT_CHANGED_nameplate4 0.01ms, 0.00% (0.00ms)
generictrigger UNIT_CHANGED_nameplate5 0.01ms, 0.00% (0.00ms)
generictrigger SPELL_CHARGES_CHANGED 0.01ms, 0.00% (0.00ms)
generictrigger UNIT_CHANGED_nameplate1 0.01ms, 0.00% (0.00ms)
generictrigger UNIT_CHANGED_nameplate6 0.01ms, 0.00% (0.00ms)
generictrigger UNIT_CHANGED_nameplate7 0.00ms, 0.00% (0.00ms)
generictrigger UNIT_CHANGED_nameplate8 0.00ms, 0.00% (0.00ms)

LibGetFrame:
```

and with this patch, notice that `Core LWA - Mage` consumes much less time, and dynamicgroup system is much lighter.

```
Total time: 61969.78ms 
Time inside WA: 1539.14ms (9.06ms)
Time spent inside WA: 2.48%

Note: Not every aspect of each aura can be tracked.
You can ask on our discord https://discord.gg/weakauras for help interpreting this output.

Auras:
Total time attributed to auras: 
Mana Bar (Arcane) - LWA - Mage 161.32ms, 12.98% (0.35ms)
Cast Bar - LWA - Mage 140.86ms, 11.33% (0.28ms)
Radiant Spark 105.86ms, 8.52% (1.09ms)
Touch of the Magi 103.29ms, 8.31% (0.97ms)
Arcane MIssiles 97.75ms, 7.86% (0.69ms)
Arcane Orb 88.36ms, 7.11% (0.20ms)
Shifting Power (Arcane) 63.68ms, 5.12% (0.76ms)
Arcane Surge 62.31ms, 5.01% (0.92ms)
Time Warp 57.98ms, 4.66% (0.47ms)
Arcane Charge 4 41.86ms, 3.37% (0.32ms)
Arcane Charge 1 36.71ms, 2.95% (0.29ms)
Arcane Charge 2 35.12ms, 2.83% (0.29ms)
Arcane Charge 3 35.10ms, 2.82% (0.28ms)
Arcane Barrage 33.33ms, 2.68% (0.23ms)
Core - LWA - Mage 21.95ms, 1.77% (0.50ms)
Rune of Power (Arcane) 10.29ms, 0.83% (0.43ms)
!Dev 9.42ms, 0.76% (0.11ms)
Mirror Images 8.65ms, 0.70% (0.06ms)
Nether Precision 8.22ms, 0.66% (0.64ms)
Dynamic Effects - LWA - Mage 7.55ms, 0.61% (0.22ms)
Frost Nova 6.94ms, 0.56% (0.10ms)
Prismatic Barrier 6.83ms, 0.55% (0.09ms)
Fire Blast (Arcane & Frost) 6.74ms, 0.54% (0.10ms)
Ring of Frost 6.58ms, 0.53% (0.09ms)
Evocation 6.44ms, 0.52% (0.73ms)
Invisibility 6.44ms, 0.52% (0.29ms)
Presence of Mind 6.38ms, 0.51% (0.99ms)
Ice Block 6.30ms, 0.51% (0.09ms)
Greater Invisibility 6.23ms, 0.50% (0.15ms)
Cone of Cold 6.22ms, 0.50% (0.08ms)
Ice Nova (Arcane & Fire) 5.92ms, 0.48% (0.08ms)
Blast Wave 5.72ms, 0.46% (0.08ms)
Arcane Tempo 5.58ms, 0.45% (0.80ms)
Maintenance - LWA - Mage 4.67ms, 0.38% (0.13ms)
Trinket 4.24ms, 0.34% (0.19ms)
Counterspell 3.45ms, 0.28% (0.07ms)
Utilities - LWA - Mage 3.43ms, 0.28% (0.10ms)
Alter Time 3.30ms, 0.27% (0.08ms)
General Options - LWA - Mage 3.19ms, 0.26% (0.21ms)
Blink 2.95ms, 0.24% (0.07ms)
Concentration 2.65ms, 0.21% (0.87ms)
Nether Tempest 2.65ms, 0.21% (1.02ms)
Arcane Intellect 0.28ms, 0.02% (0.28ms)
Arcane Familiar 0.19ms, 0.02% (0.19ms)

Systems:
dynamic conditions 541.95ms, 35.21% (0.78ms)
generictrigger cd tracking 293.22ms, 19.05% (9.06ms)
generictrigger UNIT_POWER_FREQUENT player 282.11ms, 18.33% (1.22ms)
bufftrigger2 143.78ms, 9.34% (3.49ms)
timer tick 141.10ms, 9.17% (0.08ms)
generictrigger SPELL_COOLDOWN_CHANGED 65.12ms, 4.23% (1.66ms)
dynamicgroup 37.56ms, 2.44% (0.50ms)
generictrigger GCD_END 29.21ms, 1.90% (1.73ms)
generictrigger GCD_START 27.80ms, 1.81% (1.44ms)
generictrigger UNIT_SPELLCAST_SUCCEEDED player 22.49ms, 1.46% (0.34ms)
generictrigger GCD_CHANGE 21.39ms, 1.39% (1.41ms)
generictrigger COMBAT_LOG_EVENT_UNFILTERED 16.99ms, 1.10% (0.19ms)
generictrigger UNIT_SPELLCAST_FAILED player 10.39ms, 0.68% (0.26ms)
generictrigger UNIT_SPELLCAST_START player 9.57ms, 0.62% (1.00ms)
generictrigger UNIT_HEALTH target 7.41ms, 0.48% (0.06ms)
bufftrigger2 - multi 5.78ms, 0.38% (0.02ms)
generictrigger UNIT_SPELLCAST_STOP player 5.34ms, 0.35% (0.40ms)
generictrigger LWA_UPDATE_BAR 3.26ms, 0.21% (0.21ms)
generictrigger UNIT_SPELLCAST_CHANNEL_START player 1.97ms, 0.13% (0.26ms)
load 1.27ms, 0.08% (0.15ms)
generictrigger UNIT_SPELLCAST_CHANNEL_STOP player 0.93ms, 0.06% (0.18ms)
generictrigger COMBAT_LOG_EVENT_UNFILTERED_CUSTOM 0.86ms, 0.06% (0.00ms)
generictrigger PLAYER_TOTEM_UPDATE 0.75ms, 0.05% (0.17ms)
generictrigger UNIT_MAXPOWER player 0.58ms, 0.04% (0.16ms)
generictrigger SPELL_COOLDOWN_READY 0.57ms, 0.04% (0.06ms)
generictrigger unit change 0.56ms, 0.04% (0.01ms)
generictrigger PLAYER_REGEN_ENABLED 0.51ms, 0.03% (0.51ms)
generictrigger ITEM_SLOT_COOLDOWN_STARTED 0.19ms, 0.01% (0.19ms)
generictrigger NAME_PLATE_UNIT_REMOVED 0.12ms, 0.01% (0.01ms)
generictrigger NAME_PLATE_UNIT_ADDED 0.12ms, 0.01% (0.01ms)
generictrigger GCD_UPDATE 0.05ms, 0.00% (0.00ms)
sound 0.02ms, 0.00% (0.00ms)
generictrigger UNIT_CHANGED_nameplate8 0.02ms, 0.00% (0.00ms)
generictrigger UNIT_CHANGED_nameplate3 0.01ms, 0.00% (0.00ms)
generictrigger UNIT_CHANGED_nameplate4 0.01ms, 0.00% (0.00ms)
generictrigger SPELL_CHARGES_CHANGED 0.01ms, 0.00% (0.00ms)
generictrigger UNIT_CHANGED_nameplate5 0.01ms, 0.00% (0.00ms)
generictrigger UNIT_CHANGED_nameplate7 0.01ms, 0.00% (0.00ms)
generictrigger UNIT_CHANGED_nameplate6 0.01ms, 0.00% (0.00ms)
generictrigger UNIT_CHANGED_nameplate10 0.01ms, 0.00% (0.00ms)
generictrigger UNIT_CHANGED_nameplate2 0.01ms, 0.00% (0.00ms)
generictrigger UNIT_CHANGED_nameplate9 0.00ms, 0.00% (0.00ms)

LibGetFrame:
```
