### PR TITLE
Blockburstevents

### DIFF
--- a/WeakAuras/BuffTrigger2.lua
+++ b/WeakAuras/BuffTrigger2.lua
@@ -1844,6 +1844,7 @@ local function RecheckActiveForUnitType(unitType, unit, unitsToRemoveScan)
 end
 
 local Buff2Frame = CreateFrame("Frame")
+Mixin(Buff2Frame, Private.EventBurstBlock)
 Private.frames["WeakAuras Buff2 Frame"] = Buff2Frame
 
 local function EventHandler(frame, event, arg1, arg2, ...)
@@ -1960,15 +1961,13 @@ end
 
 Buff2Frame:RegisterEvent("UNIT_AURA")
 Buff2Frame:RegisterEvent("UNIT_FACTION")
-Buff2Frame:RegisterEvent("UNIT_NAME_UPDATE")
-Buff2Frame:RegisterEvent("UNIT_FLAGS")
-Buff2Frame:RegisterEvent("PLAYER_FLAGS_CHANGED")
+Buff2Frame:BurstBlockRegisterEvent({"UNIT_FLAGS", "UNIT_NAME_UPDATE", "PLAYER_FLAGS_CHANGED"}, true)
 Buff2Frame:RegisterEvent("UNIT_PET")
-Buff2Frame:RegisterEvent("RAID_TARGET_UPDATE")
+Buff2Frame:BurstBlockRegisterEvent({"RAID_TARGET_UPDATE"})
 if not WeakAuras.IsClassicEra() then
   Buff2Frame:RegisterEvent("PLAYER_FOCUS_CHANGED")
   if WeakAuras.IsWrathOrRetail() then
-    Buff2Frame:RegisterEvent("ARENA_OPPONENT_UPDATE")
+    Buff2Frame:BurstBlockRegisterEvent({"ARENA_OPPONENT_UPDATE"})
   end
   Buff2Frame:RegisterEvent("UNIT_ENTERED_VEHICLE")
   Buff2Frame:RegisterEvent("UNIT_EXITED_VEHICLE")
@@ -1978,12 +1977,10 @@ else
   end)
 end
 Buff2Frame:RegisterEvent("PLAYER_TARGET_CHANGED")
-Buff2Frame:RegisterEvent("ENCOUNTER_START")
-Buff2Frame:RegisterEvent("ENCOUNTER_END")
-Buff2Frame:RegisterEvent("INSTANCE_ENCOUNTER_ENGAGE_UNIT")
+Buff2Frame:BurstBlockRegisterEvent({"ENCOUNTER_START", "ENCOUNTER_END", "INSTANCE_ENCOUNTER_ENGAGE_UNIT"})
 Buff2Frame:RegisterEvent("NAME_PLATE_UNIT_ADDED")
 Buff2Frame:RegisterEvent("NAME_PLATE_UNIT_REMOVED")
-Buff2Frame:RegisterEvent("GROUP_ROSTER_UPDATE")
+Buff2Frame:BurstBlockRegisterEvent({"GROUP_ROSTER_UPDATE"})
 Buff2Frame:RegisterEvent("PLAYER_ENTERING_WORLD")
 Buff2Frame:RegisterEvent("PARTY_MEMBER_DISABLE")
 Buff2Frame:RegisterEvent("PARTY_MEMBER_ENABLE")

--- a/WeakAuras/EventBurstBlock.lua
+++ b/WeakAuras/EventBurstBlock.lua
@@ -1,0 +1,82 @@
+if not WeakAuras.IsLibsOK() then return end
+--- @type string, Private
+local AddonName, Private = ...
+
+local debug = 2
+
+local function Init(frame)
+  frame.burstBlock = CreateFrame("Frame")
+  frame.burstBlock.parent = frame
+  frame.burstBlock.lastEvent = {}
+  frame.burstBlock:SetScript("OnEvent", function(self, event, ...)
+    local now = GetTime()
+    -- check if event is part of a group of events
+    local groupIndex
+    if self.groups then
+      for i, group in ipairs(self.groups) do
+        if group[event] then
+          groupIndex = i
+          break
+        end
+      end
+    end
+    if groupIndex and self.groups[groupIndex].lastEvent ~= now then
+      self.groups[groupIndex].lastEvent = now
+      self.parent:GetScript("OnEvent")(self.parent, event, ...)
+      if debug > 1 then
+        print("BurstBlock RUN", frame:GetName() or nil, now, true, event, ...)
+      end
+    elseif groupIndex == nil and self.lastEvent[event] ~= now then
+      self.lastEvent[event] = now
+      self.parent:GetScript("OnEvent")(self.parent, event, ...)
+      if debug > 1 then
+        print("BurstBlock RUN", frame:GetName() or nil, now, false, event, ...)
+      end
+    elseif debug > 0 then
+      print("BurstBlock BLOCK", frame:GetName() or nil, now, groupIndex and true or false, event, ...)
+    end
+  end)
+end
+
+-- OnEvent script is run only once per frame per event, or once per frame per group of events if multiple events are registered at once
+local BurstBlockRegisterEvent = function(self, ...)
+  if self.burstBlock == nil then
+    Init(self)
+  end
+  local num_events = select("#", ...)
+  if num_events > 1 then
+    self.burstBlock.groups = self.burstBlock.groups or {}
+    tinsert(self.burstBlock.groups, { lastEvent = 0 })
+  end
+  for i = 1, num_events do
+    local event = select(i, ...)
+    self.burstBlock:RegisterEvent(event)
+    if num_events > 1 then
+      self.burstBlock.groups[#self.burstBlock.groups][event] = true
+    end
+  end
+end
+
+--[[
+local BurstBlockUnregisterEvent = function(self, event)
+  if self.burstBlock == nil then
+    error("BurstBlockRegisterEvent needs be called before BurstBlockUnregisterEvent")
+  end
+  self.burstBlock:UnregisterEvent(event)
+  if self.burstBlock.groups then
+    for i, group in ipairs(self.burstBlock.groups) do
+      if group[event] then
+        group[event] = nil
+        break
+      end
+    end
+  end
+end
+]]
+
+Private.EventBurstBlock = {
+  BurstBlockRegisterEvent = BurstBlockRegisterEvent,
+  --BurstBlockUnregisterEvent = BurstBlockUnregisterEvent
+  --UnregisterUnitEvent = function() end,
+  --RegisterUnitEvent = function() end,
+}

--- a/WeakAuras/EventBurstBlock.lua
+++ b/WeakAuras/EventBurstBlock.lua
@@ -2,7 +2,7 @@ if not WeakAuras.IsLibsOK() then return end
 --- @type string, Private
 local AddonName, Private = ...
 
-local debug = 1
+local debug = 0
 
 local function Init(frame)
   frame.burstBlock = CreateFrame("Frame")

--- a/WeakAuras/EventBurstBlock.lua
+++ b/WeakAuras/EventBurstBlock.lua
@@ -74,24 +74,47 @@ local BurstBlockUnregisterEvent = function(self, event)
 end
 ]]
 
-local ids = {}
-local BurstBlockGenericTriggerEvent = function(id, triggernum, event)
-  local now = GetTime()
-  ids[id] = ids[id] or {}
-  if ids[id][triggernum] ~= now then
-    ids[id][triggernum] = now
-    return true
-  else
-    if debug > 0 then
-      print("BurstBlock BLOCK generictrigger", id, triggernum, event)
+local BurstBlockGenericTriggerEvent
+do
+  local ids = {}
+  BurstBlockGenericTriggerEvent = function(id, triggernum, event)
+    local now = GetTime()
+    ids[id] = ids[id] or {}
+    if ids[id][triggernum] ~= now then
+      ids[id][triggernum] = now
+      return true
+    else
+      if debug > 0 then
+        print("BurstBlock BLOCK generictrigger", id, triggernum, event)
+      end
+      return false
     end
-    return false
+  end
+end
+
+local BurstBlockGenericTriggerUnitEvent
+do
+  local ids = {}
+  BurstBlockGenericTriggerUnitEvent = function(id, triggernum, event, unit)
+    local now = GetTime()
+    ids[id] = ids[id] or {}
+    ids[id][triggernum] = ids[id][triggernum] or {}
+    if ids[id][triggernum][unit] ~= now then
+      ids[id][triggernum][unit] = now
+      return true
+    else
+      if debug > 0 then
+        print("BurstBlock BLOCK generictrigger", id, triggernum, event, unit)
+      end
+      return false
+    end
   end
 end
 
 Private.EventBurstBlock = {
   BurstBlockRegisterEvent = BurstBlockRegisterEvent,
-  BurstBlockGenericTriggerEvent = BurstBlockGenericTriggerEvent
+  BurstBlockGenericTriggerEvent = BurstBlockGenericTriggerEvent,
+  BurstBlockGenericTriggerUnitEvent = BurstBlockGenericTriggerUnitEvent
   --BurstBlockUnregisterEvent = BurstBlockUnregisterEvent
   --UnregisterUnitEvent = function() end,
   --RegisterUnitEvent = function() end,

--- a/WeakAuras/GenericTrigger.lua
+++ b/WeakAuras/GenericTrigger.lua
@@ -733,9 +733,13 @@ function WeakAuras.ScanUnitEvents(event, unit, ...)
         Private.ActivateAuraEnvironment(id);
         local updateTriggerState = false;
         for triggernum, data in pairs(triggers) do
-          local allStates = WeakAuras.GetTriggerStateForTrigger(id, triggernum);
-          if (RunTriggerFunc(allStates, data, id, triggernum, event, unit, ...)) then
-            updateTriggerState = true;
+          if not (data.statesParameter == "one" or data.statesParameter == "unit")
+          or Private.EventBurstBlock.BurstBlockGenericTriggerUnitEvent(id, triggernum, event, unit)
+          then
+            local allStates = WeakAuras.GetTriggerStateForTrigger(id, triggernum);
+            if (RunTriggerFunc(allStates, data, id, triggernum, event, unit, ...)) then
+              updateTriggerState = true;
+            end
           end
         end
         if (updateTriggerState) then
@@ -755,7 +759,9 @@ function WeakAuras.ScanEventsInternal(event_list, event, arg1, arg2, ... )
     Private.ActivateAuraEnvironment(id);
     local updateTriggerState = false;
     for triggernum, data in pairs(triggers) do
-      if data.statesParameter ~= "one" or Private.EventBurstBlock.BurstBlockGenericTriggerEvent(id, triggernum, event) then
+      if not (data.statesParameter == "one" or data.statesParameter == "unit")
+      or Private.EventBurstBlock.BurstBlockGenericTriggerEvent(id, triggernum, event)
+      then
         local allStates = WeakAuras.GetTriggerStateForTrigger(id, triggernum);
         if (RunTriggerFunc(allStates, data, id, triggernum, event, arg1, arg2, ...)) then
           updateTriggerState = true;

--- a/WeakAuras/GenericTrigger.lua
+++ b/WeakAuras/GenericTrigger.lua
@@ -2004,29 +2004,39 @@ do
 
   function Private.InitCooldownReady()
     cdReadyFrame = CreateFrame("Frame");
+    Mixin(cdReadyFrame, Private.EventBurstBlock)
     cdReadyFrame.inWorld = 0
     Private.frames["Cooldown Trigger Handler"] = cdReadyFrame
+    local groupedEvents = {
+      "SPELL_UPDATE_COOLDOWN",
+      "SPELL_UPDATE_CHARGES",
+      "ACTIONBAR_UPDATE_COOLDOWN"
+    }
     if WeakAuras.IsRetail() then
-      cdReadyFrame:RegisterEvent("RUNE_POWER_UPDATE");
-      cdReadyFrame:RegisterEvent("PLAYER_TALENT_UPDATE");
-      cdReadyFrame:RegisterEvent("PLAYER_PVP_TALENT_UPDATE");
+      table.insert(groupedEvents, "RUNE_POWER_UPDATE")
+      table.insert(groupedEvents, "PLAYER_TALENT_UPDATE")
+      table.insert(groupedEvents, "PLAYER_PVP_TALENT_UPDATE")
     else
-      cdReadyFrame:RegisterEvent("CHARACTER_POINTS_CHANGED");
+      table.insert(groupedEvents, "CHARACTER_POINTS_CHANGED")
     end
-    cdReadyFrame:RegisterEvent("SPELL_UPDATE_COOLDOWN");
-    cdReadyFrame:RegisterEvent("SPELL_UPDATE_CHARGES");
+    if WeakAuras.IsWrathClassic() then
+      table.insert(groupedEvents, "RUNE_POWER_UPDATE");
+      table.insert(groupedEvents, "RUNE_TYPE_UPDATE");
+    end
+    cdReadyFrame:BurstBlockRegisterEvent(unpack(groupedEvents));
+
+    local itemGroupedEvents = {
+      "UNIT_INVENTORY_CHANGED",
+      "BAG_UPDATE_DELAYED",
+      "PLAYER_EQUIPMENT_CHANGED"
+    }
+    cdReadyFrame:BurstBlockRegisterEvent(unpack(itemGroupedEvents));
+
+    cdReadyFrame:BurstBlockRegisterEvent("SPELLS_CHANGED");
     cdReadyFrame:RegisterEvent("UNIT_SPELLCAST_SENT");
-    cdReadyFrame:RegisterEvent("BAG_UPDATE_DELAYED");
-    cdReadyFrame:RegisterEvent("UNIT_INVENTORY_CHANGED")
-    cdReadyFrame:RegisterEvent("PLAYER_EQUIPMENT_CHANGED");
-    cdReadyFrame:RegisterEvent("ACTIONBAR_UPDATE_COOLDOWN");
-    cdReadyFrame:RegisterEvent("SPELLS_CHANGED");
     cdReadyFrame:RegisterEvent("PLAYER_ENTERING_WORLD");
     cdReadyFrame:RegisterEvent("PLAYER_LEAVING_WORLD")
-    if WeakAuras.IsWrathClassic() then
-      cdReadyFrame:RegisterEvent("RUNE_POWER_UPDATE");
-      cdReadyFrame:RegisterEvent("RUNE_TYPE_UPDATE");
-    end
+
     cdReadyFrame.HandleEvent = function(self, event, ...)
       if (event == "PLAYER_ENTERING_WORLD") then
         cdReadyFrame.inWorld = GetTime()

--- a/WeakAuras/GenericTrigger.lua
+++ b/WeakAuras/GenericTrigger.lua
@@ -760,6 +760,7 @@ function WeakAuras.ScanEventsInternal(event_list, event, arg1, arg2, ... )
     local updateTriggerState = false;
     for triggernum, data in pairs(triggers) do
       if not (data.statesParameter == "one" or data.statesParameter == "unit")
+      or tContains(data.internal_events, event)
       or Private.EventBurstBlock.BurstBlockGenericTriggerEvent(id, triggernum, event)
       then
         local allStates = WeakAuras.GetTriggerStateForTrigger(id, triggernum);

--- a/WeakAuras/GenericTrigger.lua
+++ b/WeakAuras/GenericTrigger.lua
@@ -755,9 +755,11 @@ function WeakAuras.ScanEventsInternal(event_list, event, arg1, arg2, ... )
     Private.ActivateAuraEnvironment(id);
     local updateTriggerState = false;
     for triggernum, data in pairs(triggers) do
-      local allStates = WeakAuras.GetTriggerStateForTrigger(id, triggernum);
-      if (RunTriggerFunc(allStates, data, id, triggernum, event, arg1, arg2, ...)) then
-        updateTriggerState = true;
+      if data.statesParameter ~= "one" or Private.EventBurstBlock.BurstBlockGenericTriggerEvent(id, triggernum, event) then
+        local allStates = WeakAuras.GetTriggerStateForTrigger(id, triggernum);
+        if (RunTriggerFunc(allStates, data, id, triggernum, event, arg1, arg2, ...)) then
+          updateTriggerState = true;
+        end
       end
     end
     if (updateTriggerState) then
@@ -2023,16 +2025,16 @@ do
       table.insert(groupedEvents, "RUNE_POWER_UPDATE");
       table.insert(groupedEvents, "RUNE_TYPE_UPDATE");
     end
-    cdReadyFrame:BurstBlockRegisterEvent(unpack(groupedEvents));
+    cdReadyFrame:BurstBlockRegisterEvent(groupedEvents);
 
     local itemGroupedEvents = {
       "UNIT_INVENTORY_CHANGED",
       "BAG_UPDATE_DELAYED",
       "PLAYER_EQUIPMENT_CHANGED"
     }
-    cdReadyFrame:BurstBlockRegisterEvent(unpack(itemGroupedEvents));
+    cdReadyFrame:BurstBlockRegisterEvent(itemGroupedEvents);
 
-    cdReadyFrame:BurstBlockRegisterEvent("SPELLS_CHANGED");
+    cdReadyFrame:BurstBlockRegisterEvent({"SPELLS_CHANGED"});
     cdReadyFrame:RegisterEvent("UNIT_SPELLCAST_SENT");
     cdReadyFrame:RegisterEvent("PLAYER_ENTERING_WORLD");
     cdReadyFrame:RegisterEvent("PLAYER_LEAVING_WORLD")

--- a/WeakAuras/GenericTrigger.lua
+++ b/WeakAuras/GenericTrigger.lua
@@ -760,7 +760,7 @@ function WeakAuras.ScanEventsInternal(event_list, event, arg1, arg2, ... )
     local updateTriggerState = false;
     for triggernum, data in pairs(triggers) do
       if not (data.statesParameter == "one" or data.statesParameter == "unit")
-      or tContains(data.internal_events, event)
+      or (data.internal_events and tContains(data.internal_events, event))
       or Private.EventBurstBlock.BurstBlockGenericTriggerEvent(id, triggernum, event)
       then
         local allStates = WeakAuras.GetTriggerStateForTrigger(id, triggernum);

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -1721,48 +1721,51 @@ function Private.ScanForLoads(toCheck, event, arg1, ...)
 end
 
 local loadFrame = CreateFrame("Frame");
+Mixin(loadFrame, Private.EventBurstBlock)
 Private.frames["Display Load Handling"] = loadFrame;
 
 loadFrame:RegisterEvent("ENCOUNTER_START");
 loadFrame:RegisterEvent("ENCOUNTER_END");
+loadFrame:RegisterEvent("PLAYER_LEVEL_UP");
 
+local groupedEvents = {}
 if WeakAuras.IsRetail() then
-  loadFrame:RegisterEvent("PLAYER_TALENT_UPDATE");
-  loadFrame:RegisterEvent("PLAYER_PVP_TALENT_UPDATE");
-  loadFrame:RegisterEvent("PLAYER_DIFFICULTY_CHANGED");
-  loadFrame:RegisterEvent("PET_BATTLE_OPENING_START");
-  loadFrame:RegisterEvent("PET_BATTLE_CLOSE");
-  loadFrame:RegisterEvent("VEHICLE_UPDATE");
-  loadFrame:RegisterEvent("UPDATE_VEHICLE_ACTIONBAR")
-  loadFrame:RegisterEvent("UPDATE_OVERRIDE_ACTIONBAR");
-  loadFrame:RegisterEvent("CHALLENGE_MODE_COMPLETED")
-  loadFrame:RegisterEvent("CHALLENGE_MODE_START")
-  loadFrame:RegisterEvent("TRAIT_CONFIG_CREATED")
-  loadFrame:RegisterEvent("TRAIT_CONFIG_UPDATED")
+  table.insert(groupedEvents, "PLAYER_TALENT_UPDATE");
+  table.insert(groupedEvents, "PLAYER_PVP_TALENT_UPDATE");
+  table.insert(groupedEvents, "PLAYER_DIFFICULTY_CHANGED");
+  table.insert(groupedEvents, "PET_BATTLE_OPENING_START");
+  table.insert(groupedEvents, "PET_BATTLE_CLOSE");
+  table.insert(groupedEvents, "VEHICLE_UPDATE");
+  table.insert(groupedEvents, "UPDATE_VEHICLE_ACTIONBAR")
+  table.insert(groupedEvents, "UPDATE_OVERRIDE_ACTIONBAR");
+  table.insert(groupedEvents, "CHALLENGE_MODE_COMPLETED")
+  table.insert(groupedEvents, "CHALLENGE_MODE_START")
+  table.insert(groupedEvents, "TRAIT_CONFIG_CREATED")
+  table.insert(groupedEvents, "TRAIT_CONFIG_UPDATED")
 else
-  loadFrame:RegisterEvent("CHARACTER_POINTS_CHANGED")
+  table.insert(groupedEvents, "CHARACTER_POINTS_CHANGED")
 end
 if WeakAuras.IsWrathClassic() then
-  loadFrame:RegisterEvent("PLAYER_TALENT_UPDATE");
-  loadFrame:RegisterEvent("VEHICLE_UPDATE");
-  loadFrame:RegisterEvent("UPDATE_VEHICLE_ACTIONBAR")
-  loadFrame:RegisterEvent("UPDATE_OVERRIDE_ACTIONBAR");
+  table.insert(groupedEvents, "PLAYER_TALENT_UPDATE");
+  table.insert(groupedEvents, "VEHICLE_UPDATE");
+  table.insert(groupedEvents, "UPDATE_VEHICLE_ACTIONBAR")
+  table.insert(groupedEvents, "UPDATE_OVERRIDE_ACTIONBAR");
 end
-loadFrame:RegisterEvent("GROUP_ROSTER_UPDATE");
-loadFrame:RegisterEvent("ZONE_CHANGED");
-loadFrame:RegisterEvent("ZONE_CHANGED_INDOORS");
-loadFrame:RegisterEvent("ZONE_CHANGED_NEW_AREA");
-loadFrame:RegisterEvent("PLAYER_LEVEL_UP");
-loadFrame:RegisterEvent("PLAYER_REGEN_DISABLED");
-loadFrame:RegisterEvent("PLAYER_REGEN_ENABLED");
-loadFrame:RegisterEvent("PLAYER_ROLES_ASSIGNED");
-loadFrame:RegisterEvent("SPELLS_CHANGED");
-loadFrame:RegisterEvent("UNIT_INVENTORY_CHANGED")
-loadFrame:RegisterEvent("PLAYER_EQUIPMENT_CHANGED")
-loadFrame:RegisterEvent("PLAYER_DEAD")
-loadFrame:RegisterEvent("PLAYER_ALIVE")
-loadFrame:RegisterEvent("PLAYER_UNGHOST")
-loadFrame:RegisterEvent("PARTY_LEADER_CHANGED")
+table.insert(groupedEvents, "GROUP_ROSTER_UPDATE");
+table.insert(groupedEvents, "ZONE_CHANGED");
+table.insert(groupedEvents, "ZONE_CHANGED_INDOORS");
+table.insert(groupedEvents, "ZONE_CHANGED_NEW_AREA");
+table.insert(groupedEvents, "PLAYER_REGEN_DISABLED");
+table.insert(groupedEvents, "PLAYER_REGEN_ENABLED");
+table.insert(groupedEvents, "PLAYER_ROLES_ASSIGNED");
+table.insert(groupedEvents, "SPELLS_CHANGED");
+table.insert(groupedEvents, "UNIT_INVENTORY_CHANGED")
+table.insert(groupedEvents, "PLAYER_EQUIPMENT_CHANGED")
+table.insert(groupedEvents, "PLAYER_DEAD")
+table.insert(groupedEvents, "PLAYER_ALIVE")
+table.insert(groupedEvents, "PLAYER_UNGHOST")
+table.insert(groupedEvents, "PARTY_LEADER_CHANGED")
+loadFrame:BurstBlockRegisterEvent(groupedEvents)
 
 if WeakAuras.IsRetail() then
   Private.callbacks:RegisterCallback("WA_DRAGONRIDING_UPDATE", function ()

--- a/WeakAuras/WeakAuras.toc
+++ b/WeakAuras/WeakAuras.toc
@@ -27,6 +27,7 @@ Libs\LibSpecialization\LibSpecialization.lua
 
 Init.lua
 locales.xml
+EventBurstBlock.lua
 ArchiveTypes\Repository.lua
 DefaultOptions.lua
 


### PR DESCRIPTION
# Description

This WIP PR aim at finding code run too much on same frame, and may be use as a bandage fix if it's good enough

It works on the (supposedly wrong) assumption that data fetchable with API is all ready when events start to fire in a single frame
On first event, it save time, and next events for same trigger will be skipped.

It's not good enough yet, but it helps find redundant events.

Also as Rivers pointed out https://www.wowace.com/projects/ace3/pages/api/ace-bucket-3-0 exists and doesn't do my terrible assumption



Findings:

cdReadyFrame: SPELL_UPDATE_COOLDOWN and ACTIONBAR_UPDATE_COOLDOWN both trigger same frame 99.99% of the time, except for known special case of Spinning Crane Kick <https://github.com/WeakAuras/WeakAuras2/pull/593>

bufftrigger2: UNIT_FLAGS and UNIT_NAME_UPDATE both trigger for same units when joining a raid group and not always in the order

Power trigger: UNIT_POWER_FREQUENT may be replaced