### PR TITLE
Add support for queued spell costs

### DIFF
--- a/WeakAuras/GenericTrigger.lua
+++ b/WeakAuras/GenericTrigger.lua
@@ -3373,8 +3373,9 @@ function Private.ExecEnv.CheckTotemName(totemName, triggerTotemName, triggerTote
   return true
 end
 
+-- Queueable Spells
 do
-  local queuableSpells
+  local queueableSpells
   if WeakAuras.IsClassicEraOrWrath() then
     local classQueueableSpells = {
       ["WARRIOR"] = {
@@ -3392,30 +3393,47 @@ do
       },
     }
     local class = select(2, UnitClass("player"))
-    queuableSpells = classQueueableSpells[class]
+    queueableSpells = classQueueableSpells[class]
   end
-  local function GetQueuedSpell()
-    if queuableSpells then
-      for _, spellID in ipairs(queuableSpells) do
-        -- Check the highest known rank
-        local maxRank = select(7, GetSpellInfo(GetSpellInfo(spellID)))
-        if IsCurrentSpell(maxRank) then
-          return maxRank
+
+  local queuedSpellFrame
+  function WeakAuras.WatchForQueuedSpell()
+    if not queuedSpellFrame then
+      queuedSpellFrame = CreateFrame("Frame")
+      Private.frames["Queued Spell Handler"] = queuedSpellFrame
+      queuedSpellFrame:RegisterEvent("CURRENT_SPELL_CAST_CHANGED")
+
+      queuedSpellFrame:SetScript("OnEvent", function(self, event)
+        self.queuedSpell = nil
+        if queueableSpells then
+          for _, spellID in ipairs(queueableSpells) do
+            -- Check the highest known rank
+            local maxRank = select(7, GetSpellInfo(GetSpellInfo(spellID)))
+            if IsCurrentSpell(maxRank) then
+              self.queuedSpell = maxRank
+              break
+            end
+          end
         end
-      end
+        WeakAuras.ScanEvents("WA_UNIT_QUEUED_SPELL_CHANGED", "player")
+      end)
     end
   end
 
-  function WeakAuras.GetSpellCost(powerTypeToCheck)
-    local spellID = select(9, WeakAuras.UnitCastingInfo("player"))
-    spellID = spellID or GetQueuedSpell()
-    if spellID then
-      local costTable = GetSpellPowerCost(spellID);
-      for _, costInfo in pairs(costTable) do
-        -- When there is no required aura for a power cost, the API returns an aura ID of 0 and false for hasRequiredAura despite being valid.
-        if costInfo.type == powerTypeToCheck and (costInfo.requiredAuraID == 0 or costInfo.hasRequiredAura) then
-          return costInfo.cost;
-        end
+  function WeakAuras.GetQueuedSpell()
+    return queuedSpellFrame and queuedSpellFrame.queuedSpell
+  end
+end
+
+function WeakAuras.GetSpellCost(powerTypeToCheck)
+  local spellID = select(9, WeakAuras.UnitCastingInfo("player"))
+  spellID = spellID or WeakAuras.GetQueuedSpell()
+  if spellID then
+    local costTable = GetSpellPowerCost(spellID);
+    for _, costInfo in pairs(costTable) do
+      -- When there is no required aura for a power cost, the API returns an aura ID of 0 and false for hasRequiredAura despite being valid.
+      if costInfo.type == powerTypeToCheck and (costInfo.requiredAuraID == 0 or costInfo.hasRequiredAura) then
+        return costInfo.cost;
       end
     end
   end

--- a/WeakAuras/GenericTrigger.lua
+++ b/WeakAuras/GenericTrigger.lua
@@ -584,7 +584,7 @@ local function RunTriggerFunc(allStates, data, id, triggernum, event, arg1, arg2
           arg1 = data.trigger.unit
         end
       end
-      if arg1 then
+      if arg1 ~= nil then
         if Private.multiUnitUnits[data.trigger.unit] then
           unitForUnitTrigger = arg1
           cloneIdForUnitTrigger = arg1

--- a/WeakAuras/GenericTrigger.lua
+++ b/WeakAuras/GenericTrigger.lua
@@ -3374,27 +3374,25 @@ function Private.ExecEnv.CheckTotemName(totemName, triggerTotemName, triggerTote
 end
 
 -- Queueable Spells
-do
+if WeakAuras.IsClassicEraOrWrath() then
   local queueableSpells
-  if WeakAuras.IsClassicEraOrWrath() then
-    local classQueueableSpells = {
-      ["WARRIOR"] = {
-        78,    -- Heroic Strike
-        845,   -- Cleave
-      },
-      ["HUNTER"] = {
-        2973,  -- Raptor Strike
-      },
-      ["DRUID"] = {
-        6807,  -- Maul
-      },
-      ["DEATHKNIGHT"] = {
-        56815, -- Rune Strike
-      },
-    }
-    local class = select(2, UnitClass("player"))
-    queueableSpells = classQueueableSpells[class]
-  end
+  local classQueueableSpells = {
+    ["WARRIOR"] = {
+      78,    -- Heroic Strike
+      845,   -- Cleave
+    },
+    ["HUNTER"] = {
+      2973,  -- Raptor Strike
+    },
+    ["DRUID"] = {
+      6807,  -- Maul
+    },
+    ["DEATHKNIGHT"] = {
+      56815, -- Rune Strike
+    },
+  }
+  local class = select(2, UnitClass("player"))
+  queueableSpells = classQueueableSpells[class]
 
   local queuedSpellFrame
   function WeakAuras.WatchForQueuedSpell()
@@ -3427,7 +3425,9 @@ end
 
 function WeakAuras.GetSpellCost(powerTypeToCheck)
   local spellID = select(9, WeakAuras.UnitCastingInfo("player"))
-  spellID = spellID or WeakAuras.GetQueuedSpell()
+  if WeakAuras.IsClassicEraOrWrath() and not spellID then
+    spellID = WeakAuras.GetQueuedSpell()
+  end
   if spellID then
     local costTable = GetSpellPowerCost(spellID);
     for _, costInfo in pairs(costTable) do

--- a/WeakAuras/GenericTrigger.lua
+++ b/WeakAuras/GenericTrigger.lua
@@ -3402,18 +3402,21 @@ if WeakAuras.IsClassicEraOrWrath() then
       queuedSpellFrame:RegisterEvent("CURRENT_SPELL_CAST_CHANGED")
 
       queuedSpellFrame:SetScript("OnEvent", function(self, event)
-        self.queuedSpell = nil
+        local newQueuedSpell
         if queueableSpells then
           for _, spellID in ipairs(queueableSpells) do
             -- Check the highest known rank
             local maxRank = select(7, GetSpellInfo(GetSpellInfo(spellID)))
             if IsCurrentSpell(maxRank) then
-              self.queuedSpell = maxRank
+              newQueuedSpell = maxRank
               break
             end
           end
         end
-        WeakAuras.ScanEvents("WA_UNIT_QUEUED_SPELL_CHANGED", "player")
+        if newQueuedSpell ~= self.queuedSpell then
+          self.queuedSpell = newQueuedSpell
+          WeakAuras.ScanEvents("WA_UNIT_QUEUED_SPELL_CHANGED", "player")
+        end
       end)
     end
   end

--- a/WeakAuras/GenericTrigger.lua
+++ b/WeakAuras/GenericTrigger.lua
@@ -584,7 +584,7 @@ local function RunTriggerFunc(allStates, data, id, triggernum, event, arg1, arg2
           arg1 = data.trigger.unit
         end
       end
-      if arg1 ~= nil then
+      if arg1 then
         if Private.multiUnitUnits[data.trigger.unit] then
           unitForUnitTrigger = arg1
           cloneIdForUnitTrigger = arg1

--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -2859,9 +2859,6 @@ Private.event_prototypes = {
         AddUnitEventForEvents(result, "player", "UNIT_SPELLCAST_STOP")
         AddUnitEventForEvents(result, "player", "UNIT_SPELLCAST_FAILED")
         AddUnitEventForEvents(result, "player", "UNIT_SPELLCAST_SUCCEEDED")
-        if WeakAuras.IsClassicEraOrWrath() then
-          AddUnitEventForEvents(result, false, "CURRENT_SPELL_CAST_CHANGED")
-        end
       end
       if trigger.use_powertype and trigger.powertype == 99 then
         AddUnitEventForEvents(result, unit, "UNIT_ABSORB_AMOUNT_CHANGED")
@@ -2890,14 +2887,21 @@ Private.event_prototypes = {
       if trigger.use_specId then
         AddUnitSpecChangeInternalEvents(unit, result)
       end
+      if WeakAuras.IsClassicEraOrWrath() and trigger.use_showCost and trigger.unit == "player" then
+        tinsert(result, "WA_UNIT_QUEUED_SPELL_CHANGED");
+      end
       return result
+    end,
+    loadFunc = function(trigger)
+      if WeakAuras.IsClassicEraOrWrath() and trigger.use_showCost and trigger.unit == "player" then
+        WeakAuras.WatchForQueuedSpell()
+      end
     end,
     force_events = unitHelperFunctions.UnitChangedForceEventsWithPets,
     name = L["Power"],
     init = function(trigger)
       trigger.unit = trigger.unit or "player";
       local ret = [=[
-        unit = type(unit) == "string" and unit or "player"
         unit = string.lower(unit)
         local name, realm = WeakAuras.UnitNameWithRealm(unit)
         local smart = %s
@@ -2936,7 +2940,7 @@ Private.event_prototypes = {
               state.cost = cost
               state.changed = true
             end
-          elseif ( (event == "UNIT_SPELLCAST_START" or event == "UNIT_SPELLCAST_STOP" or event == "UNIT_SPELLCAST_FAILED" or event == "UNIT_SPELLCAST_SUCCEEDED") and unit == "player") or event == "CURRENT_SPELL_CAST_CHANGED" then
+          elseif ( (event == "UNIT_SPELLCAST_START" or event == "UNIT_SPELLCAST_STOP" or event == "UNIT_SPELLCAST_FAILED" or event == "UNIT_SPELLCAST_SUCCEEDED") and unit == "player") or event == "WA_UNIT_QUEUED_SPELL_CHANGED" then
             local cost = WeakAuras.GetSpellCost(powerTypeToCheck)
             if state.cost ~= cost then
               state.cost = cost

--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -2859,7 +2859,9 @@ Private.event_prototypes = {
         AddUnitEventForEvents(result, "player", "UNIT_SPELLCAST_STOP")
         AddUnitEventForEvents(result, "player", "UNIT_SPELLCAST_FAILED")
         AddUnitEventForEvents(result, "player", "UNIT_SPELLCAST_SUCCEEDED")
-        AddUnitEventForEvents(result, false, "CURRENT_SPELL_CAST_CHANGED")
+        if WeakAuras.IsClassicEraOrWrath() then
+          AddUnitEventForEvents(result, false, "CURRENT_SPELL_CAST_CHANGED")
+        end
       end
       if trigger.use_powertype and trigger.powertype == 99 then
         AddUnitEventForEvents(result, unit, "UNIT_ABSORB_AMOUNT_CHANGED")

--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -2976,7 +2976,7 @@ Private.event_prototypes = {
 
       return ret
     end,
-    statesParameter = "one",
+    statesParameter = "unit",
     args = {
       {
         name = "unit",

--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -2859,6 +2859,7 @@ Private.event_prototypes = {
         AddUnitEventForEvents(result, "player", "UNIT_SPELLCAST_STOP")
         AddUnitEventForEvents(result, "player", "UNIT_SPELLCAST_FAILED")
         AddUnitEventForEvents(result, "player", "UNIT_SPELLCAST_SUCCEEDED")
+        AddUnitEventForEvents(result, false, "CURRENT_SPELL_CAST_CHANGED")
       end
       if trigger.use_powertype and trigger.powertype == 99 then
         AddUnitEventForEvents(result, unit, "UNIT_ABSORB_AMOUNT_CHANGED")
@@ -2894,6 +2895,7 @@ Private.event_prototypes = {
     init = function(trigger)
       trigger.unit = trigger.unit or "player";
       local ret = [=[
+        unit = type(unit) == "string" and unit or "player"
         unit = string.lower(unit)
         local name, realm = WeakAuras.UnitNameWithRealm(unit)
         local smart = %s
@@ -2932,7 +2934,7 @@ Private.event_prototypes = {
               state.cost = cost
               state.changed = true
             end
-          elseif ( (event == "UNIT_SPELLCAST_START" or event == "UNIT_SPELLCAST_STOP" or event == "UNIT_SPELLCAST_FAILED" or event == "UNIT_SPELLCAST_SUCCEEDED") and unit == "player") then
+          elseif ( (event == "UNIT_SPELLCAST_START" or event == "UNIT_SPELLCAST_STOP" or event == "UNIT_SPELLCAST_FAILED" or event == "UNIT_SPELLCAST_SUCCEEDED") and unit == "player") or event == "CURRENT_SPELL_CAST_CHANGED" then
             local cost = WeakAuras.GetSpellCost(powerTypeToCheck)
             if state.cost ~= cost then
               state.cost = cost
@@ -2972,7 +2974,7 @@ Private.event_prototypes = {
 
       return ret
     end,
-    statesParameter = "unit",
+    statesParameter = "one",
     args = {
       {
         name = "unit",


### PR DESCRIPTION
# Description

<!-- A #ticketNumber will be sufficient. -->
Fixes #4214

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested

For each test: created a Progress Bar Aura with a Player/Unit Info - Power Trigger, with Overlay Cost of Casts checked.

- [X] Tested on a level 70 Warrior in Wrath of the Lich King Classic, using Heroic Strike and Cleave.
- [X] Tested on a level 1 Warrior in Classic Era, using Heroic Strike.
- [X] Tested on several WOTLK classes with no queueable spells, where previous cost overlay functionality still works.
- [ ] Test on retail for compatibility

## Checklist
<!-- These can be checked off after the pull request is submitted, in case you want discussion before they are completely ready -->

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] ~~I'm unsure of the implications of the change I made to `statesParameter`. I'll comment on this below.~~
