### PR TITLE
Improve talent selector for overridden spells

### DIFF
--- a/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasMiniTalent_Dragonflight.lua
+++ b/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasMiniTalent_Dragonflight.lua
@@ -6,7 +6,7 @@ end
 
 local keepOpenForReload = {}
 
-local widgetType, widgetVersion = "WeakAurasMiniTalent", 2
+local widgetType, widgetVersion = "WeakAurasMiniTalent", 3
 local AceGUI = LibStub and LibStub("AceGUI-3.0", true)
 if not AceGUI or (AceGUI:GetWidgetVersion(widgetType) or 0) >= widgetVersion then
   return
@@ -19,7 +19,7 @@ local buttonSizePadded = 45
 local function Button_ShowToolTip(self)
   if self.spellId then
     GameTooltip:SetOwner(self, "ANCHOR_RIGHT")
-    GameTooltip:SetSpellByID(self.spellId)
+    GameTooltip:SetSpellByID(self.spellId, false, false, true)
   end
 end
 local function Button_HideToolTip()
@@ -250,7 +250,7 @@ local methods = {
         self.talentIdToButton[talentId] = button
         local spellId = data[2]
         button.spellId = spellId
-        local icon = select(3, GetSpellInfo(spellId))
+        local icon = select(8, GetSpellInfo(spellId))
         if icon then
           button:SetNormalTexture(icon)
         end


### PR DESCRIPTION
# Description

Current state talent selector will replace the talent nodes' icon and tooltips with those of the talent that overrides them. Two examples:
1. Enhancement Shaman: If Elemental Blast and Lava Burst are both talented, Lava Burst's node in the class talent tree will be replaced by Elemental Blast (icon and tooltip), which is misleading.
2. Guardian Druid: If Raze is talented, Maul's node at the top of the spec tree will be replaced with Raze.

This update causes the talent icons to use the 8th return value from `GetSpellInfo`, `originalIcon`, to populate the button itself.  It also sets the `dontOverride` flag when using `GameTooltip:SetSpellByID` so that the original spell's tooltip is provided instead of the override.

Note that this fix is mildly incomplete, because even with `dontOverride` set, the correct tooltip still uses the overriding spell's icon, but it will display the correct name and description.  I'm not sure of a not-ugly way to resolve as this sounds like a Blizzard issue.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

As Guardian Druid:

- [x] Talent for Maul and Raze; button texture and tooltip for both talents are now correct.
- [x] Talent for Maul without Raze; button texture and tooltip for both talents remain correct.

## Checklist
<!-- These can be checked off after the pull request is submitted, in case you want discussion before they are completely ready -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

<!-- Is there any additional work that needs to be done? If so, add it to the above list -->

1. With the change, I incremented the version of the MiniTalent widget which you may or may not want to do.
2. You may want to resolve the tooltip's icon issue, but the only way I could think of is to `gsub` the wrong icon ID with the right icon ID and it seems a bit silly.
3. Technically, these spell tooltips are not the exact tooltips that you'd see if you mouseover them in Blizzard's talent panel.  Blizzard's tooltips actually seem to break icons for spells that override or are overridden (I don't see Maul or Raze icons), and Blizzard's tooltip includes notes like "Replaces Maul" when you mouseover Raze.  I don't think this is worth caring about, but I investigated a bit with using `GameTooltip:SetTraitEntry(self.talentId)` instead; the result got a talent-panel-like tooltip except the title (spell name, icon) line was missing and I stopped caring by this point.