### PR TITLE
add unignoring uption for WagoUpdates

### DIFF
--- a/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasDisplayButton.lua
+++ b/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasDisplayButton.lua
@@ -670,6 +670,14 @@ local methods = {
       OptionsPrivate.Ungroup(self.data);
     end
 
+    function self.callbacks.IgnoreWagoUpdate(auraId)
+      if OptionsPrivate.IsWagoUpdateIgnored(auraId) then
+        StaticPopup_Show("WEAKAURAS_CONFIRM_UNIGNORE_UPDATES", "", "", auraId)
+      else
+        StaticPopup_Show("WEAKAURAS_CONFIRM_IGNORE_UPDATES", "", "", auraId)
+      end
+    end
+
     function self.callbacks.OnUpGroupClick()
       if (WeakAuras.IsImporting()) then return end;
       if(self.data.parent) then
@@ -884,6 +892,11 @@ local methods = {
       text = L["Export debug table..."],
       notCheckable = true,
       func = function() OptionsPrivate.ExportToTable(self.data.id) end
+    });
+     tinsert(self.menu, {
+      text = L["Ignore Wago Update"],
+      checked = function() return OptionsPrivate.IsWagoUpdateIgnored(self.data.id) end,
+      func = function() self.callbacks.IgnoreWagoUpdate(self.data.id) end
     });
 
     tinsert(self.menu, {

--- a/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasDisplayButton.lua
+++ b/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasDisplayButton.lua
@@ -893,11 +893,13 @@ local methods = {
       notCheckable = true,
       func = function() OptionsPrivate.ExportToTable(self.data.id) end
     });
-    tinsert(self.menu, {
-      text = L["Ignore Wago Update"],
-      checked = function() return OptionsPrivate.IsWagoUpdateIgnored(self.data.id) end,
-      func = function() self.callbacks.ToggleIgnoreWagoUpdate(self.data.id) end
-    });
+    if OptionsPrivate.HasWagoUrl(self.data.id) then
+      tinsert(self.menu, {
+        text = L["Ignore Wago Update"],
+        checked = function() return OptionsPrivate.IsWagoUpdateIgnored(self.data.id) end,
+        func = function() self.callbacks.ToggleIgnoreWagoUpdate(self.data.id) end
+      });
+    end
       
     tinsert(self.menu, {
       text = " ",

--- a/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasDisplayButton.lua
+++ b/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasDisplayButton.lua
@@ -670,7 +670,7 @@ local methods = {
       OptionsPrivate.Ungroup(self.data);
     end
 
-    function self.callbacks.IgnoreWagoUpdate(auraId)
+    function self.callbacks.ToggleIgnoreWagoUpdate(auraId)
       if OptionsPrivate.IsWagoUpdateIgnored(auraId) then
         StaticPopup_Show("WEAKAURAS_CONFIRM_UNIGNORE_UPDATES", "", "", auraId)
       else
@@ -893,12 +893,12 @@ local methods = {
       notCheckable = true,
       func = function() OptionsPrivate.ExportToTable(self.data.id) end
     });
-     tinsert(self.menu, {
+    tinsert(self.menu, {
       text = L["Ignore Wago Update"],
       checked = function() return OptionsPrivate.IsWagoUpdateIgnored(self.data.id) end,
-      func = function() self.callbacks.IgnoreWagoUpdate(self.data.id) end
+      func = function() self.callbacks.ToggleIgnoreWagoUpdate(self.data.id) end
     });
-
+      
     tinsert(self.menu, {
       text = " ",
       notClickable = true,

--- a/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasDisplayButton.lua
+++ b/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasDisplayButton.lua
@@ -900,7 +900,6 @@ local methods = {
         func = function() self.callbacks.ToggleIgnoreWagoUpdate(self.data.id) end
       });
     end
-      
     tinsert(self.menu, {
       text = " ",
       notClickable = true,

--- a/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasDisplayButton.lua
+++ b/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasDisplayButton.lua
@@ -670,14 +670,6 @@ local methods = {
       OptionsPrivate.Ungroup(self.data);
     end
 
-    function self.callbacks.ToggleIgnoreWagoUpdate(auraId)
-      if OptionsPrivate.IsWagoUpdateIgnored(auraId) then
-        StaticPopup_Show("WEAKAURAS_CONFIRM_UNIGNORE_UPDATES", "", "", auraId)
-      else
-        StaticPopup_Show("WEAKAURAS_CONFIRM_IGNORE_UPDATES", "", "", auraId)
-      end
-    end
-
     function self.callbacks.OnUpGroupClick()
       if (WeakAuras.IsImporting()) then return end;
       if(self.data.parent) then
@@ -893,6 +885,7 @@ local methods = {
       notCheckable = true,
       func = function() OptionsPrivate.ExportToTable(self.data.id) end
     });
+
     tinsert(self.menu, {
       text = " ",
       notClickable = true,

--- a/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasDisplayButton.lua
+++ b/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasDisplayButton.lua
@@ -893,13 +893,6 @@ local methods = {
       notCheckable = true,
       func = function() OptionsPrivate.ExportToTable(self.data.id) end
     });
-    if OptionsPrivate.HasWagoUrl(self.data.id) then
-      tinsert(self.menu, {
-        text = L["Ignore Wago Update"],
-        checked = function() return OptionsPrivate.IsWagoUpdateIgnored(self.data.id) end,
-        func = function() self.callbacks.ToggleIgnoreWagoUpdate(self.data.id) end
-      });
-    end
     tinsert(self.menu, {
       text = " ",
       notClickable = true,

--- a/WeakAurasOptions/InformationOptions.lua
+++ b/WeakAurasOptions/InformationOptions.lua
@@ -112,7 +112,6 @@ function OptionsPrivate.GetInformationOptions(data)
         else
           StaticPopup_Show("WEAKAURAS_CONFIRM_IGNORE_UPDATES", "", "", data.id)
         end
-        WeakAuras.ClearAndUpdateOptions(data.id)
       end,
       order = order
     }

--- a/WeakAurasOptions/InformationOptions.lua
+++ b/WeakAurasOptions/InformationOptions.lua
@@ -108,14 +108,16 @@ function OptionsPrivate.GetInformationOptions(data)
       width = WeakAuras.doubleWidth,
       get = function() return OptionsPrivate.IsWagoUpdateIgnored(data.id) end,
       set = function(info, v)
-          local auraData = WeakAuras.GetData(data.id)
+          local auraData = WeakAuras.GetData(data.id)    
           if auraData then
+            local IgnoreUpdate
+            if OptionsPrivate.IsWagoUpdateIgnored(data.id) then
+              IgnoreUpdate = nil    
+            else
+              IgnoreUpdate = true
+            end
             for child in OptionsPrivate.Private.TraverseAll(auraData) do
-              if OptionsPrivate.IsWagoUpdateIgnored(data.id) then
-                child.ignoreWagoUpdate = nil
-              else
-                child.ignoreWagoUpdate = true
-              end
+              child.ignoreWagoUpdate = IgnoreUpdate
               OptionsPrivate.ClearOptions(child.id)
             end
             WeakAuras.ClearAndUpdateOptions(data.id)

--- a/WeakAurasOptions/InformationOptions.lua
+++ b/WeakAurasOptions/InformationOptions.lua
@@ -104,13 +104,32 @@ function OptionsPrivate.GetInformationOptions(data)
     args.ignoreWagoUpdate = {
       type = "toggle",
       name = L["Ignore Wago updates"],
+      desc = OptionsPrivate.IsWagoUpdateIgnored(data.id) and L["Do you want to stop ignoring all future updates for this aura"] or L["Do you want to ignore all future updates for this aura"]
       width = WeakAuras.doubleWidth,
       get = function() return OptionsPrivate.IsWagoUpdateIgnored(data.id) end,
       set = function(info, v)
         if OptionsPrivate.IsWagoUpdateIgnored(data.id) then
-          StaticPopup_Show("WEAKAURAS_CONFIRM_UNIGNORE_UPDATES", "", "", data.id)
+          local auraData = WeakAuras.GetData(self.data)
+          if auraData then
+            for child in OptionsPrivate.Private.TraverseAll(auraData) do
+              child.ignoreWagoUpdate = nil
+              OptionsPrivate.ClearOptions(child.id)
+            end
+            WeakAuras.ClearAndUpdateOptions(self.data)
+          end
+          WeakAuras.FillOptions()
+          OptionsPrivate.SortDisplayButtons(nil, true)
         else
-          StaticPopup_Show("WEAKAURAS_CONFIRM_IGNORE_UPDATES", "", "", data.id)
+          local auraData = WeakAuras.GetData(self.data)
+          if auraData then
+            for child in OptionsPrivate.Private.TraverseAll(auraData) do
+              child.ignoreWagoUpdate = true
+              OptionsPrivate.ClearOptions(child.id)
+            end
+            WeakAuras.ClearAndUpdateOptions(self.data)
+          end
+          WeakAuras.FillOptions()
+          OptionsPrivate.SortDisplayButtons(nil, true)
         end
       end,
       order = order

--- a/WeakAurasOptions/InformationOptions.lua
+++ b/WeakAurasOptions/InformationOptions.lua
@@ -104,33 +104,25 @@ function OptionsPrivate.GetInformationOptions(data)
     args.ignoreWagoUpdate = {
       type = "toggle",
       name = L["Ignore Wago updates"],
-      desc = OptionsPrivate.IsWagoUpdateIgnored(data.id) and L["Do you want to stop ignoring all future updates for this aura"] or L["Do you want to ignore all future updates for this aura"]
+      desc = OptionsPrivate.IsWagoUpdateIgnored(data.id) and L["Do you want to stop ignoring all future updates for this aura"] or L["Do you want to ignore all future updates for this aura"],
       width = WeakAuras.doubleWidth,
       get = function() return OptionsPrivate.IsWagoUpdateIgnored(data.id) end,
       set = function(info, v)
-        if OptionsPrivate.IsWagoUpdateIgnored(data.id) then
-          local auraData = WeakAuras.GetData(self.data)
+          local auraData = WeakAuras.GetData(data.id)
           if auraData then
             for child in OptionsPrivate.Private.TraverseAll(auraData) do
-              child.ignoreWagoUpdate = nil
+              if OptionsPrivate.IsWagoUpdateIgnored(data.id) then
+                child.ignoreWagoUpdate = nil
+              else
+                child.ignoreWagoUpdate = true
+              end
               OptionsPrivate.ClearOptions(child.id)
             end
-            WeakAuras.ClearAndUpdateOptions(self.data)
+            WeakAuras.ClearAndUpdateOptions(data.id)
           end
           WeakAuras.FillOptions()
           OptionsPrivate.SortDisplayButtons(nil, true)
-        else
-          local auraData = WeakAuras.GetData(self.data)
-          if auraData then
-            for child in OptionsPrivate.Private.TraverseAll(auraData) do
-              child.ignoreWagoUpdate = true
-              OptionsPrivate.ClearOptions(child.id)
-            end
-            WeakAuras.ClearAndUpdateOptions(self.data)
-          end
-          WeakAuras.FillOptions()
-          OptionsPrivate.SortDisplayButtons(nil, true)
-        end
+
       end,
       order = order
     }

--- a/WeakAurasOptions/InformationOptions.lua
+++ b/WeakAurasOptions/InformationOptions.lua
@@ -108,11 +108,11 @@ function OptionsPrivate.GetInformationOptions(data)
       width = WeakAuras.doubleWidth,
       get = function() return OptionsPrivate.IsWagoUpdateIgnored(data.id) end,
       set = function(info, v)
-          local auraData = WeakAuras.GetData(data.id)    
+          local auraData = WeakAuras.GetData(data.id)
           if auraData then
             local IgnoreUpdate
             if OptionsPrivate.IsWagoUpdateIgnored(data.id) then
-              IgnoreUpdate = nil    
+              IgnoreUpdate = nil
             else
               IgnoreUpdate = true
             end

--- a/WeakAurasOptions/InformationOptions.lua
+++ b/WeakAurasOptions/InformationOptions.lua
@@ -103,7 +103,7 @@ function OptionsPrivate.GetInformationOptions(data)
   if OptionsPrivate.HasWagoUrl(data.id) then
     args.ignoreWagoUpdate = {
       type = "toggle",
-      name = L["Ignore Wago Update"],
+      name = L["Ignore Wago updates"],
       width = WeakAuras.doubleWidth,
       get = function() return OptionsPrivate.IsWagoUpdateIgnored(data.id) end,
       set = function(info, v)

--- a/WeakAurasOptions/InformationOptions.lua
+++ b/WeakAurasOptions/InformationOptions.lua
@@ -100,6 +100,24 @@ function OptionsPrivate.GetInformationOptions(data)
     }
     order = order + 1
   end
+  if OptionsPrivate.HasWagoUrl(data.id) then
+    args.ignoreWagoUpdate = {
+      type = "toggle",
+      name = L["Ignore Wago Update"],
+      width = WeakAuras.doubleWidth,
+      get = function() return OptionsPrivate.IsWagoUpdateIgnored(data.id) end,
+      set = function(info, v)
+        if OptionsPrivate.IsWagoUpdateIgnored(data.id) then
+          StaticPopup_Show("WEAKAURAS_CONFIRM_UNIGNORE_UPDATES", "", "", data.id)
+        else
+          StaticPopup_Show("WEAKAURAS_CONFIRM_IGNORE_UPDATES", "", "", data.id)
+        end
+        WeakAuras.ClearAndUpdateOptions(data.id)
+      end,
+      order = order
+    }
+    order = order + 1
+  end
 
 
   -- Description

--- a/WeakAurasOptions/WeakAurasOptions.lua
+++ b/WeakAurasOptions/WeakAurasOptions.lua
@@ -515,16 +515,15 @@ StaticPopupDialogs["WEAKAURAS_CONFIRM_UNIGNORE_UPDATES"] = {
 }
 
 function OptionsPrivate.IsWagoUpdateIgnored(auraId)
-    local isIgnored = false
     local auraData = WeakAuras.GetData(auraId)
       if auraData then
         for child in OptionsPrivate.Private.TraverseAll(auraData) do
           if(child.ignoreWagoUpdate == true) then
-            isIgnored = true
+            return true
           end
         end
       end
-    return isIgnored
+    return false
 end
 
 function OptionsPrivate.ConfirmDelete(toDelete, parents)

--- a/WeakAurasOptions/WeakAurasOptions.lua
+++ b/WeakAurasOptions/WeakAurasOptions.lua
@@ -474,52 +474,6 @@ StaticPopupDialogs["WEAKAURAS_CONFIRM_DELETE"] = {
   preferredindex = STATICPOPUP_NUMDIALOGS,
 }
 
-StaticPopupDialogs["WEAKAURAS_CONFIRM_IGNORE_UPDATES"] = {
-  text = L["Do you want to ignore all future updates for this aura"],
-  button1 = L["Yes"],
-  button2 = L["Cancel"],
-  OnAccept = function(self)
-    if self.data then
-      local auraData = WeakAuras.GetData(self.data)
-      if auraData then
-        for child in OptionsPrivate.Private.TraverseAll(auraData) do
-          child.ignoreWagoUpdate = true
-          OptionsPrivate.ClearOptions(child.id)
-        end
-        WeakAuras.ClearAndUpdateOptions(self.data)
-      end
-      WeakAuras.FillOptions()
-      OptionsPrivate.SortDisplayButtons(nil, true)
-    end
-  end,
-  OnCancel = function(self) end,
-  whileDead = true,
-  preferredindex = STATICPOPUP_NUMDIALOGS,
-}
-
-StaticPopupDialogs["WEAKAURAS_CONFIRM_UNIGNORE_UPDATES"] = {
-  text = L["Do you want to stop ignoring all future updates for this aura"],
-  button1 = L["Yes"],
-  button2 = L["Cancel"],
-  OnAccept = function(self)
-    if self.data then
-      local auraData = WeakAuras.GetData(self.data)
-      if auraData then
-        for child in OptionsPrivate.Private.TraverseAll(auraData) do
-          child.ignoreWagoUpdate = nil
-          OptionsPrivate.ClearOptions(child.id)
-        end
-        WeakAuras.ClearAndUpdateOptions(self.data)
-      end
-      WeakAuras.FillOptions()
-      OptionsPrivate.SortDisplayButtons(nil, true)
-    end
-  end,
-  OnCancel = function(self) end,
-  whileDead = true,
-  preferredindex = STATICPOPUP_NUMDIALOGS,
-}
-
 function OptionsPrivate.IsWagoUpdateIgnored(auraId)
     local auraData = WeakAuras.GetData(auraId)
       if auraData then

--- a/WeakAurasOptions/WeakAurasOptions.lua
+++ b/WeakAurasOptions/WeakAurasOptions.lua
@@ -1058,7 +1058,7 @@ function OptionsPrivate.SortDisplayButtons(filter, overrideReset, id)
       button:ResetLinkedAuras()
     end
     for id, aura in pairs(WeakAurasSaved.displays) do
-      if (aura.ignoreWagoUpdate and aura.ignoreWagoUpdate == true or not aura.ignoreWagoUpdate) and aura.url and aura.url ~= "" then
+      if not aura.ignoreWagoUpdate and aura.url and aura.url ~= "" then
         local slug, version = aura.url:match("wago.io/([^/]+)/([0-9]+)")
         if not slug and not version then
           slug = aura.url:match("wago.io/([^/]+)$")

--- a/WeakAurasOptions/WeakAurasOptions.lua
+++ b/WeakAurasOptions/WeakAurasOptions.lua
@@ -526,6 +526,18 @@ function OptionsPrivate.IsWagoUpdateIgnored(auraId)
     return false
 end
 
+function OptionsPrivate.HasWagoUrl(auraId)
+  local auraData = WeakAuras.GetData(auraId)
+    if auraData then
+      for child in OptionsPrivate.Private.TraverseAll(auraData) do
+        if(child.url and child.url ~= "") then
+          return true
+        end
+      end
+    end
+  return false
+end
+
 function OptionsPrivate.ConfirmDelete(toDelete, parents)
   if toDelete then
     local warningForm = L["You are about to delete %d aura(s). |cFFFF0000This cannot be undone!|r Would you like to continue?"]

--- a/WeakAurasOptions/WeakAurasOptions.lua
+++ b/WeakAurasOptions/WeakAurasOptions.lua
@@ -503,7 +503,7 @@ StaticPopupDialogs["WEAKAURAS_CONFIRM_UNIGNORE_UPDATES"] = {
       local auraData = WeakAuras.GetData(self.data)
       if auraData then
         for child in OptionsPrivate.Private.TraverseAll(auraData) do
-          child.ignoreWagoUpdate = false
+          child.ignoreWagoUpdate = nil
         end
       end
       OptionsPrivate.SortDisplayButtons(nil, true)

--- a/WeakAurasOptions/WeakAurasOptions.lua
+++ b/WeakAurasOptions/WeakAurasOptions.lua
@@ -478,7 +478,7 @@ function OptionsPrivate.IsWagoUpdateIgnored(auraId)
     local auraData = WeakAuras.GetData(auraId)
       if auraData then
         for child in OptionsPrivate.Private.TraverseAll(auraData) do
-          if(child.ignoreWagoUpdate == true) then
+          if child.ignoreWagoUpdate then
             return true
           end
         end
@@ -490,7 +490,7 @@ function OptionsPrivate.HasWagoUrl(auraId)
   local auraData = WeakAuras.GetData(auraId)
     if auraData then
       for child in OptionsPrivate.Private.TraverseAll(auraData) do
-        if(child.url and child.url ~= "") then
+        if child.url and child.url ~= "" then
           return true
         end
       end

--- a/WeakAurasOptions/WeakAurasOptions.lua
+++ b/WeakAurasOptions/WeakAurasOptions.lua
@@ -515,7 +515,7 @@ StaticPopupDialogs["WEAKAURAS_CONFIRM_UNIGNORE_UPDATES"] = {
 }
 
 function OptionsPrivate.IsWagoUpdateIgnored(auraId)
-    local isIgnored = false 
+    local isIgnored = false
     local auraData = WeakAuras.GetData(auraId)
       if auraData then
         for child in OptionsPrivate.Private.TraverseAll(auraData) do

--- a/WeakAurasOptions/WeakAurasOptions.lua
+++ b/WeakAurasOptions/WeakAurasOptions.lua
@@ -494,6 +494,39 @@ StaticPopupDialogs["WEAKAURAS_CONFIRM_IGNORE_UPDATES"] = {
   preferredindex = STATICPOPUP_NUMDIALOGS,
 }
 
+StaticPopupDialogs["WEAKAURAS_CONFIRM_UNIGNORE_UPDATES"] = {
+  text = L["Do you want to stop ignoring all future updates for this aura"],
+  button1 = L["Yes"],
+  button2 = L["Cancel"],
+  OnAccept = function(self)
+    if self.data then
+      local auraData = WeakAuras.GetData(self.data)
+      if auraData then
+        for child in OptionsPrivate.Private.TraverseAll(auraData) do
+          child.ignoreWagoUpdate = false
+        end
+      end
+      OptionsPrivate.SortDisplayButtons(nil, true)
+    end
+  end,
+  OnCancel = function(self) end,
+  whileDead = true,
+  preferredindex = STATICPOPUP_NUMDIALOGS,
+}
+
+function OptionsPrivate.IsWagoUpdateIgnored(auraId)
+    local isIgnored = false 
+    local auraData = WeakAuras.GetData(auraId)
+      if auraData then
+        for child in OptionsPrivate.Private.TraverseAll(auraData) do
+          if(child.ignoreWagoUpdate == true) then
+            isIgnored = true
+          end
+        end
+      end
+    return isIgnored
+end
+
 function OptionsPrivate.ConfirmDelete(toDelete, parents)
   if toDelete then
     local warningForm = L["You are about to delete %d aura(s). |cFFFF0000This cannot be undone!|r Would you like to continue?"]
@@ -1025,7 +1058,7 @@ function OptionsPrivate.SortDisplayButtons(filter, overrideReset, id)
       button:ResetLinkedAuras()
     end
     for id, aura in pairs(WeakAurasSaved.displays) do
-      if not aura.ignoreWagoUpdate and aura.url and aura.url ~= "" then
+      if (aura.ignoreWagoUpdate and aura.ignoreWagoUpdate == true or not aura.ignoreWagoUpdate) and aura.url and aura.url ~= "" then
         local slug, version = aura.url:match("wago.io/([^/]+)/([0-9]+)")
         if not slug and not version then
           slug = aura.url:match("wago.io/([^/]+)$")

--- a/WeakAurasOptions/WeakAurasOptions.lua
+++ b/WeakAurasOptions/WeakAurasOptions.lua
@@ -488,6 +488,7 @@ StaticPopupDialogs["WEAKAURAS_CONFIRM_IGNORE_UPDATES"] = {
         end
         WeakAuras.ClearAndUpdateOptions(self.data)
       end
+      WeakAuras.FillOptions()
       OptionsPrivate.SortDisplayButtons(nil, true)
     end
   end,
@@ -510,6 +511,7 @@ StaticPopupDialogs["WEAKAURAS_CONFIRM_UNIGNORE_UPDATES"] = {
         end
         WeakAuras.ClearAndUpdateOptions(self.data)
       end
+      WeakAuras.FillOptions()
       OptionsPrivate.SortDisplayButtons(nil, true)
     end
   end,

--- a/WeakAurasOptions/WeakAurasOptions.lua
+++ b/WeakAurasOptions/WeakAurasOptions.lua
@@ -484,7 +484,9 @@ StaticPopupDialogs["WEAKAURAS_CONFIRM_IGNORE_UPDATES"] = {
       if auraData then
         for child in OptionsPrivate.Private.TraverseAll(auraData) do
           child.ignoreWagoUpdate = true
+          OptionsPrivate.ClearOptions(child.id)
         end
+        WeakAuras.ClearAndUpdateOptions(self.data)
       end
       OptionsPrivate.SortDisplayButtons(nil, true)
     end
@@ -504,9 +506,12 @@ StaticPopupDialogs["WEAKAURAS_CONFIRM_UNIGNORE_UPDATES"] = {
       if auraData then
         for child in OptionsPrivate.Private.TraverseAll(auraData) do
           child.ignoreWagoUpdate = nil
+          OptionsPrivate.ClearOptions(child.id)
         end
+        WeakAuras.ClearAndUpdateOptions(self.data)
       end
       OptionsPrivate.SortDisplayButtons(nil, true)
+      
     end
   end,
   OnCancel = function(self) end,

--- a/WeakAurasOptions/WeakAurasOptions.lua
+++ b/WeakAurasOptions/WeakAurasOptions.lua
@@ -511,7 +511,6 @@ StaticPopupDialogs["WEAKAURAS_CONFIRM_UNIGNORE_UPDATES"] = {
         WeakAuras.ClearAndUpdateOptions(self.data)
       end
       OptionsPrivate.SortDisplayButtons(nil, true)
-      
     end
   end,
   OnCancel = function(self) end,


### PR DESCRIPTION
# Description

This pullrequest is supposed to add an option to the dropdownlist to be able to Unignore (and ignore) wago options for auras. Code is probably pretty suboptimal so please roast me to make things better thank you.

Having 2 popup dialogs that basically do exactly the same except having different texts should be changed but i wasn't sure how to handle this best.


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected) -- this depends on how updating is implemented in the companion  (which i don't know)

## How Has This Been Tested

Tried ignoring and unignoring updates which updated the auras fine in the SavedVariables.

## Checklist
<!-- These can be checked off after the pull request is submitted, in case you want discussion before they are completely ready -->

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

<!-- Is there any additional work that needs to be done? If so, add it to the above list -->

Will prob need a change alongside in companion but i didn't doublecheck with buds https://github.com/WeakAuras/WeakAuras-Companion/issues/1543