### PR TITLE
fix #4575

### DIFF
--- a/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasPendingUpdateButton.lua
+++ b/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasPendingUpdateButton.lua
@@ -71,53 +71,11 @@ local methods = {
 
     self.menu = {}
 
-    self.frame:SetScript("OnMouseUp", function()
-      Hide_Tooltip()
-      self:SetMenu()
-      LibDD:EasyMenu(self.menu, WeakAuras_DropDownMenu, self.frame, 0, 0, "MENU")
-    end)
-
     self.frame:SetScript("OnEnter", function()
       self:SetNormalTooltip()
       Show_Long_Tooltip(self.frame, self.frame.description)
     end)
     self.frame:SetScript("OnLeave", Hide_Tooltip)
-  end,
-  ["SetMenu"] = function(self)
-    wipe(self.menu)
-    for auraId in pairs(self.linkedAuras) do
-      if not self.linkedChildren[auraId] then
-        tinsert(self.menu,
-          {
-            text = auraId,
-            notCheckable = true,
-            hasArrow = true,
-            menuList = {
-              {
-                text = L["Update"],
-                notCheckable = true,
-                func = function()
-                  local auraData = WeakAuras.GetData(auraId)
-                  if auraData then
-                    local success, error = WeakAuras.Import(self.companionData.encoded, auraData)
-                    if not success and error ~= nil then
-                      WeakAuras.prettyPrint(error)
-                    end
-                  end
-                end
-              },
-              {
-                text = L["Ignore updates"],
-                notCheckable = true,
-                func = function()
-                  StaticPopup_Show("WEAKAURAS_CONFIRM_IGNORE_UPDATES", "", "", auraId)
-                end
-              }
-            }
-          }
-        )
-      end
-    end
   end,
   ["SetLogo"] = function(self, path)
     self.frame.updateLogo.tex:SetTexture(path)


### PR DESCRIPTION
# Description

As discussed with buds [here](https://discord.com/channels/172440238717665280/273144328447197186/1141816770320154664) removes the right click menue of PendingUpdateButton
<!-- A #ticketNumber will be sufficient. -->
Fixes #4575

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update (specifically in the #wa-companion-app pin)
## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Clicked around a bit on the pending update button. Ignoring from the information tab still works fine and so does updating

## Checklist
<!-- These can be checked off after the pull request is submitted, in case you want discussion before they are completely ready -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

<!-- Is there any additional work that needs to be done? If so, add it to the above list -->
Adjust the pin in #wa-companion-app channel
