### PR TITLE
Add new angle-based constant factor for circular dynamic group grow styles

### DIFF
--- a/WeakAuras/RegionTypes/DynamicGroup.lua
+++ b/WeakAuras/RegionTypes/DynamicGroup.lua
@@ -29,6 +29,7 @@ local default = {
   yOffset = 0,
   radius = 200,
   rotation = 0,
+  stepAngle = 15,
   fullCircle = true,
   arcLength = 360,
   constantFactor = "RADIUS",
@@ -718,6 +719,7 @@ local growers = {
     local constantFactor = data.constantFactor
     local space = data.space or 0
     local radius = data.radius or 0
+    local stepAngle = (data.stepAngle or 0) * math.pi / 180
     local limit = data.useLimit and data.limit or math.huge
     local sAngle = (data.rotation or 0) * math.pi / 180
     local arc = (data.fullCircle and 360 or data.arcLength or 0) * math.pi / 180
@@ -735,7 +737,7 @@ local growers = {
       for frame, regionDatas in pairs(frames) do
         local numVisible = min(limit, #regionDatas)
         local r
-        if constantFactor == "RADIUS" then
+        if constantFactor == "RADIUS" or constantFactor == "ANGLE" then
           r = radius
         else
           if numVisible <= 1 then
@@ -748,6 +750,8 @@ local growers = {
         local dAngle
         if numVisible == 1 then
           dAngle = 0
+        elseif constantFactor == "ANGLE" then
+          dAngle = stepAngle
         elseif not data.fullCircle then
           dAngle = arc / (numVisible - 1)
         else
@@ -769,6 +773,7 @@ local growers = {
     local constantFactor = data.constantFactor
     local space = data.space or 0
     local radius = data.radius or 0
+    local stepAngle = (data.stepAngle or 0) * math.pi / 180
     local limit = data.useLimit and data.limit or math.huge
     local sAngle = (data.rotation or 0) * math.pi / 180
     local arc = (data.fullCircle and 360 or data.arcLength or 0) * math.pi / 180
@@ -786,7 +791,7 @@ local growers = {
       for frame, regionDatas in pairs(frames) do
         local numVisible = min(limit, #regionDatas)
         local r
-        if constantFactor == "RADIUS" then
+        if constantFactor == "RADIUS" or constantFactor == "ANGLE" then
           r = radius
         else
           if numVisible <= 1 then
@@ -799,6 +804,8 @@ local growers = {
         local dAngle
         if numVisible == 1 then
           dAngle = 0
+        elseif constantFactor == "ANGLE" then
+          dAngle = -stepAngle
         elseif not data.fullCircle then
           dAngle = arc / (1 - numVisible)
         else

--- a/WeakAuras/Types.lua
+++ b/WeakAuras/Types.lua
@@ -35,6 +35,7 @@ Private.glow_frame_types = {
 
 --- @type table<dynamicGroupCircularTypes, string>
 Private.circular_group_constant_factor_types = {
+  ANGLE = L["Angle and Radius"],
   RADIUS = L["Radius"],
   SPACING = L["Spacing"]
 }

--- a/WeakAurasOptions/RegionOptions/DynamicGroup.lua
+++ b/WeakAurasOptions/RegionOptions/DynamicGroup.lua
@@ -276,7 +276,18 @@ local function createOptions(id, data)
       width = WeakAuras.normalWidth,
       name = L["Full Circle"],
       order = 7,
-      hidden = function() return data.grow ~= "CIRCLE" and data.grow ~= "COUNTERCIRCLE" end
+      hidden = function() return (data.grow ~= "CIRCLE" and data.grow ~= "COUNTERCIRCLE") or data.constantFactor == "ANGLE" end
+    },
+    stepAngle = {
+      type = "range",
+      control = "WeakAurasSpinBox",
+      width = WeakAuras.normalWidth,
+      name = L["Angle Between Auras"],
+      order = 12,
+      min = 0,
+      max = 180,
+      bigStep = 1,
+      hidden = function() return data.grow == "CUSTOM" or not((data.grow == "CIRCLE" or data.grow == "COUNTERCIRCLE") and data.constantFactor == "ANGLE") end
     },
     arcLength = {
       type = "range",
@@ -288,7 +299,7 @@ local function createOptions(id, data)
       max = 360,
       bigStep = 3,
       disabled = function() return data.fullCircle end,
-      hidden = function() return data.grow ~= "CIRCLE" and data.grow ~= "COUNTERCIRCLE" end
+      hidden = function() return (data.grow ~= "CIRCLE" and data.grow ~= "COUNTERCIRCLE") or data.constantFactor == "ANGLE" end
     },
     radius = {
       type = "range",
@@ -299,7 +310,7 @@ local function createOptions(id, data)
       softMin = 0,
       softMax = 500,
       bigStep = 1,
-      hidden = function() return data.grow == "CUSTOM" or not((data.grow == "CIRCLE" or data.grow == "COUNTERCIRCLE") and data.constantFactor == "RADIUS") end
+      hidden = function() return data.grow == "CUSTOM" or not((data.grow == "CIRCLE" or data.grow == "COUNTERCIRCLE" ) and data.constantFactor ~= "SPACING") end
     },
     -- grid grow options
     gridType = {
@@ -369,7 +380,7 @@ local function createOptions(id, data)
       hidden = function()
         return data.grow == "CUSTOM"
             or data.grow == "GRID"
-            or ((data.grow == "CIRCLE" or data.grow == "COUNTERCIRCLE") and data.constantFactor == "RADIUS")
+            or ((data.grow == "CIRCLE" or data.grow == "COUNTERCIRCLE") and data.constantFactor ~= "SPACING")
       end
     },
     stagger = {

--- a/WeakAurasOptions/RegionOptions/DynamicGroup.lua
+++ b/WeakAurasOptions/RegionOptions/DynamicGroup.lua
@@ -258,7 +258,7 @@ local function createOptions(id, data)
       name = L["Constant Factor"],
       order = 4,
       values = OptionsPrivate.Private.circular_group_constant_factor_types,
-      hidden = function() return data.grow ~= "CIRCLE" and data.grow ~= "COUNTERCIRCLE" end
+      hidden = function() return not(data.grow == "CIRCLE" or data.grow == "COUNTERCIRCLE") end
     },
     rotation = {
       type = "range",
@@ -269,14 +269,18 @@ local function createOptions(id, data)
       min = 0,
       max = 360,
       bigStep = 3,
-      hidden = function() return data.grow ~= "CIRCLE" and data.grow ~= "COUNTERCIRCLE" end
+      hidden = function() return not(data.grow == "CIRCLE" or data.grow == "COUNTERCIRCLE") end
     },
     fullCircle = {
       type = "toggle",
       width = WeakAuras.normalWidth,
       name = L["Full Circle"],
       order = 7,
-      hidden = function() return (data.grow ~= "CIRCLE" and data.grow ~= "COUNTERCIRCLE") or data.constantFactor == "ANGLE" end
+      hidden = function()
+        return not(
+          (data.grow == "CIRCLE" or data.grow == "COUNTERCIRCLE")
+          and (data.constantFactor == "RADIUS" or data.constantFactor == "SPACING"))
+        end
     },
     stepAngle = {
       type = "range",
@@ -287,7 +291,9 @@ local function createOptions(id, data)
       min = 0,
       max = 180,
       bigStep = 1,
-      hidden = function() return data.grow == "CUSTOM" or not((data.grow == "CIRCLE" or data.grow == "COUNTERCIRCLE") and data.constantFactor == "ANGLE") end
+      hidden = function()
+        return not((data.grow == "CIRCLE" or data.grow == "COUNTERCIRCLE") and data.constantFactor == "ANGLE")
+      end
     },
     arcLength = {
       type = "range",
@@ -299,7 +305,11 @@ local function createOptions(id, data)
       max = 360,
       bigStep = 3,
       disabled = function() return data.fullCircle end,
-      hidden = function() return (data.grow ~= "CIRCLE" and data.grow ~= "COUNTERCIRCLE") or data.constantFactor == "ANGLE" end
+      hidden = function()
+        return not(
+          (data.grow == "CIRCLE" or data.grow == "COUNTERCIRCLE")
+          and (data.constantFactor == "RADIUS" or data.constantFactor == "SPACING"))
+        end
     },
     radius = {
       type = "range",
@@ -310,7 +320,11 @@ local function createOptions(id, data)
       softMin = 0,
       softMax = 500,
       bigStep = 1,
-      hidden = function() return data.grow == "CUSTOM" or not((data.grow == "CIRCLE" or data.grow == "COUNTERCIRCLE" ) and data.constantFactor ~= "SPACING") end
+      hidden = function()
+        return not(
+          (data.grow == "CIRCLE" or data.grow == "COUNTERCIRCLE")
+          and (data.constantFactor == "RADIUS" or data.constantFactor == "ANGLE"))
+        end
     },
     -- grid grow options
     gridType = {
@@ -378,9 +392,12 @@ local function createOptions(id, data)
       softMax = 300,
       bigStep = 1,
       hidden = function()
-        return data.grow == "CUSTOM"
-            or data.grow == "GRID"
-            or ((data.grow == "CIRCLE" or data.grow == "COUNTERCIRCLE") and data.constantFactor ~= "SPACING")
+        return not(
+          data.grow == "LEFT" or data.grow == "RIGHT"
+          or data.grow == "UP" or data.grow == "DOWN"
+          or data.grow == "HORIZONTAL" or data.grow == "VERTICAL"
+          or ((data.grow == "CIRCLE" or data.grow == "COUNTERCIRCLE")
+              and (data.constantFactor == "SPACING")))
       end
     },
     stagger = {


### PR DESCRIPTION
# Description

This PR adds a new angle-based constant factor for circular dynamic group grow styles. It is similar to the existing circular growers Clockwise and Counter Clockwise, but with a few key differences. With this new constant factor:

- Spacing is constant, and is determined by a combination of the user-defined radius and angle.
- Auras fill the group sequentially from one end to the other, essentially being placed as points along that curve in order.

The motivation for this new style was a request from a friend - they were trying to use the existing circular grow styles to build a new UI that was based on circles using Masque and some custom textures, but they couldn't get some of their aura groups to fit and grow the way they wanted. My initial solution for them was to write a custom grow function that placed the auras manually, and [I posted in the discord](https://discord.com/channels/172440238717665280/1014990256493314169/1160380179655438376) to ask about my use of an "internal" variable that felt too hacky. @mrbuds responded after a little while (a few messages down from the linked one), and after some discussion I decided that it may be worth actually adding something similar to my custom grower in a more official manner.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested

I have done a moderate amount of manual testing in-game. I've tested variations on almost all of the options that are enabled for this new constant factor with the notable exception of `Group by Frame`, since I haven't ever use that myself in any grow style. I chose to leave it enabled/visible since it's also an option for the existing circular growers and this new one is quite similar to those.

## Checklist
<!-- These can be checked off after the pull request is submitted, in case you want discussion before they are completely ready -->

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings

I did not add any significant comments. The PR only adds a small amount of code to the existing circular growers, and given the nature and context of the changes and the additions should be self-explanatory.

I also didn't update any documentation since I'm not aware of any that specifically describes the individual grow styles, but I'm happy to do so if that actually exists and someone can point me in the right direction to find it.

## Potential points of discussion

I tried to make design choices that seemed appropriate and intuitive, but I do have a few questions about my choices that I can see as potential points of discussion - 

1. Constant Factor Naming: This initial submission calls the new constant factor "Angle and Radius", but the two existing factors are only one word each and one is already called "Radius". I'm not attached to this name, it just seemed descriptive.
2. Region Option Naming: I added one new region option, currently called "Angle Between Auras". This option allows the user to set the angle between auras in the group, essentially exposing the internal `dAngle` to the user for this new constant factor. Additionally, internally this option is referred to as `stepAngle`. This makes sense to me, and while it is hypothetically confusing to have `sAngle` and `stepAngle` I think the best resolution would be refactoring `sAngle` to `startAngle` or similar. That said, I'm completely open to a new name for this variable.
3. `stepAngle` default value and range: I chose `15` for the default value, which seems reasonable for my expected common use cases, but this could be biased. Additionally, I limited the slider to a max of 180 since small changes to the `stepAngle` can have a large impact on the overall group. I can even see a smaller value being appropriate given how I expect the setting to be used, but it didn't seem worth limiting it unnecessarily. 
4. Other addon versions: So far I've only added this to the retail addon, but if/when we get the details sorted out and it's approved I'm happy to look into adding it to the other versions as well. I only did one version in this PR since it's my first and I wanted to reduce the scope of changes for my first attempt.

I'm very open to any and all feedback on this new grow style. I personally think it is something that adds to WeakAuras overall and that people would use, but I certainly don't think I have a complete perspective on every player's wants and needs, or on exactly how things in the codebase should be implemented.

## Examples

Finally, here are some quick pictures of a few really basic examples that I used while coding and testing. They aren't meant to be an exhaustive list of the potential uses at all, but simply demonstrate visually what the new grower does.

#### First, of course, a picture of the group settings with the new constant factor selected.
<img width="487" alt="Screenshot 2023-10-11 at 11 36 53 PM" src="https://github.com/WeakAuras/WeakAuras2/assets/690431/c4220131-2b5c-4fe1-a2db-d7a59482be21">

#### My friends circle-based UI, that started all this.

![brew-ui](https://github.com/WeakAuras/WeakAuras2/assets/690431/42031181-aad2-40f6-93ec-8acbcbdbd62e)

#### DK runes

One simple Curve-style dynamic group tracking the 6 dk runes, that shrinks and fills intuitively and automatically. Would probably be amazing with an actual progress texture rather than a basic one, but I was just testing and not going for perfect utility or aesthetics.
<img width="375" alt="Screenshot 2023-10-10 at 1 32 23 PM" src="https://github.com/WeakAuras/WeakAuras2/assets/690431/646131b4-e66a-4a00-9910-abaa18e53afa">

#### HUD-like cooldown tracking

This is two groups - the left one for externals and the right one for personals.
<img width="375" alt="Screenshot 2023-10-10 at 1 56 55 PM" src="https://github.com/WeakAuras/WeakAuras2/assets/690431/acac2773-0779-40bb-be96-2cd91e28fd6e">
