### PR TITLE
Adding coloring for WeakAuras that never load

### DIFF
--- a/WeakAurasOptions/WeakAurasOptions.lua
+++ b/WeakAurasOptions/WeakAurasOptions.lua
@@ -1138,6 +1138,12 @@ function OptionsPrivate.SortDisplayButtons(filter, overrideReset, id)
       child:DisableLoaded();
     end
 
+    if child.data.load.use_never then
+      child.background:SetVertexColor(1, 0.12, 0.12, 0.25)
+    else
+      child.background:SetVertexColor(0.5, 0.5, 0.5, 0.25)
+    end
+
     if useTextFilter then
       if(id:lower():find(filter, 1, true)) then
         aurasMatchingFilter[id] = true


### PR DESCRIPTION
# Description

<!-- A #ticketNumber will be sufficient. -->


So my change is that WeakAuras lines are now colored red if they have load "Never" cheked

![image](https://github.com/WeakAuras/WeakAuras2/assets/91337254/b90c9e2f-6c9f-4d75-912e-38465c13b987)

Current way to identify is WeakAura loaded(look for small papersheet on the display button) is not very obvious and informative. There is often a WeakAuras that must be loaded on certain bosses and they will always be shown as unloaded, so abillity to quickly identify is WA set to never load should be a good addition.

I saw this feature on Echo WeakAura's fork during RWF so inspired to make it real for everyone.
(new to github and english is not my primary language so sorry if my description is not good enough or i made something wrong)

## Type of change


- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested

Tested on my own WAs
Tried creating new WA and set it to load never


## Checklist
<!-- These can be checked off after the pull request is submitted, in case you want discussion before they are completely ready -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

<!-- Is there any additional work that needs to be done? If so, add it to the above list -->
