### PR TITLE
Add effective combo points trigger

### DIFF
--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -7261,6 +7261,114 @@ Private.event_prototypes = {
     delayEvents = true,
     timedrequired = true
   },
+  ["Effective Combo Points"] = {
+    type = "unit",
+    canHaveDuration = false,
+    events = function(trigger)
+      local unit = "player"
+      local result = {}
+      AddUnitEventForEvents(result, unit, "UNIT_POWER_FREQUENT")
+      AddUnitEventForEvents(result, unit, "UNIT_MAXPOWER")
+      AddUnitEventForEvents(result, unit, "UNIT_DISPLAYPOWER")
+      AddUnitEventForEvents(result, unit, "UNIT_NAME_UPDATE")
+
+      if WeakAuras.IsRetail() then
+        AddUnitEventForEvents(result, unit, "UNIT_POWER_POINT_CHARGE")
+      else
+        AddUnitEventForEvents(result, unit, "UNIT_TARGET")
+      end
+      return result;
+    end,
+    internal_events = {},
+    force_events = {{"UNIT_CHANGED_player", "player"}},
+    name = L["Effective Combo Points"],
+    init = function(trigger)
+      return ""
+    end,
+    statesParameter = "one",
+    args = {
+      {
+        name = "power",
+        display = L["Power"],
+        type = "number",
+        init = not WeakAuras.IsRetail() and "powerType == 4 and GetComboPoints('player', 'player-target') or UnitPower('player', 4)"
+        or "(tContains(GetUnitChargedPowerPoints('player') or {}, UnitPower('player', 4)) and 7 or UnitPower('player', 4)) / WeakAuras.UnitPowerDisplayMod(4)",
+        store = true,
+        conditionType = "number",
+        multiEntry = {
+          operator = "and",
+          limit = 2
+        },
+      },
+      {
+        name = "value",
+        hidden = true,
+        init = "power",
+        store = true,
+        test = "true"
+      },
+      {
+        name = "total",
+        hidden = true,
+        init = not WeakAuras.IsRetail() and "(math.max(1, UnitPowerMax('player', 4))"
+                                      or "math.max(1, UnitPowerMax('player', 4)) / WeakAuras.UnitPowerDisplayMod(4)",
+        store = true,
+        test = "true"
+      },
+      {
+        name = "stacks",
+        hidden = true,
+        init = "power",
+        store = true,
+        test = "true"
+      },
+      {
+        name = "progressType",
+        hidden = true,
+        init = "'static'",
+        store = true,
+        test = "true"
+      },
+      {
+        name = "percentpower",
+        display = L["Power (%)"],
+        type = "number",
+        init = "total ~= 0 and (value / total) * 100 or nil",
+        store = true,
+        conditionType = "number",
+        multiEntry = {
+          operator = "and",
+          limit = 2
+        },
+      },
+      {
+        name = "deficit",
+        display = L["Power Deficit"],
+        type = "number",
+        init = "total - value",
+        store = true,
+        conditionType = "number",
+        multiEntry = {
+          operator = "and",
+          limit = 2
+        },
+      },
+      {
+        name = "maxpower",
+        display = WeakAuras.newFeatureString .. L["Max Power"],
+        type = "number",
+        init = "total",
+        store = true,
+        conditionType = "number",
+        multiEntry = {
+          operator = "and",
+          limit = 2
+        },
+      },
+    },
+    overlayFuncs = {},
+    automaticrequired = true
+  },
   ["Evoker Essence"] = {
     type = "unit",
     events = {},

--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -3192,12 +3192,13 @@ Private.event_prototypes = {
         local name, realm = WeakAuras.UnitNameWithRealm(unit)
         local smart = %s
         local powerType = %s;
+        local measureChargedComboPoints = %s
         local unitPowerType = UnitPowerType(unit);
         local powerTypeToCheck = powerType or unitPowerType;
         local powerThirdArg = WeakAuras.UseUnitPowerThirdArg(powerTypeToCheck);
         if not WeakAuras.IsRetail() and powerType == 99 then powerType = 1 end
       ]=];
-      ret = ret:format(trigger.unit == "group" and "true" or "false", trigger.use_powertype and trigger.powertype or "nil");
+      ret = ret:format(trigger.unit == "group" and "true" or "false", trigger.use_powertype and trigger.powertype or "nil", trigger.use_measureChargedComboPoints and "true" or "false");
 
       ret = ret .. unitHelperFunctions.SpecificUnitCheck(trigger)
 
@@ -3321,6 +3322,17 @@ Private.event_prototypes = {
         hidden = not WeakAuras.IsRetail()
       },
       {
+        name = "measureChargedComboPoints",
+        display = L["Use Value of Charged Combo Points"],
+        type = "toggle",
+        test = "true",
+        reloadOptions = true,
+        enable = function(trigger)
+          return WeakAuras.IsRetail() and trigger.unit == 'player' and trigger.use_powertype and trigger.powertype == 4
+        end,
+        hidden = not WeakAuras.IsRetail()
+      },
+      {
         name = "chargedComboPoint1",
         type = "number",
         display = L["Charged Combo Point 1"],
@@ -3379,7 +3391,7 @@ Private.event_prototypes = {
         display = L["Power"],
         type = "number",
         init = not WeakAuras.IsRetail() and "powerType == 4 and GetComboPoints(unit, unit .. '-target') or UnitPower(unit, powerType, powerThirdArg)"
-                                     or "UnitPower(unit, powerType, powerThirdArg) / WeakAuras.UnitPowerDisplayMod(powerTypeToCheck)",
+                                     or "(measureChargedComboPoints and (tContains(GetUnitChargedPowerPoints(unit) or {}, UnitPower(unit, powerType, powerThirdArg)) and 7 or UnitPower(unit, powerType, powerThirdArg)) or UnitPower(unit, powerType, powerThirdArg)) / WeakAuras.UnitPowerDisplayMod(powerTypeToCheck)",
         store = true,
         conditionType = "number",
         multiEntry = {
@@ -7260,114 +7272,6 @@ Private.event_prototypes = {
     countEvents = true,
     delayEvents = true,
     timedrequired = true
-  },
-  ["Effective Combo Points"] = {
-    type = "unit",
-    canHaveDuration = false,
-    events = function(trigger)
-      local unit = "player"
-      local result = {}
-      AddUnitEventForEvents(result, unit, "UNIT_POWER_FREQUENT")
-      AddUnitEventForEvents(result, unit, "UNIT_MAXPOWER")
-      AddUnitEventForEvents(result, unit, "UNIT_DISPLAYPOWER")
-      AddUnitEventForEvents(result, unit, "UNIT_NAME_UPDATE")
-
-      if WeakAuras.IsRetail() then
-        AddUnitEventForEvents(result, unit, "UNIT_POWER_POINT_CHARGE")
-      else
-        AddUnitEventForEvents(result, unit, "UNIT_TARGET")
-      end
-      return result;
-    end,
-    internal_events = {},
-    force_events = {{"UNIT_CHANGED_player", "player"}},
-    name = L["Effective Combo Points"],
-    init = function(trigger)
-      return ""
-    end,
-    statesParameter = "one",
-    args = {
-      {
-        name = "power",
-        display = L["Power"],
-        type = "number",
-        init = not WeakAuras.IsRetail() and "powerType == 4 and GetComboPoints('player', 'player-target') or UnitPower('player', 4)"
-        or "(tContains(GetUnitChargedPowerPoints('player') or {}, UnitPower('player', 4)) and 7 or UnitPower('player', 4)) / WeakAuras.UnitPowerDisplayMod(4)",
-        store = true,
-        conditionType = "number",
-        multiEntry = {
-          operator = "and",
-          limit = 2
-        },
-      },
-      {
-        name = "value",
-        hidden = true,
-        init = "power",
-        store = true,
-        test = "true"
-      },
-      {
-        name = "total",
-        hidden = true,
-        init = not WeakAuras.IsRetail() and "(math.max(1, UnitPowerMax('player', 4))"
-                                      or "math.max(1, UnitPowerMax('player', 4)) / WeakAuras.UnitPowerDisplayMod(4)",
-        store = true,
-        test = "true"
-      },
-      {
-        name = "stacks",
-        hidden = true,
-        init = "power",
-        store = true,
-        test = "true"
-      },
-      {
-        name = "progressType",
-        hidden = true,
-        init = "'static'",
-        store = true,
-        test = "true"
-      },
-      {
-        name = "percentpower",
-        display = L["Power (%)"],
-        type = "number",
-        init = "total ~= 0 and (value / total) * 100 or nil",
-        store = true,
-        conditionType = "number",
-        multiEntry = {
-          operator = "and",
-          limit = 2
-        },
-      },
-      {
-        name = "deficit",
-        display = L["Power Deficit"],
-        type = "number",
-        init = "total - value",
-        store = true,
-        conditionType = "number",
-        multiEntry = {
-          operator = "and",
-          limit = 2
-        },
-      },
-      {
-        name = "maxpower",
-        display = WeakAuras.newFeatureString .. L["Max Power"],
-        type = "number",
-        init = "total",
-        store = true,
-        conditionType = "number",
-        multiEntry = {
-          operator = "and",
-          limit = 2
-        },
-      },
-    },
-    overlayFuncs = {},
-    automaticrequired = true
   },
   ["Evoker Essence"] = {
     type = "unit",


### PR DESCRIPTION
# Description

This adds a new trigger kind for the "effective" combo point value the player currently has, considering charged combo points. This makes writing combo point trigger logic using charged combo points *much* simpler. (This number is what most of the APL in simc is written against)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested

- Made a weak aura with the new trigger and a `>= 6` condition. Used echoing reprimand to charge combo points, and got to 3 combo points, and verified that the weak aura appears (since 3 becomes effectively 7 when charged).
<details><summary>WA Import Code</summary>
!WA:2!1nvqUTTruulOffGOX1vUWO1PleCaCrAacqdsmCqTDHPTyKluIvOOQDxrpKZNItk5mdMzOTLxkuGKnzJpcADxPJqobec9eOfDvw5tq(dPbsrrT2W)F0BM379N30WRvElAl67(bLOWKX4G64Hb9o6vDuxECsIgm3t(iktlZiJdGlnHjcvoXekdnSCiKoMtYzXHMufOtfz0XZ1PeQ4IFVEZF)sZi84uHQVGXn((h9IUbY2395v31qUsCH2iYTigkPed4dNdCZcsbUkXWIpHrnPU7JTksSHj46T81gIY4eLW4mDQJl(X4mXOyJgbk9YBQUT8FCnJLGBb(3YwfAiKePfQOUaj7LckC2cDrufBdkssyxol8G9heeoiyF)GfsXfGkuibfbzE9n2B3RTNq1YNv6ixRtscG65CO9bI8ir7kFRl)MiRHb1IpZxfxt0sil7iQ2XhhKG2zIfGvAFwg9vakd)b970RNFftR3ARPuicLxa6ev3o967nS31f8BDOJ8RjvIiOU3s1FTKCJ7EUNlOHOLGZKBE3GYGrK4XHjzcHk9AnKLu5o3ED8cCteCJCfpf7Q2VUGqXdJ0oiykAcFyK9(z91kxDo2grI)JryyJtDZeeQxKHKHUCn)8ImdZXfNiXRv(to(XzeT2w5Qzxb2IjwsgGnF3TPStRtznNQQ4WonCnOWJIf8e2iNRjCMnUi4BvUS3haIggyuaFKj9lkx1Ll4WCAHQcrOnvO0aUvQEIfQ94k3XnNW4EL)mUHYDk3TCVYFb)(v)3vKp4UhCsfeZ0ihnL3))fvDHVfmDQvaSQinodezc1V2e)PEd(IGLmU8hNAeXNJkfr8TnEB6gm6uVQiF7xjUyYfcf9efro5KBlMLOWKfAB8gP5n1Vg9SlzT3t67FOAC9u8Jl9KcgDw6ZlE6d32n6WHVyo(CdrFSSwnZ(xAVS7S6RGdQuyJgnAoftPaT6H5F(LZy8AtH705gmLakoj73QL97BP9F2J3(XpR15)9PFk
</details>



https://github.com/WeakAuras/WeakAuras2/assets/2932786/bfdfe1a8-65ef-45de-aec4-03e5042822e4

