### PR TITLE
currencytrigger fixes

### DIFF
--- a/WeakAuras/Types.lua
+++ b/WeakAuras/Types.lua
@@ -1339,6 +1339,18 @@ local function InitializeCurrencies()
   Private.discovered_currencies = {}
   Private.discovered_currencies_sorted = {}
   Private.discovered_currencies_headers = {}
+
+  --expand all collapsed headers and save collapsed header indexes
+  local collapsedHeaders = {}
+  for index = 1, C_CurrencyInfo.GetCurrencyListSize() do
+    local currencyInfo = C_CurrencyInfo.GetCurrencyListInfo(index)
+    if currencyInfo and currencyInfo.isHeader and not currencyInfo.isHeaderExpanded then
+        C_CurrencyInfo.ExpandCurrencyList(index, true)
+        tinsert(collapsedHeaders, index)
+    end
+  end
+
+  --loop again with all headers expanded
   for index = 1, C_CurrencyInfo.GetCurrencyListSize() do
     local currencyLink = C_CurrencyInfo.GetCurrencyListLink(index)
     local currencyInfo = C_CurrencyInfo.GetCurrencyListInfo(index)
@@ -1357,6 +1369,12 @@ local function InitializeCurrencies()
 
   Private.discovered_currencies["member"] = "|Tinterface\\common\\ui-searchbox-icon:0:0:0:-2|t"..L["Specific Currency"];
   Private.discovered_currencies_sorted["member"] = -1;
+
+  --restore collapsed headers
+  for i=1, #collapsedHeaders do
+    local headerIndex = collapsedHeaders[#collapsedHeaders + 1 - i] --reverseloop to prevent index jumping
+    C_CurrencyInfo.ExpandCurrencyList(headerIndex, false)
+  end
 end
 
 Private.GetDiscoveredCurencies = function()

--- a/WeakAuras/Types.lua
+++ b/WeakAuras/Types.lua
@@ -1320,17 +1320,6 @@ for id, str in pairs(Private.combatlog_spell_school_types) do
   Private.combatlog_spell_school_types_for_ui[id] = ("%.3d - %s"):format(id, str)
 end
 
-Private.item_quality_types = {
-  [0] = ITEM_QUALITY0_DESC,
-  [1] = ITEM_QUALITY1_DESC,
-  [2] = ITEM_QUALITY2_DESC,
-  [3] = ITEM_QUALITY3_DESC,
-  [4] = ITEM_QUALITY4_DESC,
-  [5] = ITEM_QUALITY5_DESC,
-  [6] = ITEM_QUALITY6_DESC,
-  [7] = ITEM_QUALITY7_DESC,
-  [8] = ITEM_QUALITY8_DESC,
-}
 
 local function InitializeCurrencies()
   if Private.discovered_currencies then


### PR DESCRIPTION
fixes:
> If a currency group header is collapsed on the Currency tab, the dropdown list doesn't contain any items from that group  