### PR TITLE
Currency Trigger: support classic wrath, disable on classic era

### DIFF
--- a/WeakAuras/GenericTrigger.lua
+++ b/WeakAuras/GenericTrigger.lua
@@ -4425,11 +4425,40 @@ WeakAuras.GetHitChance = function()
   return max(melee, ranged, spell)
 end
 
+Private.ExecEnv.GetCurrencyInfo = function(id)
+  if WeakAuras.IsRetail() then
+    return C_CurrencyInfo.GetCurrencyInfo(id)
+  elseif WeakAuras.IsWrathClassic() then
+    local name, currentAmount, texture, earnedThisWeek, weeklyMax, totalMax, isDiscovered, rarity = GetCurrencyInfo(id)
+    local currencyInfo = {
+      name = name,
+      description = "",
+      isHeader = false,
+      isHeaderExpanded = false,
+      isTypeUnused = false,
+      isShowInBackpack = false,
+      quantity = currentAmount,
+      trackedQuantity = 0,
+      iconFileID = texture,
+      maxQuantity = totalMax,
+      canEarnPerWeek = weeklyMax > 0,
+      quantityEarnedThisWeek = earnedThisWeek,
+      isTradeable = false,
+      quality = rarity,
+      maxWeeklyQuantity = weeklyMax,
+      totalEarned = 0,
+      discovered = isDiscovered,
+      useTotalEarnedForMaxQty = false,
+    }
+    return currencyInfo
+  end
+end
+
 Private.GetCurrencyInfoForTrigger = function(trigger)
   if trigger.currencyId then
     local currencyId = tonumber(trigger.currencyId)
     if currencyId then
-      return C_CurrencyInfo.GetCurrencyInfo(currencyId)
+      return Private.ExecEnv.GetCurrencyInfo(currencyId)
     end
   end
 end

--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -10234,9 +10234,9 @@ Private.event_prototypes = {
     name = WeakAuras.newFeatureString..L["Currency"],
     init = function(trigger)
       local ret = [=[
-        local currencyInfo = C_CurrencyInfo.GetCurrencyInfo(%d)
+        local currencyInfo = Private.ExecEnv.GetCurrencyInfo(%d)
         if not currencyInfo then
-          currencyInfo = C_CurrencyInfo.GetCurrencyInfo(1) --Currency Token Test Token 4
+          currencyInfo = Private.ExecEnv.GetCurrencyInfo(1) --Currency Token Test Token 4
           currencyInfo.iconFileID = "Interface\\Icons\\INV_Misc_QuestionMark" --We don't want the user to think their input was valid
         end
       ]=]
@@ -10417,6 +10417,7 @@ if WeakAuras.IsClassicEraOrWrath() then
   end
   if not WeakAuras.IsWrathClassic() then
     Private.event_prototypes["Death Knight Rune"] = nil
+    Private.event_prototypes["Currency"] = nil
   end
   Private.event_prototypes["Evoker Essence"] = nil
   Private.event_prototypes["Alternate Power"] = nil

--- a/WeakAuras/Types.lua
+++ b/WeakAuras/Types.lua
@@ -1324,29 +1324,31 @@ Private.GetCurrencyListInfo = function(index)
   if WeakAuras.IsRetail() then
     return C_CurrencyInfo.GetCurrencyListInfo(index)
   elseif WeakAuras.IsWrathClassic() then
-    local name, isHeader, isExpanded, isUnused, isWatched, _, icon, _, hasWeeklyLimit, _, _, itemID = GetCurrencyListInfo(index)
-    local _, currentAmount, _, earnedThisWeek, weeklyMax, totalMax, isDiscovered, rarity = itemID and GetCurrencyInfo(itemID)
-    local currencyInfo = {
-      name = name,
-      description = "",
-      isHeader = isHeader,
-      isHeaderExpanded = isExpanded,
-      isTypeUnused = isUnused,
-      isShowInBackpack = isWatched,
-      quantity = currentAmount,
-      trackedQuantity = 0,
-      iconFileID = icon,
-      maxQuantity = totalMax,
-      canEarnPerWeek = hasWeeklyLimit,
-      quantityEarnedThisWeek = earnedThisWeek,
-      isTradeable = false,
-      quality = rarity,
-      maxWeeklyQuantity = weeklyMax,
-      totalEarned = 0,
-      discovered = isDiscovered,
-      useTotalEarnedForMaxQty = false,
-    }
-    return currencyInfo
+    local _, isHeader, isExpanded, isUnused, isWatched, _, icon, _, hasWeeklyLimit, _, _, itemID = GetCurrencyListInfo(index)
+    local name, currentAmount, _, earnedThisWeek, weeklyMax, totalMax, isDiscovered, rarity = itemID and GetCurrencyInfo(itemID)
+    if name then
+      local currencyInfo = {
+        name = name,
+        description = "",
+        isHeader = isHeader,
+        isHeaderExpanded = isExpanded,
+        isTypeUnused = isUnused,
+        isShowInBackpack = isWatched,
+        quantity = currentAmount,
+        trackedQuantity = 0,
+        iconFileID = icon,
+        maxQuantity = totalMax,
+        canEarnPerWeek = hasWeeklyLimit,
+        quantityEarnedThisWeek = earnedThisWeek,
+        isTradeable = false,
+        quality = rarity,
+        maxWeeklyQuantity = weeklyMax,
+        totalEarned = 0,
+        discovered = isDiscovered,
+        useTotalEarnedForMaxQty = false,
+      }
+      return currencyInfo
+    end
   end
 end
 

--- a/WeakAuras/Types.lua
+++ b/WeakAuras/Types.lua
@@ -1325,40 +1325,38 @@ Private.GetCurrencyListInfo = function(index)
     return C_CurrencyInfo.GetCurrencyListInfo(index)
   elseif WeakAuras.IsWrathClassic() then
     local name, isHeader, isExpanded, isUnused, isWatched, _, icon, _, hasWeeklyLimit, _, _, itemID = GetCurrencyListInfo(index)
+    local currentAmount, earnedThisWeek, weeklyMax, totalMax, isDiscovered, rarity
     if itemID then
-      local _, currentAmount, _, earnedThisWeek, weeklyMax, totalMax, isDiscovered, rarity = GetCurrencyInfo(itemID)
-      local currencyInfo = {
-        name = name,
-        description = "",
-        isHeader = isHeader,
-        isHeaderExpanded = isExpanded,
-        isTypeUnused = isUnused,
-        isShowInBackpack = isWatched,
-        quantity = currentAmount,
-        trackedQuantity = 0,
-        iconFileID = icon,
-        maxQuantity = totalMax,
-        canEarnPerWeek = hasWeeklyLimit,
-        quantityEarnedThisWeek = earnedThisWeek,
-        isTradeable = false,
-        quality = rarity,
-        maxWeeklyQuantity = weeklyMax,
-        totalEarned = 0,
-        discovered = isDiscovered,
-        useTotalEarnedForMaxQty = false,
-      }
-      return currencyInfo
+      _, currentAmount, _, earnedThisWeek, weeklyMax, totalMax, isDiscovered, rarity = GetCurrencyInfo(itemID)
     end
+    local currencyInfo = {
+      name = name,
+      description = "",
+      isHeader = isHeader,
+      isHeaderExpanded = isExpanded,
+      isTypeUnused = isUnused,
+      isShowInBackpack = isWatched,
+      quantity = currentAmount,
+      trackedQuantity = 0,
+      iconFileID = icon,
+      maxQuantity = totalMax,
+      canEarnPerWeek = hasWeeklyLimit,
+      quantityEarnedThisWeek = earnedThisWeek,
+      isTradeable = false,
+      quality = rarity,
+      maxWeeklyQuantity = weeklyMax,
+      totalEarned = 0,
+      discovered = isDiscovered,
+      useTotalEarnedForMaxQty = false,
+    }
+    return currencyInfo
   end
 end
 
-Private.GetCurrencyListSize = function()
-  if WeakAuras.IsRetail() then
-    return C_CurrencyInfo.GetCurrencyListSize()
-  end
-  if WeakAuras.IsWrathClassic() then
-    return GetCurrencyListSize()
-  end
+if WeakAuras.IsRetail() then
+  Private.GetCurrencyListSize = C_CurrencyInfo.GetCurrencyListSize
+elseif WeakAuras.IsWrathClassic() then
+  Private.GetCurrencyListSize = GetCurrencyListSize
 end
 
 Private.ExpandCurrencyList = function(index, expand)
@@ -1366,7 +1364,7 @@ Private.ExpandCurrencyList = function(index, expand)
     return C_CurrencyInfo.ExpandCurrencyList(index, expand)
   end
   if WeakAuras.IsWrathClassic() then
-    return ExpandCurrencyList(index, expand)
+    return ExpandCurrencyList(index, expand and 1 or 0)
   end
 end
 

--- a/WeakAuras/Types.lua
+++ b/WeakAuras/Types.lua
@@ -1320,10 +1320,21 @@ for id, str in pairs(Private.combatlog_spell_school_types) do
   Private.combatlog_spell_school_types_for_ui[id] = ("%.3d - %s"):format(id, str)
 end
 
-Private.GetCurrencyListInfo = function(index)
-  if WeakAuras.IsRetail() then
-    return C_CurrencyInfo.GetCurrencyListInfo(index)
-  elseif WeakAuras.IsWrathClassic() then
+if WeakAuras.IsRetail() then
+  Private.GetCurrencyListSize = C_CurrencyInfo.GetCurrencyListSize
+  Private.GetCurrencyIDFromLink = C_CurrencyInfo.GetCurrencyIDFromLink
+  Private.ExpandCurrencyList = C_CurrencyInfo.ExpandCurrencyList
+  Private.GetCurrencyListInfo = C_CurrencyInfo.GetCurrencyListInfo
+elseif WeakAuras.IsWrathClassic() then
+  Private.GetCurrencyListSize = GetCurrencyListSize
+  Private.GetCurrencyIDFromLink = function(currencyLink)
+    local currencyID = string.match(currencyLink, "|Hcurrency:(%d+):")
+    return currencyID
+  end
+  Private.ExpandCurrencyList = function(index, expand)
+    ExpandCurrencyList(index, expand and 1 or 0)
+  end
+  Private.GetCurrencyListInfo = function(index)
     local name, isHeader, isExpanded, isUnused, isWatched, _, icon, _, hasWeeklyLimit, _, _, itemID = GetCurrencyListInfo(index)
     local currentAmount, earnedThisWeek, weeklyMax, totalMax, isDiscovered, rarity
     if itemID then
@@ -1350,31 +1361,6 @@ Private.GetCurrencyListInfo = function(index)
       useTotalEarnedForMaxQty = false,
     }
     return currencyInfo
-  end
-end
-
-if WeakAuras.IsRetail() then
-  Private.GetCurrencyListSize = C_CurrencyInfo.GetCurrencyListSize
-elseif WeakAuras.IsWrathClassic() then
-  Private.GetCurrencyListSize = GetCurrencyListSize
-end
-
-Private.ExpandCurrencyList = function(index, expand)
-  if WeakAuras.IsRetail() then
-    return C_CurrencyInfo.ExpandCurrencyList(index, expand)
-  end
-  if WeakAuras.IsWrathClassic() then
-    return ExpandCurrencyList(index, expand and 1 or 0)
-  end
-end
-
-Private.GetCurrencyIDFromLink = function(currencyLink)
-  if WeakAuras.IsRetail() then
-    return C_CurrencyInfo.GetCurrencyIDFromLink(currencyLink)
-  end
-  if WeakAuras.IsWrathClassic() then
-    local currencyID = string.match(currencyLink, "|Hcurrency:(%d+):")
-    return currencyID
   end
 end
 

--- a/WeakAuras/Types.lua
+++ b/WeakAuras/Types.lua
@@ -1320,6 +1320,64 @@ for id, str in pairs(Private.combatlog_spell_school_types) do
   Private.combatlog_spell_school_types_for_ui[id] = ("%.3d - %s"):format(id, str)
 end
 
+Private.GetCurrencyListInfo = function(index)
+  if WeakAuras.IsRetail() then
+    return C_CurrencyInfo.GetCurrencyListInfo(index)
+  elseif WeakAuras.IsWrathClassic() then
+    local name, isHeader, isExpanded, isUnused, isWatched, _, icon, _, hasWeeklyLimit, _, _, itemID = GetCurrencyListInfo(index)
+    local _, currentAmount, _, earnedThisWeek, weeklyMax, totalMax, isDiscovered, rarity = itemID and GetCurrencyInfo(itemID)
+    local currencyInfo = {
+      name = name,
+      description = "",
+      isHeader = isHeader,
+      isHeaderExpanded = isExpanded,
+      isTypeUnused = isUnused,
+      isShowInBackpack = isWatched,
+      quantity = currentAmount,
+      trackedQuantity = 0,
+      iconFileID = icon,
+      maxQuantity = totalMax,
+      canEarnPerWeek = hasWeeklyLimit,
+      quantityEarnedThisWeek = earnedThisWeek,
+      isTradeable = false,
+      quality = rarity,
+      maxWeeklyQuantity = weeklyMax,
+      totalEarned = 0,
+      discovered = isDiscovered,
+      useTotalEarnedForMaxQty = false,
+    }
+    return currencyInfo
+  end
+end
+
+Private.GetCurrencyListSize = function()
+  if WeakAuras.IsRetail() then
+    return C_CurrencyInfo.GetCurrencyListSize()
+  end
+  if WeakAuras.IsWrathClassic() then
+    return GetCurrencyListSize()
+  end
+end
+
+Private.ExpandCurrencyList = function(index, expand)
+  if WeakAuras.IsRetail() then
+    return C_CurrencyInfo.GetCurrencyListLink(index, expand)
+  end
+  if WeakAuras.IsWrathClassic() then
+    return ExpandCurrencyList(index, expand)
+  end
+end
+
+Private.GetCurrencyIDFromLink = function(currencyLink)
+  if WeakAuras.IsRetail() then
+    return C_CurrencyInfo.GetCurrencyIDFromLink(currencyLink)
+  end
+  if WeakAuras.IsWrathClassic() then
+    local currencyID = string.match(currencyLink, "|Hcurrency:(%d+):")
+    return currencyID
+  end
+end
+
 local function InitializeCurrencies()
   if Private.discovered_currencies then
     return
@@ -1328,20 +1386,21 @@ local function InitializeCurrencies()
   Private.discovered_currencies_sorted = {}
   Private.discovered_currencies_headers = {}
   local expanded = {}
-  for index = C_CurrencyInfo.GetCurrencyListSize(), 1, -1 do
-    local currencyInfo = C_CurrencyInfo.GetCurrencyListInfo(index)
+
+  for index = Private.GetCurrencyListSize(), 1, -1 do
+    local currencyInfo = Private.GetCurrencyListInfo(index)
     if currencyInfo.isHeader and not currencyInfo.isHeaderExpanded then
-      C_CurrencyInfo.ExpandCurrencyList(index, true)
+      Private.ExpandCurrencyList(index, true)
       expanded[currencyInfo.name] = true
     end
   end
 
-  for index = 1, C_CurrencyInfo.GetCurrencyListSize() do
+  for index = 1, Private.GetCurrencyListSize() do
     local currencyLink = C_CurrencyInfo.GetCurrencyListLink(index)
-    local currencyInfo = C_CurrencyInfo.GetCurrencyListInfo(index)
+    local currencyInfo = Private.GetCurrencyListInfo(index)
 
     if currencyLink then
-      local currencyID = C_CurrencyInfo.GetCurrencyIDFromLink(currencyLink)
+      local currencyID = Private.GetCurrencyIDFromLink(currencyLink)
       local icon = currencyInfo.iconFileID or "Interface\\Icons\\INV_Misc_QuestionMark" --iconFileID not available on first login
       Private.discovered_currencies[currencyID] = "|T" .. icon .. ":0|t" .. currencyInfo.name
       Private.discovered_currencies_sorted[currencyID] = index
@@ -1352,10 +1411,10 @@ local function InitializeCurrencies()
     end
   end
 
-  for index = C_CurrencyInfo.GetCurrencyListSize(), 1, -1 do
-    local currencyInfo = C_CurrencyInfo.GetCurrencyListInfo(index)
+  for index = Private.GetCurrencyListSize(), 1, -1 do
+    local currencyInfo = Private.GetCurrencyListInfo(index)
     if currencyInfo.isHeader and expanded[currencyInfo.name] then
-      C_CurrencyInfo.ExpandCurrencyList(index, false)
+      Private.ExpandCurrencyList(index, false)
     end
   end
 

--- a/WeakAuras/Types.lua
+++ b/WeakAuras/Types.lua
@@ -1363,7 +1363,7 @@ end
 
 Private.ExpandCurrencyList = function(index, expand)
   if WeakAuras.IsRetail() then
-    return C_CurrencyInfo.GetCurrencyListLink(index, expand)
+    return C_CurrencyInfo.ExpandCurrencyList(index, expand)
   end
   if WeakAuras.IsWrathClassic() then
     return ExpandCurrencyList(index, expand)

--- a/WeakAuras/Types.lua
+++ b/WeakAuras/Types.lua
@@ -1324,9 +1324,9 @@ Private.GetCurrencyListInfo = function(index)
   if WeakAuras.IsRetail() then
     return C_CurrencyInfo.GetCurrencyListInfo(index)
   elseif WeakAuras.IsWrathClassic() then
-    local _, isHeader, isExpanded, isUnused, isWatched, _, icon, _, hasWeeklyLimit, _, _, itemID = GetCurrencyListInfo(index)
-    local name, currentAmount, _, earnedThisWeek, weeklyMax, totalMax, isDiscovered, rarity = itemID and GetCurrencyInfo(itemID)
-    if name then
+    local name, isHeader, isExpanded, isUnused, isWatched, _, icon, _, hasWeeklyLimit, _, _, itemID = GetCurrencyListInfo(index)
+    if itemID then
+      local _, currentAmount, _, earnedThisWeek, weeklyMax, totalMax, isDiscovered, rarity = GetCurrencyInfo(itemID)
       local currencyInfo = {
         name = name,
         description = "",


### PR DESCRIPTION
Classic Wrath's API for CurrencyInfo is not the same as on Retail. 
On Classic Era, currencies don't exist.