### PR TITLE
Update flipbooks for StopMotion

### DIFF
--- a/WeakAuras/Types.lua
+++ b/WeakAuras/Types.lua
@@ -3683,15 +3683,13 @@ Private.item_weapon_types[4 * 256 + 6] = GetItemSubClassInfo(4, 6)
 WeakAuras.item_weapon_types = Private.item_weapon_types
 
 WeakAuras.StopMotion = {}
-WeakAuras.StopMotion.texture_types = {
-}
+WeakAuras.StopMotion.texture_types = {}
 
 WeakAuras.StopMotion.texture_types.Basic = {
   ["Interface\\AddOns\\WeakAuras\\Media\\Textures\\stopmotion"] = "Example",
 }
 
-WeakAuras.StopMotion.texture_data = {
-}
+WeakAuras.StopMotion.texture_data = {}
 
 WeakAuras.StopMotion.texture_data["Interface\\AddOns\\WeakAuras\\Media\\Textures\\stopmotion"] = {
      ["count"] = 64,
@@ -3802,167 +3800,470 @@ WeakAuras.StopMotion.texture_data["Interface\\AddOns\\WeakAurasStopMotion\\Textu
      ["columns"] = 4
   }
 
+-- Blizzard flipbooks, only for Retail
 if WeakAuras.IsRetail() then
-  WeakAuras.StopMotion.texture_types.Blizzard = {
-    ["Skillbar_Fill_Flipbook_Alchemy"] = L["Alchemy Cast Bar"],
-    ["Skillbar_Fill_Flipbook_Blacksmithing"] = L["Blacksmithing Cast Bar"],
-    ["Skillbar_Fill_Flipbook_Jewelcrafting"] = L["Jewelcrafting Cast Bar"],
-    ["Skillbar_Fill_Flipbook_Tailoring"] = L["Tailoring Cast Bar"],
-    ["Skillbar_Fill_Flipbook_Leatherworking"] = L["Leatherworking Cast Bar"],
-    ["Skillbar_Fill_Flipbook_Enchanting"] = L["Enchanting Cast Bar"],
-    ["groupfinder-eye-flipbook-initial"] = L["Group Finder Eye Initial"],
-    ["groupfinder-eye-flipbook-searching"] = L["Group Finder Eye"],
-    ["groupfinder-eye-flipbook-mouseover"] = L["Group Finder Mouse Over"],
-    ["groupfinder-eye-flipbook-foundfx"] = L["Group Finder Found Initial"],
-    ["groupfinder-eye-flipbook-found-loop"] = L["Group Finder Found"],
-    ["groupfinder-eye-flipbook-poke-initial"] = L["Group Finder Poke Initial"],
-    ["groupfinder-eye-flipbook-poke-loop"] = L["Group Finder Poke"],
-    ["groupfinder-eye-flipbook-poke-end"] = L["Group Finder Poke End"],
-    ["UI-HUD-UnitFrame-Player-Rest-Flipbook"] = L["Player Rest"],
-  }
+  WeakAuras.StopMotion.texture_types.Blizzard = {}
+  local replacementString = {}
 
-
-  WeakAuras.StopMotion.texture_data["Skillbar_Fill_Flipbook_Alchemy"] = {
-    ["count"] = 60,
-    ["rows"] = 30,
-    ["columns"] = 2
+  -- Action bar GCD
+  WeakAuras.StopMotion.texture_data["UI-HUD-ActionBar-GCD-Flipbook-2x"] = {
+    ["rows"] = 11,
+    ["columns"] = 2,
+    ["count"] = 22,
+    ["isBlizzardFlipbook"] = true
   }
+  WeakAuras.StopMotion.texture_types.Blizzard["UI-HUD-ActionBar-GCD-Flipbook-2x"] = "UI-HUD-ActionBar-GCD-Flipbook-2x"
 
-  WeakAuras.StopMotion.texture_data["Skillbar_Fill_Flipbook_Blacksmithing"] = {
-    ["count"] = 60,
-    ["rows"] = 30,
-    ["columns"] = 2
-  }
-
-  WeakAuras.StopMotion.texture_data["Skillbar_Fill_Flipbook_Jewelcrafting"] = {
-    ["count"] = 44,
-    ["rows"] = 22,
-    ["columns"] = 2
-  }
-
-  WeakAuras.StopMotion.texture_data["Skillbar_Fill_Flipbook_Tailoring"] = {
-    ["count"] = 58,
-    ["rows"] = 29,
-    ["columns"] = 2
-  }
-
-  WeakAuras.StopMotion.texture_data["Skillbar_Fill_Flipbook_Leatherworking"] = {
-    ["count"] = 60,
-    ["rows"] = 30,
-    ["columns"] = 2
-  }
-
-  WeakAuras.StopMotion.texture_data["Skillbar_Fill_Flipbook_Enchanting"] = {
-    ["count"] = 74,
-    ["rows"] = 37,
-    ["columns"] = 2
-  }
-  WeakAuras.StopMotion.texture_data["groupfinder-eye-flipbook-initial"] = {
-    ["count"] = 52,
+  -- Arcane shock
+  WeakAuras.StopMotion.texture_data["UF-Arcane-ShockFX"] = {
     ["rows"] = 5,
-    ["columns"] = 11
+    ["columns"] = 6,
+    ["count"] = 28,
+    ["isBlizzardFlipbook"] = true
   }
-  WeakAuras.StopMotion.texture_data["groupfinder-eye-flipbook-searching"] = {
-    ["count"] = 80,
-    ["rows"] = 8,
-    ["columns"] = 11
-  }
-  WeakAuras.StopMotion.texture_data["groupfinder-eye-flipbook-mouseover"] = {
-    ["count"] = 12,
-    ["rows"] = 1,
-    ["columns"] = 12
-  }
-  WeakAuras.StopMotion.texture_data["groupfinder-eye-flipbook-foundfx"] = {
-    ["count"] = 75,
-    ["rows"] = 5,
-    ["columns"] = 15
-  }
-  WeakAuras.StopMotion.texture_data["groupfinder-eye-flipbook-found-loop"] = {
-    ["count"] = 41,
-    ["rows"] = 4,
-    ["columns"] = 11
-  }
-  WeakAuras.StopMotion.texture_data["groupfinder-eye-flipbook-poke-initial"] = {
-    ["count"] = 66,
-    ["rows"] = 6,
-    ["columns"] = 11
-  }
-  WeakAuras.StopMotion.texture_data["groupfinder-eye-flipbook-poke-loop"] = {
-    ["count"] = 62,
-    ["rows"] = 6,
-    ["columns"] = 11
-  }
-  WeakAuras.StopMotion.texture_data["groupfinder-eye-flipbook-poke-end"] = {
-    ["count"] = 38,
-    ["rows"] = 4,
-    ["columns"] = 11
-  }
-  WeakAuras.StopMotion.texture_data["UI-HUD-UnitFrame-Player-Rest-Flipbook"] = {
+  WeakAuras.StopMotion.texture_types.Blizzard["UF-Arcane-ShockFX"] = "UF-Arcane-ShockFX"
+
+  -- Checkmark
+  WeakAuras.StopMotion.texture_data["activities-checkmark_flipbook-large"] = {
+    ["rows"] = 2,
+    ["columns"] = 4,
     ["count"] = 8,
-    ["rows"] = 1,
-    ["columns"] = 8
+    ["isBlizzardFlipbook"] = true
+  }
+  WeakAuras.StopMotion.texture_types.Blizzard["activities-checkmark_flipbook-large"] = "activities-checkmark_flipbook-large"
+
+  -- Chi wind
+  WeakAuras.StopMotion.texture_data["UF-Chi-WindFX"] = {
+    ["rows"] = 3,
+    ["columns"] = 6,
+    ["count"] = 17,
+    ["isBlizzardFlipbook"] = true
+  }
+  WeakAuras.StopMotion.texture_types.Blizzard["UF-Chi-WindFX"] = "UF-Chi-WindFX"
+
+  -- Death knight runes
+  replacementString = {
+    "Blood",
+    "Default",
+    "Frost",
+    "Unholy"
   }
 
-  local professions = {
-    "Blacksmithing",
-    "Enchanting",
-    "Tailoring",
-    "Jewelcrafting",
-    "Alchemy",
-    "Leatherworking",
-    "Engineering",
-    "Herbalism",
-    "Mining",
-    "Skinning",
-    "Inscription",
-  }
-  for _, profession in ipairs(professions) do
-    local name = ("SpecDial_Pip_Flipbook_%s"):format(profession)
+  for _, v in ipairs(replacementString) do
+    local name = ("UF-DKRunes-%sDeplete"):format(v)
     WeakAuras.StopMotion.texture_data[name] = {
-      ["count"] = 24,
       ["rows"] = 4,
-      ["columns"] = 4
-    }
-    WeakAuras.StopMotion.texture_types.Blizzard[name] = name
-    name = ("SpecDial_EndPip_Flipbook_%s"):format(profession)
-    WeakAuras.StopMotion.texture_data[name] = {
-      ["count"] = 16,
-      ["rows"] = 4,
-      ["columns"] = 6
-    }
-    WeakAuras.StopMotion.texture_types.Blizzard[name] = name
-    name = ("SpecDial_Fill_Flipbook_%s"):format(profession)
-    WeakAuras.StopMotion.texture_data[name] = {
-      ["count"] = 36,
-      ["rows"] = 6,
-      ["columns"] = 6
+      ["columns"] = 6,
+      ["count"] = 23,
+      ["isBlizzardFlipbook"] = true
     }
     WeakAuras.StopMotion.texture_types.Blizzard[name] = name
   end
+
+  -- Dice
+  WeakAuras.StopMotion.texture_data["lootroll-animdice"] = {
+    ["rows"] = 9,
+    ["columns"] = 5,
+    ["count"] = 44,
+    ["isBlizzardFlipbook"] = true
+  }
+  WeakAuras.StopMotion.texture_types.Blizzard["lootroll-animdice"] = "lootroll-animdice"
+
+  -- Dragonriding vigor
+  WeakAuras.StopMotion.texture_data["dragonriding_vigor_fill_flipbook"] = {
+    ["rows"] = 5,
+    ["columns"] = 4,
+    ["count"] = 20,
+    ["isBlizzardFlipbook"] = true
+  }
+  WeakAuras.StopMotion.texture_types.Blizzard["dragonriding_vigor_fill_flipbook"] = "dragonriding_vigor_fill_flipbook"
+
+  -- Druid combo points
+  WeakAuras.StopMotion.texture_data["UF-DruidCP-Slash"] = {
+    ["rows"] = 3,
+    ["columns"] = 8,
+    ["count"] = 20,
+    ["isBlizzardFlipbook"] = true
+  }
+  WeakAuras.StopMotion.texture_types.Blizzard["UF-DruidCP-Slash"] = "UF-DruidCP-Slash"
+
+  -- Essence spinner
+  WeakAuras.StopMotion.texture_data["UF-Essence-Flipbook-FX-Circ"] = {
+    ["rows"] = 3,
+    ["columns"] = 10,
+    ["count"] = 29,
+    ["isBlizzardFlipbook"] = true
+  }
+  WeakAuras.StopMotion.texture_types.Blizzard["UF-Essence-Flipbook-FX-Circ"] = "UF-Essence-Flipbook-FX-Circ"
+
+  -- Experience bars
+  replacementString = {
+    "Rested",
+    "Reputation",
+    "Experience",
+    "Honor",
+    "ArtifactPower"
+  }
+
+  for _, v in ipairs(replacementString) do
+    local name = ("UI-HUD-ExperienceBar-Fill-%s-2x-Flipbook"):format(v)
+    WeakAuras.StopMotion.texture_data[name] = {
+      ["rows"] = 30,
+      ["columns"] = 1,
+      ["count"] = 30,
+      ["isBlizzardFlipbook"] = true
+    }
+    WeakAuras.StopMotion.texture_types.Blizzard[name] = name
+  end
+
+  replacementString = {
+    "Rested",
+    "Reputation",
+    "XP",
+    "Faction-Orange",
+    "ArtifactPower"
+  }
+
+  for _, v in ipairs(replacementString) do
+    local name = ("UI-HUD-ExperienceBar-Flare-%s-2x-Flipbook"):format(v)
+    WeakAuras.StopMotion.texture_data[name] = {
+      ["rows"] = 7,
+      ["columns"] = 4,
+      ["count"] = 28,
+      ["isBlizzardFlipbook"] = true
+    }
+    WeakAuras.StopMotion.texture_types.Blizzard[name] = name
+  end
+
+  -- Great vault unlocking
+  WeakAuras.StopMotion.texture_data["greatVault-unlocked-anim"] = {
+    ["rows"] = 11,
+    ["columns"] = 5,
+    ["count"] = 54,
+    ["isBlizzardFlipbook"] = true
+  }
+  WeakAuras.StopMotion.texture_types.Blizzard["greatVault-unlocked-anim"] = "greatVault-unlocked-anim"
+
+  -- Group finder eye
+  WeakAuras.StopMotion.texture_data["groupfinder-eye-flipbook-initial"] = {
+    ["rows"] = 5,
+    ["columns"] = 11,
+    ["count"] = 52,
+    ["isBlizzardFlipbook"] = true
+  }
+  WeakAuras.StopMotion.texture_types.Blizzard["groupfinder-eye-flipbook-initial"] = "groupfinder-eye-flipbook-initial"
+
+  WeakAuras.StopMotion.texture_data["groupfinder-eye-flipbook-searching"] = {
+    ["rows"] = 8,
+    ["columns"] = 11,
+    ["count"] = 80,
+    ["isBlizzardFlipbook"] = true
+  }
+  WeakAuras.StopMotion.texture_types.Blizzard["groupfinder-eye-flipbook-searching"] = "groupfinder-eye-flipbook-searching"
+
+  WeakAuras.StopMotion.texture_data["groupfinder-eye-flipbook-mouseover"] = {
+    ["rows"] = 1,
+    ["columns"] = 12,
+    ["count"] = 12,
+    ["isBlizzardFlipbook"] = true
+  }
+  WeakAuras.StopMotion.texture_types.Blizzard["groupfinder-eye-flipbook-mouseover"] = "groupfinder-eye-flipbook-mouseover"
+
+  WeakAuras.StopMotion.texture_data["groupfinder-eye-flipbook-foundfx"] = {
+    ["rows"] = 5,
+    ["columns"] = 15,
+    ["count"] = 75,
+    ["isBlizzardFlipbook"] = true
+  }
+  WeakAuras.StopMotion.texture_types.Blizzard["groupfinder-eye-flipbook-foundfx"] = "groupfinder-eye-flipbook-foundfx"
+
+  WeakAuras.StopMotion.texture_data["groupfinder-eye-flipbook-found-initial"] = {
+    ["rows"] = 7,
+    ["columns"] = 11,
+    ["count"] = 70,
+    ["isBlizzardFlipbook"] = true
+  }
+  WeakAuras.StopMotion.texture_types.Blizzard["groupfinder-eye-flipbook-found-initial"] = "groupfinder-eye-flipbook-found-initial"
+
+  WeakAuras.StopMotion.texture_data["groupfinder-eye-flipbook-found-loop"] = {
+    ["rows"] = 4,
+    ["columns"] = 11,
+    ["count"] = 41,
+    ["isBlizzardFlipbook"] = true
+  }
+  WeakAuras.StopMotion.texture_types.Blizzard["groupfinder-eye-flipbook-found-loop"] = "groupfinder-eye-flipbook-found-loop"
+
+  WeakAuras.StopMotion.texture_data["groupfinder-eye-flipbook-poke-initial"] = {
+    ["rows"] = 6,
+    ["columns"] = 11,
+    ["count"] = 66,
+    ["isBlizzardFlipbook"] = true
+  }
+  WeakAuras.StopMotion.texture_types.Blizzard["groupfinder-eye-flipbook-poke-initial"] = "groupfinder-eye-flipbook-poke-initial"
+
+  WeakAuras.StopMotion.texture_data["groupfinder-eye-flipbook-poke-loop"] = {
+    ["rows"] = 6,
+    ["columns"] = 11,
+    ["count"] = 62,
+    ["isBlizzardFlipbook"] = true
+  }
+  WeakAuras.StopMotion.texture_types.Blizzard["groupfinder-eye-flipbook-poke-loop"] = "groupfinder-eye-flipbook-poke-loop"
+
+  WeakAuras.StopMotion.texture_data["groupfinder-eye-flipbook-poke-end"] = {
+    ["rows"] = 4,
+    ["columns"] = 11,
+    ["count"] = 38,
+    ["isBlizzardFlipbook"] = true
+  }
+  WeakAuras.StopMotion.texture_types.Blizzard["groupfinder-eye-flipbook-poke-end"] = "groupfinder-eye-flipbook-poke-end"
+
+  -- Holy power runes
+  for i = 1, 5 do
+    local name = ("UF-HolyPower-DepleteRune%d"):format(i)
+    WeakAuras.StopMotion.texture_data[name] = {
+      ["rows"] = 5,
+      ["columns"] = 6,
+      ["count"] = 26,
+      ["isBlizzardFlipbook"] = true
+    }
+    WeakAuras.StopMotion.texture_types.Blizzard[name] = name
+  end
+
+  -- Loot roll reveal
+  WeakAuras.StopMotion.texture_data["lootroll-animreveal-a"] = {
+    ["rows"] = 2,
+    ["columns"] = 6,
+    ["count"] = 12,
+    ["isBlizzardFlipbook"] = true
+  }
+  WeakAuras.StopMotion.texture_types.Blizzard["lootroll-animreveal-a"] = "lootroll-animreveal-a"
+
+   -- Mail
+   WeakAuras.StopMotion.texture_data["UI-HUD-Minimap-Mail-New-Flipbook-2x"] = {
+    ["rows"] = 5,
+    ["columns"] = 4,
+    ["count"] = 20,
+    ["isBlizzardFlipbook"] = true
+  }
+  WeakAuras.StopMotion.texture_types.Blizzard["UI-HUD-Minimap-Mail-New-Flipbook-2x"] = "UI-HUD-Minimap-Mail-New-Flipbook-2x"
+
+  WeakAuras.StopMotion.texture_data["UI-HUD-Minimap-Mail-Reminder-Flipbook-2x"] = {
+    ["rows"] = 3,
+    ["columns"] = 4,
+    ["count"] = 12,
+    ["isBlizzardFlipbook"] = true
+  }
+  WeakAuras.StopMotion.texture_types.Blizzard["UI-HUD-Minimap-Mail-Reminder-Flipbook-2x"] = "UI-HUD-Minimap-Mail-Reminder-Flipbook-2x"
+
+  -- Ping markers
+  replacementString = {
+    "Assist",
+    "Attack",
+    "OnMyWay",
+    "Warning",
+    "NonThreat",
+    "Threat"
+  }
+
+  for _, v in ipairs(replacementString) do
+    local name = ("Ping_Marker_FlipBook_%s"):format(v)
+    WeakAuras.StopMotion.texture_data[name] = {
+      ["rows"] = 4,
+      ["columns"] = 6,
+      ["count"] = 21,
+      ["isBlizzardFlipbook"] = true
+    }
+    WeakAuras.StopMotion.texture_types.Blizzard[name] = name
+  end
+
+  -- Player rest
+  WeakAuras.StopMotion.texture_data["UI-HUD-UnitFrame-Player-Rest-Flipbook"] = {
+    ["rows"] = 7,
+    ["columns"] = 6,
+    ["count"] = 42,
+    ["isBlizzardFlipbook"] = true
+  }
+  WeakAuras.StopMotion.texture_types.Blizzard["UI-HUD-UnitFrame-Player-Rest-Flipbook"] = "UI-HUD-UnitFrame-Player-Rest-Flipbook"
+
+  -- Priest void bar
+  WeakAuras.StopMotion.texture_data["Unit_Priest_Void_Fill_Flipbook"] = {
+    ["rows"] = 9,
+    ["columns"] = 5,
+    ["count"] = 45,
+    ["isBlizzardFlipbook"] = true
+  }
+  WeakAuras.StopMotion.texture_types.Blizzard["Unit_Priest_Void_Fill_Flipbook"] = "Unit_Priest_Void_Fill_Flipbook"
+
+  -- Professions
+  replacementString = {
+    "Alchemy",
+    "Blacksmithing",
+    "Cooking",
+    "Engineering",
+    "Fishing",
+    "Herbalism",
+    "Inscription",
+    "Leatherworking",
+    "Mining",
+    "Skinning",
+    "Tailoring"
+  }
+
+  for _, v in ipairs(replacementString) do
+    local name = ("Skillbar_Fill_Flipbook_%s"):format(v)
+    WeakAuras.StopMotion.texture_data[name] = {
+      ["rows"] = 30,
+      ["columns"] = 2,
+      ["count"] = 60,
+      ["isBlizzardFlipbook"] = true
+    }
+    WeakAuras.StopMotion.texture_types.Blizzard[name] = name
+  end
+
+  WeakAuras.StopMotion.texture_data["Skillbar_Fill_Flipbook_Enchanting"] = {
+    ["rows"] = 37,
+    ["columns"] = 2,
+    ["count"] = 74,
+    ["isBlizzardFlipbook"] = true
+  }
+  WeakAuras.StopMotion.texture_types.Blizzard["Skillbar_Fill_Flipbook_Enchanting"] = "Skillbar_Fill_Flipbook_Enchanting"
+
+  WeakAuras.StopMotion.texture_data["Skillbar_Fill_Flipbook_Jewelcrafting"] = {
+    ["rows"] = 22,
+    ["columns"] = 2,
+    ["count"] = 44,
+    ["isBlizzardFlipbook"] = true
+  }
+  WeakAuras.StopMotion.texture_types.Blizzard["Skillbar_Fill_Flipbook_Jewelcrafting"] = "Skillbar_Fill_Flipbook_Jewelcrafting"
+
+  replacementString = {
+    "Alchemy",
+    "Blacksmithing",
+    "Enchanting",
+    "Engineering",
+    "Herbalism",
+    "Inscription",
+    "Jewelcrafting",
+    "Leatherworking",
+    "Mining",
+    "Skinning",
+    "Tailoring"
+  }
+
+  for _, v in ipairs(replacementString) do
+    local name = ("SpecDial_Fill_Flipbook_%s"):format(v)
+    WeakAuras.StopMotion.texture_data[name] = {
+      ["rows"] = 6,
+      ["columns"] = 6,
+      ["count"] = 36,
+      ["isBlizzardFlipbook"] = true
+    }
+    WeakAuras.StopMotion.texture_types.Blizzard[name] = name
+
+    name = ("SpecDial_Pip_Flipbook_%s"):format(v)
+    WeakAuras.StopMotion.texture_data[name] = {
+      ["rows"] = 4,
+      ["columns"] = 4,
+      ["count"] = 16,
+      ["isBlizzardFlipbook"] = true
+    }
+    WeakAuras.StopMotion.texture_types.Blizzard[name] = name
+
+    name = ("SpecDial_EndPip_Flipbook_%s"):format(v)
+    WeakAuras.StopMotion.texture_data[name] = {
+      ["rows"] = 4,
+      ["columns"] = 6,
+      ["count"] = 24,
+      ["isBlizzardFlipbook"] = true
+    }
+    WeakAuras.StopMotion.texture_types.Blizzard[name] = name
+  end
+
   for i = 1, 5 do
     local name = ("GemAppear_T%d_Flipbook"):format(i)
     WeakAuras.StopMotion.texture_data[name] = {
-      ["count"] = 12,
       ["rows"] = 3,
-      ["columns"] = 4
+      ["columns"] = 4,
+      ["count"] = 12,
+      ["isBlizzardFlipbook"] = true
     }
     WeakAuras.StopMotion.texture_types.Blizzard[name] = name
+
     name = ("Quality-BarFill-Flipbook-T%d-x2"):format(i)
     WeakAuras.StopMotion.texture_data[name] = {
-      ["count"] = 60,
       ["rows"] = 15,
-      ["columns"] = 4
+      ["columns"] = 4,
+      ["count"] = 60,
+      ["isBlizzardFlipbook"] = true
     }
     WeakAuras.StopMotion.texture_types.Blizzard[name] = name
   end
+
   for i = 1, 4 do
     local name = ("GemDissolve_T%d_Flipbook"):format(i)
     WeakAuras.StopMotion.texture_data[name] = {
-      ["count"] = 12,
       ["rows"] = 3,
-      ["columns"] = 4
+      ["columns"] = 4,
+      ["count"] = 12,
+      ["isBlizzardFlipbook"] = true
     }
     WeakAuras.StopMotion.texture_types.Blizzard[name] = name
+  end
+
+  -- Rogue combo points
+  replacementString = {
+    "Red",
+    "Blue"
+  }
+
+  for _, v in ipairs(replacementString) do
+    local name = ("UF-RogueCP-Slash-%s"):format(v)
+    WeakAuras.StopMotion.texture_data[name] = {
+      ["rows"] = 3,
+      ["columns"] = 6,
+      ["count"] = 17,
+      ["isBlizzardFlipbook"] = true
+    }
+    WeakAuras.StopMotion.texture_types.Blizzard[name] = name
+  end
+
+  -- Soul shards
+  replacementString = {
+    "A",
+    "B",
+    "C"
+  }
+
+  for _, v in ipairs(replacementString) do
+    local name = ("UF-SoulShards-Flipbook-Deplete%s"):format(v)
+    WeakAuras.StopMotion.texture_data[name] = {
+      ["rows"] = 3,
+      ["columns"] = 6,
+      ["count"] = 15,
+      ["isBlizzardFlipbook"] = true
+    }
+    WeakAuras.StopMotion.texture_types.Blizzard[name] = name
+  end
+
+  WeakAuras.StopMotion.texture_data["UF-SoulShards-Flipbook-Soul"] = {
+    ["rows"] = 3,
+    ["columns"] = 7,
+    ["count"] = 18,
+    ["isBlizzardFlipbook"] = true
+  }
+  WeakAuras.StopMotion.texture_types.Blizzard["UF-SoulShards-Flipbook-Soul"] = "UF-SoulShards-Flipbook-Soul"
+
+  -- Supplement the data
+  for k, v in pairs(WeakAuras.StopMotion.texture_data) do
+    if v.isBlizzardFlipbook then
+      local atlasInfo = C_Texture.GetAtlasInfo(k)
+      if atlasInfo then
+        if atlasInfo.rawSize then
+          v.tileWidth = atlasInfo.rawSize.x / v.columns
+          v.tileHeight = atlasInfo.rawSize.y / v.rows
+        end
+      end
+    end
   end
 end
 

--- a/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasTextureButton.lua
+++ b/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasTextureButton.lua
@@ -1,6 +1,7 @@
 if not WeakAuras.IsLibsOK() then return end
+local AddonName, OptionsPrivate = ...
 
-local Type, Version = "WeakAurasTextureButton", 25
+local Type, Version = "WeakAurasTextureButton", 26
 local AceGUI = LibStub and LibStub("AceGUI-3.0", true)
 if not AceGUI or (AceGUI:GetWidgetVersion(Type) or 0) >= Version then return end
 local GetAtlasInfo = C_Texture and  C_Texture.GetAtlasInfo or GetAtlasInfo
@@ -37,10 +38,19 @@ local methods = {
     if atlasInfo then
       self.texture:SetAtlas(texturePath, false);
       self.texture.IsAtlas = true
-      if atlasInfo.width > atlasInfo.height then
-        self.texture:SetSize(120, 120 * (atlasInfo.height / atlasInfo.width))
-      elseif atlasInfo.height > atlasInfo.width then
-        self.texture:SetSize(120 * (atlasInfo.width / atlasInfo.height), 120)
+      local width = atlasInfo.width
+      local height = atlasInfo.height
+      if IsStopMotion then
+        local flipbookInfo = OptionsPrivate.GetFlipbookTileSize(texturePath)
+        if flipbookInfo then
+          width = flipbookInfo.tileWidth
+          height = flipbookInfo.tileHeight
+        end
+      end
+      if width > height then
+        self.texture:SetSize(120, 120 * (height / width))
+      elseif height > width then
+        self.texture:SetSize(120 * (width / height), 120)
       else
         self.texture:SetSize(120, 120)
       end

--- a/WeakAurasOptions/OptionsFrames/TexturePicker.lua
+++ b/WeakAurasOptions/OptionsFrames/TexturePicker.lua
@@ -234,7 +234,7 @@ local function ConstructTexturePicker(frame)
         pickedwidget = widget;
       end
     end
-    local width, height
+    local width, height, flipbookInfo
     if(pickedwidget) then
       pickedwidget:Pick();
       if not pickedwidget.texture.IsStopMotion then
@@ -242,6 +242,12 @@ local function ConstructTexturePicker(frame)
         if atlasInfo then
           width = atlasInfo.width
           height = atlasInfo.height
+        end
+      else
+        flipbookInfo = OptionsPrivate.GetFlipbookTileSize(pickedwidget.texture.path)
+        if flipbookInfo then
+          width = flipbookInfo.tileWidth
+          height = flipbookInfo.tileHeight
         end
       end
     end

--- a/WeakAurasOptions/RegionOptions/StopMotion.lua
+++ b/WeakAurasOptions/RegionOptions/StopMotion.lua
@@ -130,7 +130,7 @@ local function createOptions(id, data)
                   color = "foregroundColor",
                   mirror = "mirror",
                   blendMode = "blendMode"
-                }, texture_types, setTextureFunc);
+                }, texture_types, setTextureFunc, true);
             end,
             imageWidth = 24,
             imageHeight = 24,
@@ -383,7 +383,7 @@ local function createOptions(id, data)
                   color = "backgroundColor",
                   mirror = "mirror",
                   blendMode = "blendMode"
-                }, texture_types, setTextureFunc);
+                }, texture_types, setTextureFunc, true);
             end,
             disabled = function() return data.sameTexture or data.hideBackground; end,
             hidden = function() return data.hideBackground end,

--- a/WeakAurasOptions/RegionOptions/StopMotion.lua
+++ b/WeakAurasOptions/RegionOptions/StopMotion.lua
@@ -682,7 +682,7 @@ local function modifyThumbnail(parent, region, data, fullModify, size)
     local texture = data.foregroundTexture or "Interface\\AddOns\\WeakAuras\\Media\\Textures\\stopmotion";
 
     if (region.foreground.rows and region.foreground.columns) then
-      region.texture:SetTexture(texture);
+      OptionsPrivate.Private.SetTextureOrAtlas(region.texture, texture)
       local frameScaleW, frameScaleH = 1, 1
       if region.foreground.fileWidth and region.foreground.frameWidth
         and region.foreground.fileWidth > 0 and region.foreground.frameWidth > 0

--- a/WeakAurasOptions/RegionOptions/StopMotion.lua
+++ b/WeakAurasOptions/RegionOptions/StopMotion.lua
@@ -6,6 +6,17 @@ local texture_data = WeakAuras.StopMotion.texture_data;
 local animation_types = WeakAuras.StopMotion.animation_types;
 local setTile = WeakAuras.setTile
 
+-- Returns value only for Blizzard flipbooks
+function OptionsPrivate.GetFlipbookTileSize(name)
+  if texture_data[name] then
+    if texture_data[name].isBlizzardFlipbook then
+      if texture_data[name].tileWidth and texture_data[name].tileHeight then
+        return {["tileWidth"] = texture_data[name].tileWidth, ["tileHeight"] = texture_data[name].tileHeight}
+      end
+    end
+  end
+end
+
 local function setTextureFunc(textureWidget, texturePath, textureName)
   local data = texture_data[texturePath];
   if not(data) then


### PR DESCRIPTION
# Description

Includes the following changes:

- Add new flipbooks and fix some others where the data was incorrect
- Make the flipbook display proportional in the texture picker
- Set region size to match the flipbook tile size when selecting a texture
- Fix StopMotion thumbnail

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)