### PR TITLE
Currency trigger: don't specify test on value block

### DIFF
--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -10270,7 +10270,6 @@ Private.event_prototypes = {
         type = "number",
         display = L["Quantity"],
         store = true,
-        test = "true",
         conditionType = "number",
       },
       {


### PR DESCRIPTION
Bugfix