### PR TITLE
Fix texture search in the texture picker

### DIFF
--- a/WeakAurasOptions/OptionsFrames/TexturePicker.lua
+++ b/WeakAurasOptions/OptionsFrames/TexturePicker.lua
@@ -160,7 +160,7 @@ local function ConstructTexturePicker(frame)
       filter = filter:lower()
     end
     for texturePath, textureName in pairs(group.textures[uniquevalue]) do
-      if filter == nil or filter == "" or textureName:lower():match(filter) then
+      if filter == nil or filter == "" or textureName:lower():find(filter, 1, true) then
         tinsert(group.selectedGroupSorted, {texturePath, textureName})
       end
     end


### PR DESCRIPTION
# Description
It fixes texture search in the texture picker.

Many atlas names may contain characters that have special meaning when used in patterns. For example, `!Barbershop-MiddleTile`. If you type `shop-M` into the search field, nothing will show up in the texture picker. Therefore, it's better to use the find function with pattern matching disabled


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)