### PR TITLE
Add dynamic information last active trigger

### DIFF
--- a/WeakAuras/Types.lua
+++ b/WeakAuras/Types.lua
@@ -852,6 +852,7 @@ Private.trigger_require_types_one = {
 
 Private.trigger_modes = {
   ["first_active"] = -10,
+  ["last_active"] = -5,
 }
 
 Private.debuff_types = {

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -4509,6 +4509,15 @@ function Private.UpdatedTriggerState(id)
       end
     end
   end
+  if (newActiveTrigger == Private.trigger_modes.last_active) then
+    -- Mode is last active trigger, so find a active trigger
+    for i = triggerState[id].numTriggers, 1, -1 do
+      if (triggerState[id].triggers[i]) then
+        newActiveTrigger = i;
+        break;
+      end
+    end
+  end
 
   local oldShow = triggerState[id].show;
   triggerState[id].activeTrigger = newActiveTrigger;

--- a/WeakAurasOptions/TriggerOptions.lua
+++ b/WeakAurasOptions/TriggerOptions.lua
@@ -65,6 +65,7 @@ local function GetGlobalOptions(data)
       values = function()
         local vals = {};
         vals[OptionsPrivate.Private.trigger_modes.first_active] = L["Dynamic information from first active trigger"];
+        vals[OptionsPrivate.Private.trigger_modes.last_active] = L["Dynamic information from last active trigger"];
         for i = 1, #data.triggers do
           vals[i] = L["Dynamic information from Trigger %i"]:format(i);
         end


### PR DESCRIPTION
# Description

I've added the option to get dynamic information from the last active trigger.
This helps to mantain always the same order when using multiple triggers and makes editing group conditions much easier.

Thanks for your amaizing work.

## Type of change

- [x] New feature (non-breaking change which adds functionality)