### PR TITLE
Player Location: Parent Zone support

### DIFF
--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -164,7 +164,7 @@ end
 local function get_zoneId_list()
   local currentmap_id = C_Map.GetBestMapForUnit("player")
   local instanceId = select(8, GetInstanceInfo())
-  local bottomText = L["Supports multiple entries, separated by commas. Group Zone IDs must be prefixed with 'g', e.g. g277. Supports Area IDs from https://wago.tools/db2/AreaTable prefixed with 'a'. Supports Instance IDs prefixed with 'i'."]
+  local bottomText = L["Supports multiple entries, separated by commas. \nGroup Zone IDs must be prefixed with 'g', e.g. g277. \nParent Zone IDs must be prefixed with 'p'. \nSupports Area IDs from https://wago.tools/db2/AreaTable prefixed with 'a'. \nSupports Instance IDs prefixed with 'i'."]
   if not instanceId and not currentmap_id then
     return ("%s\n\n%s"):format(Private.get_zoneId_list(), bottomText)
   elseif not currentmap_id then
@@ -173,6 +173,7 @@ local function get_zoneId_list()
   local currentmap_info = C_Map.GetMapInfo(currentmap_id)
   local currentmap_name = currentmap_info and currentmap_info.name or ""
   local currentmap_zone_name = ""
+  local parentmap_zone_name = ""
   local mapGroupId = C_Map.GetMapGroupID(currentmap_id)
   if mapGroupId then
     currentmap_zone_name = string.format("|cffffd200%s|r\n%s: g%d\n\n",
@@ -186,12 +187,19 @@ local function get_zoneId_list()
       end
     end
   end
+  if currentmap_info and currentmap_info.parentMapID > 0  then
+    local parentmap_info = C_Map.GetMapInfo(currentmap_info.parentMapID)
+    local parentmap_name = parentmap_info and parentmap_info.name or ""
+    parentmap_zone_name = string.format("|cffffd200%s|r\n%s: p%d\n\n",
+                                         L["Parent Zone"], parentmap_name, currentmap_info.parentMapID)
+  end
 
-  return ("%s|cffffd200%s|r\n%s: %d\n\n%s|cffffd200%s|r\n%s: %d\n\n%s"):format(
+  return ("%s|cffffd200%s|r\n%s: %d\n\n%s%s|cffffd200%s|r\n%s: %d\n\n%s"):format(
     Private.get_zoneId_list(),
     L["Current Zone"],
     currentmap_name,
     currentmap_id,
+    parentmap_zone_name,
     currentmap_zone_name,
     L["Current Instance"],
     L["Instance Id"],

--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -164,7 +164,7 @@ end
 local function get_zoneId_list()
   local currentmap_id = C_Map.GetBestMapForUnit("player")
   local instanceId = select(8, GetInstanceInfo())
-  local bottomText = L["Supports multiple entries, separated by commas. \nGroup Zone IDs must be prefixed with 'g', e.g. g277. \nParent Zone IDs must be prefixed with 'p'. \nSupports Area IDs from https://wago.tools/db2/AreaTable prefixed with 'a'. \nSupports Instance IDs prefixed with 'i'."]
+  local bottomText = L["Supports multiple entries, separated by commas. To include child zone ids, prefix with 'c', e.g. 'c2022'.\nGroup Zone IDs must be prefixed with 'g', e.g. 'g277'. \nSupports Area IDs from https://wago.tools/db2/AreaTable prefixed with 'a'. \nSupports Instance IDs prefixed with 'i'."]
   if not instanceId and not currentmap_id then
     return ("%s\n\n%s"):format(Private.get_zoneId_list(), bottomText)
   elseif not currentmap_id then
@@ -190,7 +190,7 @@ local function get_zoneId_list()
   if currentmap_info and currentmap_info.parentMapID > 0  then
     local parentmap_info = C_Map.GetMapInfo(currentmap_info.parentMapID)
     local parentmap_name = parentmap_info and parentmap_info.name or ""
-    parentmap_zone_name = string.format("|cffffd200%s|r\n%s: p%d\n\n",
+    parentmap_zone_name = string.format("|cffffd200%s|r\n%s: c%d\n\n",
                                          L["Parent Zone"], parentmap_name, currentmap_info.parentMapID)
   end
 

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -5953,6 +5953,12 @@ function Private.ExecEnv.ParseZoneCheck(input)
         local prevChar = input:sub(start - 1, start - 1)
         if prevChar == 'g' or prevChar == 'G' then
           self.zoneGroupIds[id] = true
+        elseif prevChar == 'p' or prevChar == 'P' then
+          self.zoneIds[id] = true
+          local info = C_Map.GetMapChildrenInfo(id, nil, true)
+          for _,childInfo in pairs(info) do
+             self.zoneIds[childInfo.mapID] = true
+          end
         elseif prevChar == 'a' or prevChar == 'A' then
           self.areaNames[C_Map.GetAreaInfo(id)] = true
         elseif prevChar == 'i' or prevChar == 'I' then

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -5953,7 +5953,7 @@ function Private.ExecEnv.ParseZoneCheck(input)
         local prevChar = input:sub(start - 1, start - 1)
         if prevChar == 'g' or prevChar == 'G' then
           self.zoneGroupIds[id] = true
-        elseif prevChar == 'p' or prevChar == 'P' then
+        elseif prevChar == 'c' or prevChar == 'C' then
           self.zoneIds[id] = true
           local info = C_Map.GetMapChildrenInfo(id, nil, true)
           for _,childInfo in pairs(info) do


### PR DESCRIPTION
# Description

Adds support for Parent Zone IDs in the Player Location load option.
Parent Zone IDs must be prefixed with 'p'.
E.g. if you want it to load in all child maps of "Dragon Isles" : 'p1978'.

The child maps are gathered recursively meaning it would also load in childs of childs of childs.
E.g. 'p1978' makes it load in Dragon Isles > Thaldraszus > Valdrakken.

The Parent Zone is added to the tooltip, and I've added newlines to the bottomText for better readability.

![image](https://github.com/WeakAuras/WeakAuras2/assets/6916881/6462141e-18b7-43c8-bb2a-62bfe323ec97)
