### PR TITLE
Add DBM_TimerUpdateIcon event listener

### DIFF
--- a/WeakAuras/BossMods.lua
+++ b/WeakAuras/BossMods.lua
@@ -296,7 +296,10 @@ Private.ExecEnv.BossMods.DBM = {
       if bar then
         bar.icon = icon
       end
-      WeakAuras.ScanEvents("DBM_TimerUpdateIcon")
+      WeakAuras.ScanEvents("DBM_TimerUpdateIcon", timerId)
+      if self.isGeneric then
+        WeakAuras.ScanEvents("BossMod_TimerUpdateIcon", timerId)
+      end
     elseif event == "DBM_SetStage" or event == "DBM_Pull" or event == "DBM_Wipe" or event == "DBM_Kill" then
       WeakAuras.ScanEvents("DBM_SetStage")
       if self.isGeneric then
@@ -449,7 +452,8 @@ Private.event_prototypes["DBM Timer"] = {
   type = "addons",
   events = {},
   internal_events = {
-    "DBM_TimerStart", "DBM_TimerStop", "DBM_TimerUpdate", "DBM_TimerForce", "DBM_TimerResume", "DBM_TimerPause"
+    "DBM_TimerStart", "DBM_TimerStop", "DBM_TimerUpdate", "DBM_TimerForce", "DBM_TimerResume", "DBM_TimerPause",
+    "DBM_TimerUpdateIcon"
   },
   force_events = "DBM_TimerForce",
   name = L["DBM Timer"],
@@ -536,7 +540,7 @@ Private.event_prototypes["DBM Timer"] = {
               state.changed = true
               return true
             end
-          elseif event == "DBM_TimerUpdate" then
+          elseif event == "DBM_TimerUpdate" or event == "DBM_TimerUpdateIcon" then
             local changed
             for timerId, bar in pairs(Private.ExecEnv.BossMods.DBM:GetAllTimers()) do
               if Private.ExecEnv.BossMods.DBM:TimerMatches(timerId, triggerText, triggerTextOperator, triggerSpellId, counter, triggerId, triggerDbmType) then
@@ -1480,7 +1484,8 @@ Private.event_prototypes["Boss Mod Timer"] = {
   type = "addons",
   events = {},
   internal_events = {
-    "BossMod_TimerStart", "BossMod_TimerStop", "BossMod_TimerUpdate", "BossMod_TimerForce", "BossMod_TimerResume", "BossMod_TimerPause"
+    "BossMod_TimerStart", "BossMod_TimerStop", "BossMod_TimerUpdate", "BossMod_TimerForce", "BossMod_TimerResume",
+    "BossMod_TimerPause", "BossMod_TimerUpdateIcon"
   },
   force_events = "BossMod_TimerForce",
   name = L["Boss Mod Timer"],
@@ -1568,7 +1573,7 @@ Private.event_prototypes["Boss Mod Timer"] = {
               state.changed = true
               return true
             end
-          elseif event == "BossMod_TimerUpdate" then
+          elseif event == "BossMod_TimerUpdate" or event == "BossMod_TimerUpdateIcon" then
             local changed
             for timerId, bar in pairs(Private.ExecEnv.BossMods.Generic:GetAllTimers()) do
               if Private.ExecEnv.BossMods.Generic:TimerMatchesGeneric(timerId, triggerText, triggerTextOperator, triggerSpellId, counter) then

--- a/WeakAuras/BossMods.lua
+++ b/WeakAuras/BossMods.lua
@@ -296,6 +296,7 @@ Private.ExecEnv.BossMods.DBM = {
       if bar then
         bar.icon = icon
       end
+      WeakAuras.ScanEvents("DBM_TimerUpdateIcon")
     elseif event == "DBM_SetStage" or event == "DBM_Pull" or event == "DBM_Wipe" or event == "DBM_Kill" then
       WeakAuras.ScanEvents("DBM_SetStage")
       if self.isGeneric then

--- a/WeakAuras/BossMods.lua
+++ b/WeakAuras/BossMods.lua
@@ -290,6 +290,12 @@ Private.ExecEnv.BossMods.DBM = {
       if self.isGeneric then
         WeakAuras.ScanEvents("BossMod_TimerUpdate", timerId)
       end
+    elseif event == "DBM_TimerUpdateIcon" then
+      local timerId, icon = ...
+      local bar = self.bars[timerId]
+      if bar then
+        bar.icon = icon
+      end
     elseif event == "DBM_SetStage" or event == "DBM_Pull" or event == "DBM_Wipe" or event == "DBM_Kill" then
       WeakAuras.ScanEvents("DBM_SetStage")
       if self.isGeneric then
@@ -314,6 +320,7 @@ Private.ExecEnv.BossMods.DBM = {
     self:RegisterCallback("DBM_TimerPause")
     self:RegisterCallback("DBM_TimerResume")
     self:RegisterCallback("DBM_TimerUpdate")
+    self:RegisterCallback("DBM_TimerUpdateIcon")
   end,
 
   RegisterMessage = function(self)


### PR DESCRIPTION
# Description

DBM timers can call `:UpdateIcon` which will replace the default icon state from when a timer is started. This fires the `DBM_TimerUpdateIcon` event, and any WeakAuras that have listened to what the icon is should update the icon to reflect these changes.
The `DBM_TimerUpdateIcon` is newly implemented in <https://github.com/DeadlyBossMods/DeadlyBossMods/commit/5e75945aa704cf157d9e4ad198610cce26fee8c9>

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Tested DBM icon updating

## Checklist
<!-- These can be checked off after the pull request is submitted, in case you want discussion before they are completely ready -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

<!-- Is there any additional work that needs to be done? If so, add it to the above list -->
