### PR TITLE
Add GitHub Actions workflows for Release Notifications

### DIFF
--- a/.github/scripts/generate_twitter_post.py
+++ b/.github/scripts/generate_twitter_post.py
@@ -8,7 +8,7 @@ from pathlib import Path
 WEAKAURAS_URL_RELEASE_URL = "https://github.com/WeakAuras/WeakAuras2/releases/tag/{tag}"
 MAX_POST_LENGTH = 280
 
-POST_TEMPLATE = """New Release: {tag}
+POST_TEMPLATE = """New Release published: {tag}
 {highlight_content}
 {url}
 """
@@ -39,7 +39,7 @@ def get_changelog_text(changelog_file):
         print('Could not find "Highlights" content.')
         print(content)
         print("=======================================")
-        print("Going to provide an empty content")
+        print("Going to provide an empty content.")
         return ""
 
     return match.group(1).strip()
@@ -85,10 +85,9 @@ def write_post_to_file(post):
         twitter_post.write(post)
 
 
-#### START #####
 parser = argparse.ArgumentParser(
     prog="generate_twitter_post",
-    description="Reads a changelog file and generates a post suitible for social media sites",
+    description="Reads a changelog file and generates a post suitable for social media sites",
 )
 parser.add_argument(
     "-c",
@@ -96,7 +95,7 @@ parser.add_argument(
     dest="changelog_path",
     action="store",
     default="./CHANGELOG.md",
-    help="specifiys where the changelog file is",
+    help="specifies where the changelog file is",
     required=False,
     type=str,
 )

--- a/.github/scripts/generate_twitter_post.py
+++ b/.github/scripts/generate_twitter_post.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+
+import argparse
+import re
+import subprocess
+from pathlib import Path
+
+WEAKAURAS_URL_RELEASE_URL = "https://github.com/WeakAuras/WeakAuras2/releases/tag/{tag}"
+MAX_POST_LENGTH = 280
+
+POST_TEMPLATE = """New Release: {tag}
+{highlight_content}
+{url}
+"""
+
+
+def get_empty_post_length():
+    tag = get_latest_tag()
+    release_url = WEAKAURAS_URL_RELEASE_URL.format(tag=tag)
+    post = POST_TEMPLATE.format(tag=tag, highlight_content="", url=release_url)
+    return len(post)
+
+
+def run_shell_command(cmd, shell=True, timeout=600, capture_output=False):
+    return subprocess.run(
+        cmd, shell=shell, timeout=timeout, capture_output=capture_output
+    )
+
+
+def get_changelog_text(changelog_file):
+    with open(changelog_file, mode="r") as file:
+        content = file.read()
+
+    regex = r"(?<=## Highlights)(.*)(?=## Commits)"
+    match = re.search(regex, content, re.DOTALL)
+
+    if not match:
+        print("=======================================")
+        print('Could not find "Highlights" content.')
+        print(content)
+        print("=======================================")
+        print("Going to provide an empty content")
+        return ""
+
+    return match.group(1).strip()
+
+
+def shorten_highlight_content(highlight_content):
+    base_length = get_empty_post_length()
+
+    # MAX_POST_LENGTH - base_length = max highlight text length
+    max_content_length = MAX_POST_LENGTH - base_length
+
+    if len(highlight_content) > max_content_length:
+        # We only have 280 characters to play with, so lets reserve {max_content_length} for our own use, then use the rest for the highlight message.
+        shortend_content = highlight_content[:max_content_length]
+        # this will remove the last 'line', mainly to remove anything that got cut off in the middle and give us more character space.
+        shortend_content = shortend_content.split("\n\n")[:-1]
+        highlight_content = "\n\n".join(shortend_content)
+
+    return highlight_content
+
+
+def get_latest_tag():
+    return (
+        run_shell_command(
+            "git describe --tags --always --abbrev=0", capture_output=True
+        )
+        .stdout.decode()
+        .strip()
+    )
+
+
+def generate_twitter_post(content):
+    print("generating post")
+    tag = get_latest_tag()
+    release_url = WEAKAURAS_URL_RELEASE_URL.format(tag=tag)
+    post = POST_TEMPLATE.format(tag=tag, highlight_content=content, url=release_url)
+    return post
+
+
+def write_post_to_file(post):
+    print("writing post to file")
+    with open("twitter_post.txt", mode="w") as twitter_post:
+        twitter_post.write(post)
+
+
+#### START #####
+parser = argparse.ArgumentParser(
+    prog="generate_twitter_post",
+    description="Reads a changelog file and generates a post suitible for social media sites",
+)
+parser.add_argument(
+    "-c",
+    "--changelog",
+    dest="changelog_path",
+    action="store",
+    default="./CHANGELOG.md",
+    help="specifiys where the changelog file is",
+    required=False,
+    type=str,
+)
+args = parser.parse_args()
+print(args)
+
+
+changelog = Path(args.changelog_path)
+if not changelog.exists():
+    print("No Changelog found..")
+    exit(1)
+
+
+highlight_content = get_changelog_text(changelog)
+highlight_content = shorten_highlight_content(highlight_content)
+latest_tag = get_latest_tag()
+post = generate_twitter_post(highlight_content)
+write_post_to_file(post)

--- a/.github/scripts/test_files/large_changelog_example.md
+++ b/.github/scripts/test_files/large_changelog_example.md
@@ -1,0 +1,430 @@
+# [5.15.0](https://github.com/WeakAuras/WeakAuras2/tree/5.15.0) (2024-03-23)
+
+[Full Changelog](https://github.com/WeakAuras/WeakAuras2/compare/5.11.2...5.15.0)
+
+## Highlights
+
+ Fix Relative Progress Animations not running in certain cases
+
+Relative Progress Animations rely on the region having information on
+the progress, which is set by UpdateProgress.
+
+Thus we need to call UpdateProgress in all cases.
+
+Fixes: #4936
+
+Relative Progress Animations rely on the region having information on
+the progress, which is set by UpdateProgress.
+
+Thus we need to call UpdateProgress in all cases.
+
+Fixes: #4936
+
+Relative Progress Animations rely on the region having information on
+the progress, which is set by UpdateProgress.
+
+Thus we need to call UpdateProgress in all cases.
+
+Fixes: #4936
+
+Relative Progress Animations rely on the region having information on
+the progress, which is set by UpdateProgress.
+
+Thus we need to call UpdateProgress in all cases.
+
+Fixes: #4936
+
+Relative Progress Animations rely on the region having information on
+the progress, which is set by UpdateProgress.
+
+Thus we need to call UpdateProgress in all cases.
+
+Fixes: #4936
+
+Relative Progress Animations rely on the region having information on
+the progress, which is set by UpdateProgress.
+
+Thus we need to call UpdateProgress in all cases.
+
+Fixes: #4936
+
+
+## Commits
+
+InfusOnWoW (17):
+
+- Fix Relative Progress Animations not running in certain cases
+- Fix border of dynamic groups with animated position childd auras
+- AutoHide: Automatically set expirationTime
+- Fix ordering of region creation
+- Cast Trigger: Fix inverse setting autoHide
+- Item Cooldowns: Adjust to changed retail api
+- For tracking a specific charge, don't use static progress
+- ProgressTexture: Fix switching from timed to static progress
+- Change EnsureRegion to not create child regions for dynamic groups
+- Progress Source: Ignore max progress setting for no duration timers
+- Icon: Fix inverse not probably being effective
+- Make Time Formatter format (Elapsed) Timers
+- Modernize before validate, but wrap Modernize in xpcall
+- Ticks: Add texture chaning conditions (both use and texture path)
+- Refactor progress handling
+- Spinbox: Remove mouse wheel support
+- Update Atlas File List from wago.tools
+- Fix Relative Progress Animations not running in certain cases
+- Fix border of dynamic groups with animated position childd auras
+- AutoHide: Automatically set expirationTime
+- Fix ordering of region creation
+- Cast Trigger: Fix inverse setting autoHide
+- Item Cooldowns: Adjust to changed retail api
+- For tracking a specific charge, don't use static progress
+- ProgressTexture: Fix switching from timed to static progress
+- Change EnsureRegion to not create child regions for dynamic groups
+- Progress Source: Ignore max progress setting for no duration timers
+- Icon: Fix inverse not probably being effective
+- Make Time Formatter format (Elapsed) Timers
+- Modernize before validate, but wrap Modernize in xpcall
+- Ticks: Add texture chaning conditions (both use and texture path)
+- Refactor progress handling
+- Spinbox: Remove mouse wheel support
+- Update Atlas File List from wago.tools
+- Fix Relative Progress Animations not running in certain cases
+- Fix border of dynamic groups with animated position childd auras
+- AutoHide: Automatically set expirationTime
+- Fix ordering of region creation
+- Cast Trigger: Fix inverse setting autoHide
+- Item Cooldowns: Adjust to changed retail api
+- For tracking a specific charge, don't use static progress
+- ProgressTexture: Fix switching from timed to static progress
+- Change EnsureRegion to not create child regions for dynamic groups
+- Progress Source: Ignore max progress setting for no duration timers
+- Icon: Fix inverse not probably being effective
+- Make Time Formatter format (Elapsed) Timers
+- Modernize before validate, but wrap Modernize in xpcall
+- Ticks: Add texture chaning conditions (both use and texture path)
+- Refactor progress handling
+- Spinbox: Remove mouse wheel support
+- Update Atlas File List from wago.tools
+- Fix Relative Progress Animations not running in certain cases
+- Fix border of dynamic groups with animated position childd auras
+- AutoHide: Automatically set expirationTime
+- Fix ordering of region creation
+- Cast Trigger: Fix inverse setting autoHide
+- Item Cooldowns: Adjust to changed retail api
+- For tracking a specific charge, don't use static progress
+- ProgressTexture: Fix switching from timed to static progress
+- Change EnsureRegion to not create child regions for dynamic groups
+- Progress Source: Ignore max progress setting for no duration timers
+- Icon: Fix inverse not probably being effective
+- Make Time Formatter format (Elapsed) Timers
+- Modernize before validate, but wrap Modernize in xpcall
+- Ticks: Add texture chaning conditions (both use and texture path)
+- Refactor progress handling
+- Spinbox: Remove mouse wheel support
+- Update Atlas File List from wago.tools
+- Fix Relative Progress Animations not running in certain cases
+- Fix border of dynamic groups with animated position childd auras
+- AutoHide: Automatically set expirationTime
+- Fix ordering of region creation
+- Cast Trigger: Fix inverse setting autoHide
+- Item Cooldowns: Adjust to changed retail api
+- For tracking a specific charge, don't use static progress
+- ProgressTexture: Fix switching from timed to static progress
+- Change EnsureRegion to not create child regions for dynamic groups
+- Progress Source: Ignore max progress setting for no duration timers
+- Icon: Fix inverse not probably being effective
+- Make Time Formatter format (Elapsed) Timers
+- Modernize before validate, but wrap Modernize in xpcall
+- Ticks: Add texture chaning conditions (both use and texture path)
+- Refactor progress handling
+- Spinbox: Remove mouse wheel support
+- Update Atlas File List from wago.tools
+- Fix Relative Progress Animations not running in certain cases
+- Fix border of dynamic groups with animated position childd auras
+- AutoHide: Automatically set expirationTime
+- Fix ordering of region creation
+- Cast Trigger: Fix inverse setting autoHide
+- Item Cooldowns: Adjust to changed retail api
+- For tracking a specific charge, don't use static progress
+- ProgressTexture: Fix switching from timed to static progress
+- Change EnsureRegion to not create child regions for dynamic groups
+- Progress Source: Ignore max progress setting for no duration timers
+- Icon: Fix inverse not probably being effective
+- Make Time Formatter format (Elapsed) Timers
+- Modernize before validate, but wrap Modernize in xpcall
+- Ticks: Add texture chaning conditions (both use and texture path)
+- Refactor progress handling
+- Spinbox: Remove mouse wheel support
+- Update Atlas File List from wago.tools
+- Fix Relative Progress Animations not running in certain cases
+- Fix border of dynamic groups with animated position childd auras
+- AutoHide: Automatically set expirationTime
+- Fix ordering of region creation
+- Cast Trigger: Fix inverse setting autoHide
+- Item Cooldowns: Adjust to changed retail api
+- For tracking a specific charge, don't use static progress
+- ProgressTexture: Fix switching from timed to static progress
+- Change EnsureRegion to not create child regions for dynamic groups
+- Progress Source: Ignore max progress setting for no duration timers
+- Icon: Fix inverse not probably being effective
+- Make Time Formatter format (Elapsed) Timers
+- Modernize before validate, but wrap Modernize in xpcall
+- Ticks: Add texture chaning conditions (both use and texture path)
+- Refactor progress handling
+- Spinbox: Remove mouse wheel support
+- Update Atlas File List from wago.tools
+- Fix Relative Progress Animations not running in certain cases
+- Fix border of dynamic groups with animated position childd auras
+- AutoHide: Automatically set expirationTime
+- Fix ordering of region creation
+- Cast Trigger: Fix inverse setting autoHide
+- Item Cooldowns: Adjust to changed retail api
+- For tracking a specific charge, don't use static progress
+- ProgressTexture: Fix switching from timed to static progress
+- Change EnsureRegion to not create child regions for dynamic groups
+- Progress Source: Ignore max progress setting for no duration timers
+- Icon: Fix inverse not probably being effective
+- Make Time Formatter format (Elapsed) Timers
+- Modernize before validate, but wrap Modernize in xpcall
+- Ticks: Add texture chaning conditions (both use and texture path)
+- Refactor progress handling
+- Spinbox: Remove mouse wheel support
+- Update Atlas File List from wago.tools
+- Fix Relative Progress Animations not running in certain cases
+- Fix border of dynamic groups with animated position childd auras
+- AutoHide: Automatically set expirationTime
+- Fix ordering of region creation
+- Cast Trigger: Fix inverse setting autoHide
+- Item Cooldowns: Adjust to changed retail api
+- For tracking a specific charge, don't use static progress
+- ProgressTexture: Fix switching from timed to static progress
+- Change EnsureRegion to not create child regions for dynamic groups
+- Progress Source: Ignore max progress setting for no duration timers
+- Icon: Fix inverse not probably being effective
+- Make Time Formatter format (Elapsed) Timers
+- Modernize before validate, but wrap Modernize in xpcall
+- Ticks: Add texture chaning conditions (both use and texture path)
+- Refactor progress handling
+- Spinbox: Remove mouse wheel support
+- Update Atlas File List from wago.tools
+- Fix Relative Progress Animations not running in certain cases
+- Fix border of dynamic groups with animated position childd auras
+- AutoHide: Automatically set expirationTime
+- Fix ordering of region creation
+- Cast Trigger: Fix inverse setting autoHide
+- Item Cooldowns: Adjust to changed retail api
+- For tracking a specific charge, don't use static progress
+- ProgressTexture: Fix switching from timed to static progress
+- Change EnsureRegion to not create child regions for dynamic groups
+- Progress Source: Ignore max progress setting for no duration timers
+- Icon: Fix inverse not probably being effective
+- Make Time Formatter format (Elapsed) Timers
+- Modernize before validate, but wrap Modernize in xpcall
+- Ticks: Add texture chaning conditions (both use and texture path)
+- Refactor progress handling
+- Spinbox: Remove mouse wheel support
+- Update Atlas File List from wago.tools
+- Fix Relative Progress Animations not running in certain cases
+- Fix border of dynamic groups with animated position childd auras
+- AutoHide: Automatically set expirationTime
+- Fix ordering of region creation
+- Cast Trigger: Fix inverse setting autoHide
+- Item Cooldowns: Adjust to changed retail api
+- For tracking a specific charge, don't use static progress
+- ProgressTexture: Fix switching from timed to static progress
+- Change EnsureRegion to not create child regions for dynamic groups
+- Progress Source: Ignore max progress setting for no duration timers
+- Icon: Fix inverse not probably being effective
+- Make Time Formatter format (Elapsed) Timers
+- Modernize before validate, but wrap Modernize in xpcall
+- Ticks: Add texture chaning conditions (both use and texture path)
+- Refactor progress handling
+- Spinbox: Remove mouse wheel support
+- Update Atlas File List from wago.tools
+- Fix Relative Progress Animations not running in certain cases
+- Fix border of dynamic groups with animated position childd auras
+- AutoHide: Automatically set expirationTime
+- Fix ordering of region creation
+- Cast Trigger: Fix inverse setting autoHide
+- Item Cooldowns: Adjust to changed retail api
+- For tracking a specific charge, don't use static progress
+- ProgressTexture: Fix switching from timed to static progress
+- Change EnsureRegion to not create child regions for dynamic groups
+- Progress Source: Ignore max progress setting for no duration timers
+- Icon: Fix inverse not probably being effective
+- Make Time Formatter format (Elapsed) Timers
+- Modernize before validate, but wrap Modernize in xpcall
+- Ticks: Add texture chaning conditions (both use and texture path)
+- Refactor progress handling
+- Spinbox: Remove mouse wheel support
+- Update Atlas File List from wago.tools
+- Fix Relative Progress Animations not running in certain cases
+- Fix border of dynamic groups with animated position childd auras
+- AutoHide: Automatically set expirationTime
+- Fix ordering of region creation
+- Cast Trigger: Fix inverse setting autoHide
+- Item Cooldowns: Adjust to changed retail api
+- For tracking a specific charge, don't use static progress
+- ProgressTexture: Fix switching from timed to static progress
+- Change EnsureRegion to not create child regions for dynamic groups
+- Progress Source: Ignore max progress setting for no duration timers
+- Icon: Fix inverse not probably being effective
+- Make Time Formatter format (Elapsed) Timers
+- Modernize before validate, but wrap Modernize in xpcall
+- Ticks: Add texture chaning conditions (both use and texture path)
+- Refactor progress handling
+- Spinbox: Remove mouse wheel support
+- Update Atlas File List from wago.tools
+- Fix Relative Progress Animations not running in certain cases
+- Fix border of dynamic groups with animated position childd auras
+- AutoHide: Automatically set expirationTime
+- Fix ordering of region creation
+- Cast Trigger: Fix inverse setting autoHide
+- Item Cooldowns: Adjust to changed retail api
+- For tracking a specific charge, don't use static progress
+- ProgressTexture: Fix switching from timed to static progress
+- Change EnsureRegion to not create child regions for dynamic groups
+- Progress Source: Ignore max progress setting for no duration timers
+- Icon: Fix inverse not probably being effective
+- Make Time Formatter format (Elapsed) Timers
+- Modernize before validate, but wrap Modernize in xpcall
+- Ticks: Add texture chaning conditions (both use and texture path)
+- Refactor progress handling
+- Spinbox: Remove mouse wheel support
+- Update Atlas File List from wago.tools
+- Fix Relative Progress Animations not running in certain cases
+- Fix border of dynamic groups with animated position childd auras
+- AutoHide: Automatically set expirationTime
+- Fix ordering of region creation
+- Cast Trigger: Fix inverse setting autoHide
+- Item Cooldowns: Adjust to changed retail api
+- For tracking a specific charge, don't use static progress
+- ProgressTexture: Fix switching from timed to static progress
+- Change EnsureRegion to not create child regions for dynamic groups
+- Progress Source: Ignore max progress setting for no duration timers
+- Icon: Fix inverse not probably being effective
+- Make Time Formatter format (Elapsed) Timers
+- Modernize before validate, but wrap Modernize in xpcall
+- Ticks: Add texture chaning conditions (both use and texture path)
+- Refactor progress handling
+- Spinbox: Remove mouse wheel support
+- Update Atlas File List from wago.tools
+- Fix Relative Progress Animations not running in certain cases
+- Fix border of dynamic groups with animated position childd auras
+- AutoHide: Automatically set expirationTime
+- Fix ordering of region creation
+- Cast Trigger: Fix inverse setting autoHide
+- Item Cooldowns: Adjust to changed retail api
+- For tracking a specific charge, don't use static progress
+- ProgressTexture: Fix switching from timed to static progress
+- Change EnsureRegion to not create child regions for dynamic groups
+- Progress Source: Ignore max progress setting for no duration timers
+- Icon: Fix inverse not probably being effective
+- Make Time Formatter format (Elapsed) Timers
+- Modernize before validate, but wrap Modernize in xpcall
+- Ticks: Add texture chaning conditions (both use and texture path)
+- Refactor progress handling
+- Spinbox: Remove mouse wheel support
+- Update Atlas File List from wago.tools
+- Fix Relative Progress Animations not running in certain cases
+- Fix border of dynamic groups with animated position childd auras
+- AutoHide: Automatically set expirationTime
+- Fix ordering of region creation
+- Cast Trigger: Fix inverse setting autoHide
+- Item Cooldowns: Adjust to changed retail api
+- For tracking a specific charge, don't use static progress
+- ProgressTexture: Fix switching from timed to static progress
+- Change EnsureRegion to not create child regions for dynamic groups
+- Progress Source: Ignore max progress setting for no duration timers
+- Icon: Fix inverse not probably being effective
+- Make Time Formatter format (Elapsed) Timers
+- Modernize before validate, but wrap Modernize in xpcall
+- Ticks: Add texture chaning conditions (both use and texture path)
+- Refactor progress handling
+- Spinbox: Remove mouse wheel support
+- Update Atlas File List from wago.tools
+- Fix Relative Progress Animations not running in certain cases
+- Fix border of dynamic groups with animated position childd auras
+- AutoHide: Automatically set expirationTime
+- Fix ordering of region creation
+- Cast Trigger: Fix inverse setting autoHide
+- Item Cooldowns: Adjust to changed retail api
+- For tracking a specific charge, don't use static progress
+- ProgressTexture: Fix switching from timed to static progress
+- Change EnsureRegion to not create child regions for dynamic groups
+- Progress Source: Ignore max progress setting for no duration timers
+- Icon: Fix inverse not probably being effective
+- Make Time Formatter format (Elapsed) Timers
+- Modernize before validate, but wrap Modernize in xpcall
+- Ticks: Add texture chaning conditions (both use and texture path)
+- Refactor progress handling
+- Spinbox: Remove mouse wheel support
+- Update Atlas File List from wago.tools
+v
+- Fix Relative Progress Animations not running in certain cases
+- Fix border of dynamic groups with animated position childd auras
+- AutoHide: Automatically set expirationTime
+- Fix ordering of region creation
+- Cast Trigger: Fix inverse setting autoHide
+- Item Cooldowns: Adjust to changed retail api
+- For tracking a specific charge, don't use static progress
+- ProgressTexture: Fix switching from timed to static progress
+- Change EnsureRegion to not create child regions for dynamic groups
+- Progress Source: Ignore max progress setting for no duration timers
+- Icon: Fix inverse not probably being effective
+- Make Time Formatter format (Elapsed) Timers
+- Modernize before validate, but wrap Modernize in xpcall
+- Ticks: Add texture chaning conditions (both use and texture path)
+- Refactor progress handling
+- Spinbox: Remove mouse wheel support
+- Update Atlas File List from wago.tools
+- Fix Relative Progress Animations not running in certain cases
+- Fix border of dynamic groups with animated position childd auras
+- AutoHide: Automatically set expirationTime
+- Fix ordering of region creation
+- Cast Trigger: Fix inverse setting autoHide
+- Item Cooldowns: Adjust to changed retail api
+- For tracking a specific charge, don't use static progress
+- ProgressTexture: Fix switching from timed to static progress
+- Change EnsureRegion to not create child regions for dynamic groups
+- Progress Source: Ignore max progress setting for no duration timers
+- Icon: Fix inverse not probably being effective
+- Make Time Formatter format (Elapsed) Timers
+- Modernize before validate, but wrap Modernize in xpcall
+- Ticks: Add texture chaning conditions (both use and texture path)
+- Refactor progress handling
+- Spinbox: Remove mouse wheel support
+- Update Atlas File List from wago.tools
+- Fix Relative Progress Animations not running in certain cases
+- Fix border of dynamic groups with animated position childd auras
+- AutoHide: Automatically set expirationTime
+- Fix ordering of region creation
+- Cast Trigger: Fix inverse setting autoHide
+- Item Cooldowns: Adjust to changed retail api
+- For tracking a specific charge, don't use static progress
+- ProgressTexture: Fix switching from timed to static progress
+- Change EnsureRegion to not create child regions for dynamic groups
+- Progress Source: Ignore max progress setting for no duration timers
+- Icon: Fix inverse not probably being effective
+- Make Time Formatter format (Elapsed) Timers
+- Modernize before validate, but wrap Modernize in xpcall
+- Ticks: Add texture chaning conditions (both use and texture path)
+- Refactor progress handling
+- Spinbox: Remove mouse wheel support
+- Update Atlas File List from wago.tools
+
+Stanzilla (2):
+
+- Update the Atlas script to fetch for `wow_classic_beta`
+- Cataclysm Beta compatibility
+
+emptyrivers (2):
+
+- add a missing yield
+- fix login deferral logic for AnchorFrame
+
+mrbuds (4):
+
+- Rework Profiling window (#4906)
+- make sure deferred group's custom anchors are actually anchored
+- update toc files for 10.2.6
+- Remove debug print in TestForLongString

--- a/.github/workflows/release_notifications.yml
+++ b/.github/workflows/release_notifications.yml
@@ -1,0 +1,130 @@
+# description of this workflow, can be anything you want
+name: Send Release Notification
+
+# we need to let GitHub know _when_ we want to release, typically only when we create a new tag.
+# this will target only tags, and not all pushes to the master branch.
+# this part can be heavily customized to your liking, like targeting only tags that match a certain word,
+# other branches or even pullrequests.
+# 'workflow_dispatch' allows us to re-run a failed job.
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+# a workflow is built up as jobs, and within these jobs are steps
+jobs:
+  ## We seperate each item into different 'jobs'.  The first job will get all the text that we need
+  ## the subsequent jobs will require the text from the first, and then send it to their approporate channels.
+  ## This allows us to reun-run specific social media sites seperately incase of errors.
+
+  release-notification-output:
+    # we can run our steps on pretty much anything, but the "ubuntu-latest" image is a safe bet
+    runs-on: ubuntu-latest
+
+    # output documentation: https://docs.github.com/en/actions/using-jobs/defining-outputs-for-jobs
+    outputs:
+      changeLogText: ${{ steps.readChanglog.outputs.text }}
+      tweetText: ${{ steps.readTweet.outputs.text }}
+
+    # "steps" holds a list of all the steps needed to package and release our AddOn
+    steps:
+      # we first have to clone the AddOn project, this is a required step
+      - name: Clone project
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # gets git history for changelogs
+
+      # run a custom changelog script in the root of the repo.
+      - name: Generate Changelog
+        id: Changelog
+        run: ./generate_changelog.sh
+
+      # save the output of the changelog into a variable.
+      - name: save changelog in variable
+        uses: pCYSl5EDgo/cat@master
+        id: readChanglog
+        with:
+          path: CHANGELOG.md
+
+      # generate the text for twitter or other social media
+      - name: Generate Twitter Text
+        id: twitter_post
+        run: /usr/bin/env python3 .github/scripts/generate_twitter_post.py
+
+      # save the generated information into a variable.
+      - name: save twitter post to variable
+        uses: pCYSl5EDgo/cat@master
+        id: readTweet
+        with:
+            path: twitter_post.txt
+
+############### DISCORD ####################
+  # "release-notification" is a job, you can name it anything you want
+  discord-release-notification:
+    # we can run our steps on pretty much anything, but the "ubuntu-latest" image is a safe bet
+    runs-on: ubuntu-latest
+    needs: release-notification-output
+
+    # specify the environment variables used by the packager, matching the secrets from the project on GitHub
+    env:
+      MESSAGE: "New WeakAuras Release"
+
+    # "steps" holds a list of all the steps needed to package and release our AddOn
+    steps:
+
+    # using Discord webhook to send release information
+      - name: Discord Release Webhook Action
+        uses: tsickert/discord-webhook@v5.4.0
+        if: success()
+        with:
+          webhook-url: ${{ secrets.RELEASE_WEBHOOK_URL }}
+          embed-title: ${{ env.MESSAGE }}
+          embed-url: https://github.com/WeakAuras/WeakAuras2/releases/latest
+          embed-description:  ${{needs.release-notification-output.outputs.changeLogText}}
+
+############### TWITTER ####################
+  twitter-release-notification:
+    # we can run our steps on pretty much anything, but the "ubuntu-latest" image is a safe bet
+    runs-on: ubuntu-latest
+    needs: release-notification-output
+
+    # "steps" holds a list of all the steps needed to package and release our AddOn
+    steps:
+      - name: Twitter Notification
+        uses: nearform-actions/github-action-notify-twitter@master
+        with:
+          message: ${{needs.release-notification-output.outputs.tweetText}}
+          twitter-app-key: ${{ secrets.TWITTER_API_KEY }}
+          twitter-app-secret: ${{ secrets.TWITTER_API_KEY_SECRET }}
+          twitter-access-token: ${{ secrets.TWITTER_ACCESS_TOKEN }}
+          twitter-access-token-secret: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}
+
+############### MASTODON ####################
+  mastodon-release-notification:
+    # we can run our steps on pretty much anything, but the "ubuntu-latest" image is a safe bet
+    runs-on: ubuntu-latest
+    needs: release-notification-output
+
+    # "steps" holds a list of all the steps needed to package and release our AddOn
+    steps:
+      - name: Mastodon Notification
+        id: mastodon
+        uses: cbrgm/mastodon-github-action@v2.0.5
+        with:
+          access-token: ${{ secrets.MASTODON_ACCESS_TOKEN }} # access token
+          url: ${{ secrets.MASTODON_URL }} # https://example.social
+          message: ${{needs.release-notification-output.outputs.tweetText}}
+
+############### BLUESKY ####################
+  bluesky-release-notification:
+    # we can run our steps on pretty much anything, but the "ubuntu-latest" image is a safe bet
+    runs-on: ubuntu-latest
+    needs: release-notification-output
+
+    # "steps" holds a list of all the steps needed to package and release our AddOn
+    steps:
+      - uses: myConsciousness/bluesky-post@v5
+        with:
+          text: ${{needs.release-notification-output.outputs.tweetText}}
+          identifier: ${{ secrets.BLUESKY_IDENTIFIER }}
+          password: ${{ secrets.BLUESKY_PASSWORD }}

--- a/.github/workflows/release_notifications.yml
+++ b/.github/workflows/release_notifications.yml
@@ -1,78 +1,53 @@
-# description of this workflow, can be anything you want
-name: Send Release Notification
+name: Send Release Notifications
 
-# we need to let GitHub know _when_ we want to release, typically only when we create a new tag.
-# this will target only tags, and not all pushes to the master branch.
-# this part can be heavily customized to your liking, like targeting only tags that match a certain word,
-# other branches or even pullrequests.
-# 'workflow_dispatch' allows us to re-run a failed job.
 on:
   workflow_dispatch:
   release:
     types: [published]
 
-# a workflow is built up as jobs, and within these jobs are steps
 jobs:
-  ## We seperate each item into different 'jobs'.  The first job will get all the text that we need
-  ## the subsequent jobs will require the text from the first, and then send it to their approporate channels.
-  ## This allows us to reun-run specific social media sites seperately incase of errors.
-
   release-notification-output:
-    # we can run our steps on pretty much anything, but the "ubuntu-latest" image is a safe bet
     runs-on: ubuntu-latest
 
-    # output documentation: https://docs.github.com/en/actions/using-jobs/defining-outputs-for-jobs
     outputs:
       changeLogText: ${{ steps.readChanglog.outputs.text }}
       tweetText: ${{ steps.readTweet.outputs.text }}
 
-    # "steps" holds a list of all the steps needed to package and release our AddOn
     steps:
-      # we first have to clone the AddOn project, this is a required step
       - name: Clone project
         uses: actions/checkout@v4
         with:
           fetch-depth: 0  # gets git history for changelogs
 
-      # run a custom changelog script in the root of the repo.
       - name: Generate Changelog
         id: Changelog
         run: ./generate_changelog.sh
 
-      # save the output of the changelog into a variable.
       - name: save changelog in variable
         uses: pCYSl5EDgo/cat@master
         id: readChanglog
         with:
           path: CHANGELOG.md
 
-      # generate the text for twitter or other social media
       - name: Generate Twitter Text
         id: twitter_post
         run: /usr/bin/env python3 .github/scripts/generate_twitter_post.py
 
-      # save the generated information into a variable.
       - name: save twitter post to variable
         uses: pCYSl5EDgo/cat@master
         id: readTweet
         with:
             path: twitter_post.txt
 
-############### DISCORD ####################
-  # "release-notification" is a job, you can name it anything you want
+
   discord-release-notification:
-    # we can run our steps on pretty much anything, but the "ubuntu-latest" image is a safe bet
     runs-on: ubuntu-latest
     needs: release-notification-output
 
-    # specify the environment variables used by the packager, matching the secrets from the project on GitHub
     env:
       MESSAGE: "New WeakAuras Release"
 
-    # "steps" holds a list of all the steps needed to package and release our AddOn
     steps:
-
-    # using Discord webhook to send release information
       - name: Discord Release Webhook Action
         uses: tsickert/discord-webhook@v5.4.0
         if: success()
@@ -82,13 +57,10 @@ jobs:
           embed-url: https://github.com/WeakAuras/WeakAuras2/releases/latest
           embed-description:  ${{needs.release-notification-output.outputs.changeLogText}}
 
-############### TWITTER ####################
   twitter-release-notification:
-    # we can run our steps on pretty much anything, but the "ubuntu-latest" image is a safe bet
     runs-on: ubuntu-latest
     needs: release-notification-output
 
-    # "steps" holds a list of all the steps needed to package and release our AddOn
     steps:
       - name: Twitter Notification
         uses: nearform-actions/github-action-notify-twitter@master
@@ -99,13 +71,10 @@ jobs:
           twitter-access-token: ${{ secrets.TWITTER_ACCESS_TOKEN }}
           twitter-access-token-secret: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}
 
-############### MASTODON ####################
   mastodon-release-notification:
-    # we can run our steps on pretty much anything, but the "ubuntu-latest" image is a safe bet
     runs-on: ubuntu-latest
     needs: release-notification-output
 
-    # "steps" holds a list of all the steps needed to package and release our AddOn
     steps:
       - name: Mastodon Notification
         id: mastodon
@@ -115,13 +84,10 @@ jobs:
           url: ${{ secrets.MASTODON_URL }} # https://example.social
           message: ${{needs.release-notification-output.outputs.tweetText}}
 
-############### BLUESKY ####################
   bluesky-release-notification:
-    # we can run our steps on pretty much anything, but the "ubuntu-latest" image is a safe bet
     runs-on: ubuntu-latest
     needs: release-notification-output
 
-    # "steps" holds a list of all the steps needed to package and release our AddOn
     steps:
       - uses: myConsciousness/bluesky-post@v5
         with:

--- a/.github/workflows/release_notifications_manual_tests.yml
+++ b/.github/workflows/release_notifications_manual_tests.yml
@@ -1,0 +1,119 @@
+# description of this workflow, can be anything you want
+name: Send TEST Release Notification
+
+# 'workflow_dispatch' means it will only be manually triggerd via actions menu.
+on:
+  workflow_dispatch:
+
+# a workflow is built up as jobs, and within these jobs are steps
+jobs:
+  ## We seperate each item into different 'jobs'.  The first job will get all the text that we need
+  ## the subsequent jobs will require the text from the first, and then send it to their approporate channels.
+  ## This allows us to reun-run specific social media sites seperately incase of errors.
+
+  # "release-notification" is a job, you can name it anything you want
+  test-release-notification-output:
+    # we can run our steps on pretty much anything, but the "ubuntu-latest" image is a safe bet
+    runs-on: ubuntu-latest
+
+    # output documentation: https://docs.github.com/en/actions/using-jobs/defining-outputs-for-jobs
+    outputs:
+      changeLogText: ${{ steps.readChanglog.outputs.text }}
+      tweetText: ${{ steps.readTweet.outputs.text }}
+
+    # "steps" holds a list of all the steps needed to package and release our AddOn
+    steps:
+      # we first have to clone the AddOn project, this is a required step
+      - name: Clone project
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # gets git history for changelogs
+
+      # save the output of the changelog into a variable.
+      - name: save changelog in variable
+        uses: pCYSl5EDgo/cat@master
+        id: readChanglog
+        with:
+          path: .github/scripts/test_files/large_changelog_example.md # use the custom large changelog
+
+      # generate the text for twitter or other social media
+      - name: Generate Twitter Text
+        id: twitter_post
+        # pass in the large changelog into the twitter script.
+        run: /usr/bin/env python3 .github/scripts/generate_twitter_post.py -c .github/scripts/test_files/large_changelog_example.md
+
+      # save the generated information into a variable.
+      - name: save twitter post to variable
+        uses: pCYSl5EDgo/cat@master
+        id: readTweet
+        with:
+            path: twitter_post.txt
+
+############### DISCORD ####################
+  test-discord-release-notification:
+    # we can run our steps on pretty much anything, but the "ubuntu-latest" image is a safe bet
+    runs-on: ubuntu-latest
+    needs: test-release-notification-output
+
+    # specify the environment variables used by the packager, matching the secrets from the project on GitHub
+    env:
+      MESSAGE: "TEST NOTIFICATION"
+
+    # "steps" holds a list of all the steps needed to package and release our AddOn
+    steps:
+    # using Discord webhook to send release information
+      - name: Discord Release Webhook Action
+        uses: tsickert/discord-webhook@v5.4.0
+        if: success()
+        with:
+          webhook-url: ${{ secrets.TEST_RELEASE_WEBHOOK_URL }}
+          embed-title: ${{ env.MESSAGE }}
+          embed-url: https://github.com/WeakAuras/WeakAuras2/releases/latest
+          embed-description:  ${{needs.test-release-notification-output.outputs.changeLogText}}
+
+############### TWITTER ####################
+  test-twitter-release-notification:
+    # we can run our steps on pretty much anything, but the "ubuntu-latest" image is a safe bet
+    runs-on: ubuntu-latest
+    needs: test-release-notification-output
+
+    # "steps" holds a list of all the steps needed to package and release our AddOn
+    steps:
+      - name: Twitter Notification
+        uses: nearform-actions/github-action-notify-twitter@master
+        with:
+          message: ${{needs.test-release-notification-output.outputs.tweetText}}
+          twitter-app-key: ${{ secrets.TEST_TWITTER_API_KEY }}
+          twitter-app-secret: ${{ secrets.TEST_TWITTER_API_KEY_SECRET }}
+          twitter-access-token: ${{ secrets.TEST_TWITTER_ACCESS_TOKEN }}
+          twitter-access-token-secret: ${{ secrets.TEST_TWITTER_ACCESS_TOKEN_SECRET }}
+
+############### MASTODON ####################
+  test-mastodon-release-notification:
+    # we can run our steps on pretty much anything, but the "ubuntu-latest" image is a safe bet
+    runs-on: ubuntu-latest
+    needs: test-release-notification-output
+
+    # "steps" holds a list of all the steps needed to package and release our AddOn
+    steps:
+      - name: Mastodon Notification
+        id: mastodon
+        uses: cbrgm/mastodon-github-action@v2.0.5
+        with:
+          access-token: ${{ secrets.TEST_MASTODON_ACCESS_TOKEN }} # access token
+          url: ${{ secrets.TEST_MASTODON_URL }} # https://example.social
+          message: ${{needs.test-release-notification-output.outputs.tweetText}}
+
+############### BLUESKY ####################
+  test-bluesky-release-notification:
+    # we can run our steps on pretty much anything, but the "ubuntu-latest" image is a safe bet
+    runs-on: ubuntu-latest
+    needs: test-release-notification-output
+
+    # "steps" holds a list of all the steps needed to package and release our AddOn
+    steps:
+      - uses: myConsciousness/bluesky-post@v5
+        with:
+          text: ${{needs.test-release-notification-output.outputs.tweetText}}
+          identifier: ${{ secrets.TEST_BLUESKY_IDENTIFIER }}
+          password: ${{ secrets.TEST_BLUESKY_PASSWORD }}

--- a/.github/workflows/release_notifications_manual_tests.yml
+++ b/.github/workflows/release_notifications_manual_tests.yml
@@ -1,5 +1,5 @@
 # description of this workflow, can be anything you want
-name: Send TEST Release Notification
+name: Send TEST Release Notifications
 
 # 'workflow_dispatch' means it will only be manually triggerd via actions menu.
 on:
@@ -66,7 +66,7 @@ jobs:
         uses: tsickert/discord-webhook@v5.4.0
         if: success()
         with:
-          webhook-url: ${{ secrets.TEST_RELEASE_WEBHOOK_URL }}
+          webhook-url: ${{ secrets.RELEASE_WEBHOOK_URL }}
           embed-title: ${{ env.MESSAGE }}
           embed-url: https://github.com/WeakAuras/WeakAuras2/releases/latest
           embed-description:  ${{needs.test-release-notification-output.outputs.changeLogText}}
@@ -83,10 +83,10 @@ jobs:
         uses: nearform-actions/github-action-notify-twitter@master
         with:
           message: ${{needs.test-release-notification-output.outputs.tweetText}}
-          twitter-app-key: ${{ secrets.TEST_TWITTER_API_KEY }}
-          twitter-app-secret: ${{ secrets.TEST_TWITTER_API_KEY_SECRET }}
-          twitter-access-token: ${{ secrets.TEST_TWITTER_ACCESS_TOKEN }}
-          twitter-access-token-secret: ${{ secrets.TEST_TWITTER_ACCESS_TOKEN_SECRET }}
+          twitter-app-key: ${{ secrets.TWITTER_API_KEY }}
+          twitter-app-secret: ${{ secrets.TWITTER_API_KEY_SECRET }}
+          twitter-access-token: ${{ secrets.TWITTER_ACCESS_TOKEN }}
+          twitter-access-token-secret: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}
 
 ############### MASTODON ####################
   test-mastodon-release-notification:
@@ -100,8 +100,8 @@ jobs:
         id: mastodon
         uses: cbrgm/mastodon-github-action@v2.0.5
         with:
-          access-token: ${{ secrets.TEST_MASTODON_ACCESS_TOKEN }} # access token
-          url: ${{ secrets.TEST_MASTODON_URL }} # https://example.social
+          access-token: ${{ secrets.MASTODON_ACCESS_TOKEN }} # access token
+          url: ${{ secrets.MASTODON_URL }} # https://example.social
           message: ${{needs.test-release-notification-output.outputs.tweetText}}
 
 ############### BLUESKY ####################
@@ -115,5 +115,5 @@ jobs:
       - uses: myConsciousness/bluesky-post@v5
         with:
           text: ${{needs.test-release-notification-output.outputs.tweetText}}
-          identifier: ${{ secrets.TEST_BLUESKY_IDENTIFIER }}
-          password: ${{ secrets.TEST_BLUESKY_PASSWORD }}
+          identifier: ${{ secrets.BLUESKY_IDENTIFIER }}
+          password: ${{ secrets.BLUESKY_PASSWORD }}

--- a/.github/workflows/release_notifications_setup.md
+++ b/.github/workflows/release_notifications_setup.md
@@ -1,0 +1,155 @@
+# Setting up release notification hooks.
+
+## Requirements
+This folder contains a [release_notifications.yml](release_notifications.yml) file that contains workflows for github actions to be able to post an automated message to various social media platforms when a released is published.
+
+For the most part, this file can work plug-and-play into any repo, you simply need to set up the various github 'secrets' so that the workflow knows where to push the updates to. This page will highlight the required peices for it to work as well as where to find the keys/tokens to use for your notifications.
+
+An important part of the yml is the following block:
+```yml
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+```
+where `workflow_dispatch` will tell Github Actions that this job can be run manually, allowing you to run it at will, and the `release` portion saying when a Github Release is pusblished.  This is the part that will automatically run a release is made.
+
+For this workflow to work, you are required to have the [generate_changelog.sh](../../generate_changelog.sh) script to generate a change log based on the tags during the release process, as well as [generate_twitter_post.py](../scripts/generate_twitter_post.py) to generate a smaller version of the produced changelog to fit within a twitter post.
+
+With these scripts and [release_notifications.yml](release_notifications.yml) you can have automated messeages sent to the various social media channels.
+
+There is also a [release_notifications_manual_tests.yml](release_notifications_manual_tests.yml) file that is set up in a similar way, but all the 'secrets' are pre-pended with `TEST_`.  You can simply omit this file if you don't think you need it, but this allows you to manually run a seperate set of tokens/urls to test out the output before you push to your main channels.  To use this, follow the below steps, but add `TEST_` to the start of each secret, and that file will push to that instead.
+
+-------
+## Where to save your 'secrets'
+Github has pretty decent [documentation](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions) for how the secrets work, but i will give a short explination here.
+
+From your repo go to Settings -> Secrets and variables -> Actions:
+![secrets and variables](https://i.imgur.com/IR9PDAG.png)
+
+From here you will see 'Repository secrets'.  Here is where you will set up all your tokens and URLs to use for the release notifications.
+
+![secret examples](https://i.imgur.com/bGXW1uk.png)
+
+-------
+
+## API keys / tokens for the notifications.
+
+Each application needs their own set of tokens and urls to push to.
+
+###  Discord
+For discord, you simply need to set up a webhook to a channel.
+
+Pick a channel, and hit 'edit channel'
+![](https://i.imgur.com/Gr9llZy.png)
+
+Integrations -> View Webhooks
+![](https://i.imgur.com/hAY1nqt.png)
+
+Create a new webhook and copy the URL.
+
+Go to your github secrets and save the URL as: `RELEASE_WEBHOOK_URL`
+
+###  Twitter
+First sign into the twitter developer portal with the account you want to post with: https://developer.twitter.com/en
+
+once you have an account set up you can go to the dashboard: https://developer.twitter.com/en/portal/dashboard
+
+For a free twitter developer account you can set up a single 'project', create one.
+![](https://i.imgur.com/Jlu4MId.png)
+
+Once you create the project it will ask you to make an 'app', which will give you API Keys afterwards.  Don't worry about these, we are going to regenerate them anyway after the next step.
+![](https://i.imgur.com/3IUNUI3.png)
+
+
+Once you get your first set of keys/tokens, go to the 'App Settings'.  You can get to it from the dashboard on the left side and clicking the name of your app.  Towards the bottom, you want to click 'set up' for user authentication settings.
+![](https://i.imgur.com/z7AXpfj.png)
+
+From here you want to fill out the information the best you can, but the important parts are the two radio buttons at the top:
+![](https://i.imgur.com/CJPERMY.png)
+
+'Read and write' are required for your bot to post to twitter.  Set both 'Read and Write' as well as 'Bot' as Type of App, and fill out the rest of the form.  The website and callback URL requires `https://` or `http://` at the start to be valid.  This will give you a client ID and Client Secret, dont worry about this either, we will regenerate all at once to get everything we need.
+
+Now, we have everything set up to regenerate the keys and save them. Go back to the dashboard, click your app name and then 'keys and tokens'
+![](https://i.imgur.com/UvWl0f9.png)
+
+From here you will see various tokens. You can 'Regenerate' your `API Key and Secret` and save it in a text file for now. You want both `API Key` and `API Key Secret`.
+
+Next, you want the `Access Token and Secret`.  Hit 'Regenerate' and save both `Access Token` and `Access Token Secret`.
+
+**IMPORTANT:** after you save this information ENSURE that the you see `Created with Read and Write permissions` below it.  If write permissions are not granted you will not be able to send messages.
+
+Finally, go to Github Actions Secrets and save the following information:
+```
+TWITTER_ACCESS_TOKEN
+TWITTER_ACCESS_TOKEN_SECRET
+TWITTER_API_KEY
+TWITTER_API_KEY_SECRET
+```
+
+###  Mastodon
+
+For Mastodon you only need 2 easy to get items.  For the URL you simply provide the URL of the network you're on.  For exmaple: https://mastodon.social
+
+For the access token you need to make a new application.  Go to your Prefrences -> Development - and create a new application
+![](https://i.imgur.com/3PW6ztz.png)
+
+From here you can customize the information you want to give it.
+![](https://i.imgur.com/XGCzmZB.png)
+
+Simply submit the application and open it up to see your access token
+![](https://i.imgur.com/GAtF3uo.png)
+
+```
+MASTODON_ACCESS_TOKEN
+MASTODON_URL # https://mastodon.social
+```
+
+###  Bluesky
+Bluesky only needs 2 items, the handle/identifier to post to (user name or email) and the 'app password'.
+
+To get the 'app password' go to your bluesky settings and click 'App Passwords'
+![](https://i.imgur.com/kG8oywU.png)
+
+Generate a new app password with a unique name and it will generate a key for you to save.
+![](https://i.imgur.com/gn4x2B6.png)
+
+
+```
+BLUESKY_IDENTIFIER # user name or email
+BLUESKY_PASSWORD # 'app password'
+```
+
+-------
+
+## Running the Workflow
+
+If you want to test the notifications you can go to ACTIONS and check your workflows
+![](https://i.imgur.com/npbcEJ6.png)
+
+You can use `Send TEST Release Notification` to test it out. Remember, these will use the pre-pended `TEST_` secrets.  This will also use a custom changelog found here:[large_changelog_example.md](../scripts/test_files/large_changelog_example.md).
+
+If for some reason something fails, it is set up in a way to be able to re-run specific notifications.  As an example, in this image mastadon failed.
+![](https://i.imgur.com/EXUTZCa.png)
+
+You can view the error and see if you can fix it with the secrets, if you did a copy/paste error and re-run only the mastodon job.
+
+When running a test, normally the changelog will not generate a 'highlights' section, which means the tweet will only include a URL to the latest tag.  If the tag is the newest commit, it should work normally.
+
+When you publish a new release with a new tag it will also automatically run, and you can re-run failed jobs as well.
+
+---
+
+## Example screenshots with TEST release info
+
+### Discord
+![](https://i.imgur.com/wWFurie.png)
+
+### Twitter
+![](https://i.imgur.com/EdTWSCo.png)
+
+### Mastadon
+![](https://i.imgur.com/WBPSjye.png)
+
+### Bluesky
+![](https://i.imgur.com/nFgWJ7O.png)

--- a/.github/workflows/release_notifications_setup.md
+++ b/.github/workflows/release_notifications_setup.md
@@ -1,28 +1,33 @@
-# Setting up release notification hooks.
+# Setting up release notification hooks
 
 ## Requirements
+
 This folder contains a [release_notifications.yml](release_notifications.yml) file that contains workflows for github actions to be able to post an automated message to various social media platforms when a released is published.
 
-For the most part, this file can work plug-and-play into any repo, you simply need to set up the various github 'secrets' so that the workflow knows where to push the updates to. This page will highlight the required peices for it to work as well as where to find the keys/tokens to use for your notifications.
+For the most part, this file can work plug-and-play into any repo, you simply need to set up the various github 'secrets' so that the workflow knows where to push the updates to. This page will highlight the required pieces for it to work as well as where to find the keys/tokens to use for your notifications.
 
 An important part of the yml is the following block:
+
 ```yml
 on:
   workflow_dispatch:
   release:
     types: [published]
 ```
-where `workflow_dispatch` will tell Github Actions that this job can be run manually, allowing you to run it at will, and the `release` portion saying when a Github Release is pusblished.  This is the part that will automatically run a release is made.
+
+where `workflow_dispatch` will tell Github Actions that this job can be run manually, allowing you to run it at will, and the `release` portion saying when a Github Release is published.  This is the part that will automatically run a release is made.
 
 For this workflow to work, you are required to have the [generate_changelog.sh](../../generate_changelog.sh) script to generate a change log based on the tags during the release process, as well as [generate_twitter_post.py](../scripts/generate_twitter_post.py) to generate a smaller version of the produced changelog to fit within a twitter post.
 
-With these scripts and [release_notifications.yml](release_notifications.yml) you can have automated messeages sent to the various social media channels.
+With these scripts and [release_notifications.yml](release_notifications.yml) you can have automated messages sent to the various social media channels.
 
-There is also a [release_notifications_manual_tests.yml](release_notifications_manual_tests.yml) file that is set up in a similar way, but all the 'secrets' are pre-pended with `TEST_`.  You can simply omit this file if you don't think you need it, but this allows you to manually run a seperate set of tokens/urls to test out the output before you push to your main channels.  To use this, follow the below steps, but add `TEST_` to the start of each secret, and that file will push to that instead.
+There is also a [release_notifications_manual_tests.yml](release_notifications_manual_tests.yml) file that is set up in a similar way, but all the 'secrets' are pre-pended with `TEST_`.  You can simply omit this file if you don't think you need it, but this allows you to manually run a separate set of tokens/urls to test out the output before you push to your main channels.  To use this, follow the below steps, but add `TEST_` to the start of each secret, and that file will push to that instead.
 
 -------
+
 ## Where to save your 'secrets'
-Github has pretty decent [documentation](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions) for how the secrets work, but i will give a short explination here.
+
+Github has pretty decent [documentation](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions) for how the secrets work, but i will give a short explanation here.
 
 From your repo go to Settings -> Secrets and variables -> Actions:
 ![secrets and variables](https://i.imgur.com/IR9PDAG.png)
@@ -33,12 +38,13 @@ From here you will see 'Repository secrets'.  Here is where you will set up all 
 
 -------
 
-## API keys / tokens for the notifications.
+## API keys / tokens for the notifications
 
 Each application needs their own set of tokens and urls to push to.
 
-###  Discord
-For discord, you simply need to set up a webhook to a channel.
+### Discord
+
+For Discord, you simply need to set up a webhook to a channel.
 
 Pick a channel, and hit 'edit channel'
 ![](https://i.imgur.com/Gr9llZy.png)
@@ -50,17 +56,17 @@ Create a new webhook and copy the URL.
 
 Go to your github secrets and save the URL as: `RELEASE_WEBHOOK_URL`
 
-###  Twitter
-First sign into the twitter developer portal with the account you want to post with: https://developer.twitter.com/en
+### Twitter
 
-once you have an account set up you can go to the dashboard: https://developer.twitter.com/en/portal/dashboard
+First sign into the twitter developer portal with the account you want to post with: <https://developer.twitter.com/en>
+
+once you have an account set up you can go to the dashboard: <https://developer.twitter.com/en/portal/dashboard>
 
 For a free twitter developer account you can set up a single 'project', create one.
 ![](https://i.imgur.com/Jlu4MId.png)
 
 Once you create the project it will ask you to make an 'app', which will give you API Keys afterwards.  Don't worry about these, we are going to regenerate them anyway after the next step.
 ![](https://i.imgur.com/3IUNUI3.png)
-
 
 Once you get your first set of keys/tokens, go to the 'App Settings'.  You can get to it from the dashboard on the left side and clicking the name of your app.  Towards the bottom, you want to click 'set up' for user authentication settings.
 ![](https://i.imgur.com/z7AXpfj.png)
@@ -77,21 +83,22 @@ From here you will see various tokens. You can 'Regenerate' your `API Key and Se
 
 Next, you want the `Access Token and Secret`.  Hit 'Regenerate' and save both `Access Token` and `Access Token Secret`.
 
-**IMPORTANT:** after you save this information ENSURE that the you see `Created with Read and Write permissions` below it.  If write permissions are not granted you will not be able to send messages.
+**IMPORTANT:** after you save this information ENSURE that the you see `Created with Read and Write permissions` below it. If write permissions are not granted you will not be able to send messages.
 
 Finally, go to Github Actions Secrets and save the following information:
-```
+
+```sh
 TWITTER_ACCESS_TOKEN
 TWITTER_ACCESS_TOKEN_SECRET
 TWITTER_API_KEY
 TWITTER_API_KEY_SECRET
 ```
 
-###  Mastodon
+### Mastodon
 
-For Mastodon you only need 2 easy to get items.  For the URL you simply provide the URL of the network you're on.  For exmaple: https://mastodon.social
+For Mastodon you only need 2 easy to get items.  For the URL you simply provide the URL of the network you're on.  For example: <https://mastodon.social>
 
-For the access token you need to make a new application.  Go to your Prefrences -> Development - and create a new application
+For the access token you need to make a new application.  Go to your Preferences -> Development - and create a new application
 ![](https://i.imgur.com/3PW6ztz.png)
 
 From here you can customize the information you want to give it.
@@ -100,12 +107,13 @@ From here you can customize the information you want to give it.
 Simply submit the application and open it up to see your access token
 ![](https://i.imgur.com/GAtF3uo.png)
 
-```
+```sh
 MASTODON_ACCESS_TOKEN
 MASTODON_URL # https://mastodon.social
 ```
 
-###  Bluesky
+### Bluesky
+
 Bluesky only needs 2 items, the handle/identifier to post to (user name or email) and the 'app password'.
 
 To get the 'app password' go to your bluesky settings and click 'App Passwords'
@@ -114,8 +122,7 @@ To get the 'app password' go to your bluesky settings and click 'App Passwords'
 Generate a new app password with a unique name and it will generate a key for you to save.
 ![](https://i.imgur.com/gn4x2B6.png)
 
-
-```
+```sh
 BLUESKY_IDENTIFIER # user name or email
 BLUESKY_PASSWORD # 'app password'
 ```
@@ -138,18 +145,22 @@ When running a test, normally the changelog will not generate a 'highlights' sec
 
 When you publish a new release with a new tag it will also automatically run, and you can re-run failed jobs as well.
 
----
+-------
 
 ## Example screenshots with TEST release info
 
 ### Discord
+
 ![](https://i.imgur.com/wWFurie.png)
 
 ### Twitter
+
 ![](https://i.imgur.com/EdTWSCo.png)
 
 ### Mastadon
+
 ![](https://i.imgur.com/WBPSjye.png)
 
 ### Bluesky
+
 ![](https://i.imgur.com/nFgWJ7O.png)


### PR DESCRIPTION
# Description
Add Github Actions to automatically post release notifications when a release is published to the following:
	- Discord Webhook
	- Twitter
	- Mastodon
	- Bluesky

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested
Tested via my own personal fork of the code base, using GitHub Actions.  I provided a 'TEST' workflow as well that will use a custom made 'changelog' that has a large amount of changes to see what it looks like.  We can add other test files or change this one for future uses.  The test file also uses separate GitHub 'secrets', so that they don't interfere with the production channels.

## Checklist
<!-- These can be checked off after the pull request is submitted, in case you want discussion before they are completely ready -->

- [x] My code follows the style guidelines of this project (maybe? its all new files not directly related to the addon)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

<!-- Is there any additional work that needs to be done? If so, add it to the above list -->

## Extra info
I still need to test twitter once more, I think there was a daily rate limit on the free tier, so  I need to wait a day to test it again.

I will also go through and add extra comments some of files I created.  Please let me know if there is anything in particular that does not make sense.

I also need to write some documentation on how to set up each individual 'notification' channel.  Twitter was slightly more involved and confusing to understand which keys to use.
