### PR TITLE
fixed name for NewButton

### DIFF
--- a/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasNewButton.lua
+++ b/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasNewButton.lua
@@ -1,7 +1,7 @@
 if not WeakAuras.IsLibsOK() then return end
 local AddonName, OptionsPrivate = ...
 
-local Type, Version = "WeakAurasNewButton", 27
+local Type, Version = "WeakAurasNewButton", 28
 local AceGUI = LibStub and LibStub("AceGUI-3.0", true)
 if not AceGUI or (AceGUI:GetWidgetVersion(Type) or 0) >= Version then return end
 
@@ -90,7 +90,7 @@ Constructor
 -------------------------------------------------------------------------------]]
 
 local function Constructor()
-  local name = "WeakAurasDisplayButton"..AceGUI:GetNextWidgetNum(Type);
+  local name = "WeakAurasNewButton"..AceGUI:GetNextWidgetNum(Type);
   local button = CreateFrame("Button", name, UIParent, "OptionsListButtonTemplate");
   button:SetHeight(40);
   button:SetWidth(380);


### PR DESCRIPTION
# Description

The widget for WeakAurasNewButton shares a name with WeakAurasDisplayButton, which overrides first 11 globals for DisplayButtons.

I do some silly stuff with those buttons in addon that my guild uses and first 11 display buttons unaccessible from global environment which somewhat breakes my stuff.