### PR TITLE
Hide boolean types in text replacements tooltips

### DIFF
--- a/WeakAuras/GenericTrigger.lua
+++ b/WeakAuras/GenericTrigger.lua
@@ -4049,7 +4049,7 @@ function GenericTrigger.GetAdditionalProperties(data, triggernum)
       elseif type(v.enable) == "boolean" then
         enable = v.enable
       end
-      if (enable and v.store and v.name and v.display) then
+      if (enable and v.store and v.name and v.display and v.conditionType ~= "bool") then
         found = true;
         additional = additional .. "|cFFFFCC00%".. triggernum .. "." .. v.name .. "|r - " .. v.display .. "\n";
       end


### PR DESCRIPTION
# Description

Trigger boolean types stored in the state are needed to make the option available for conditions, however this also shows them as an available text replacement. When a trigger features many of these boolean options, the text replacements tooltip becomes cluttered with options that are probably never used as output.

Before:
![image](https://github.com/WeakAuras/WeakAuras2/assets/6916881/f1afad34-f0cb-4f0f-846f-b8bf0006a6c0)

After:
![image](https://github.com/WeakAuras/WeakAuras2/assets/6916881/24eb252d-dcca-47b6-8ec0-8aa9dadcb8f6)
`%capped, %isParagon, %isWeeklyRenownCapped` are removed from the tooltip, though they are still available.

