### PR TITLE
Add missing difficulty IDs from latest WoW patch

### DIFF
--- a/WeakAuras/Types.lua
+++ b/WeakAuras/Types.lua
@@ -2870,9 +2870,14 @@ do
     [174] = L["Heroic Party"],
     [175] = L["10 Player Raid"],
     [176] = L["25 Player Raid"],
+    [184] = L["Normal Party"],
+    [185] = L["20 Player Raid"],
+    [186] = L["40 Player Raid"],
     [192] = L["Dungeon (Mythic+)"], -- "Challenge Level 1" TODO: check if this label is correct
     [193] = L["10 Player Raid (Heroic)"],
     [194] = L["25 Player Raid (Heroic)"],
+    [197] = L["10 Player Raid"],
+    [198] = L["Normal Party"],
   }
 
   for i = 1, 200 do


### PR DESCRIPTION
# Description

Unknown difficulty ID warnings coming from the latest WoW patch. This is a simple change to add them to `Types.lua`.

- Fixes https://github.com/WeakAuras/WeakAuras2/issues/4986

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

Tested locally.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings