### PR TITLE
only use whisper comms if target is on the actually same server

### DIFF
--- a/WeakAuras/Transmission.lua
+++ b/WeakAuras/Transmission.lua
@@ -553,7 +553,7 @@ end
 
 local function crossRealmSendCommMessage(prefix, text, target, queueName, callbackFn, callbackArg)
   local chattype = "WHISPER"
-  if target and not UnitIsSameServer(target) then
+  if target and (UnitRealmRelationship(target) or 0) ~= 1 then
     if UnitInRaid(target) then
       chattype = "RAID"
       text = ("§§%s:%s"):format(target, text)

--- a/WeakAuras/Transmission.lua
+++ b/WeakAuras/Transmission.lua
@@ -553,6 +553,7 @@ end
 
 local function crossRealmSendCommMessage(prefix, text, target, queueName, callbackFn, callbackArg)
   local chattype = "WHISPER"
+  -- WORKAROUND https://github.com/Stanzilla/WoWUIBugs/issues/535, and use RAID/PARTY comms for connected realms
   if target and (UnitRealmRelationship(target) or 0) ~= 1 then
     if UnitInRaid(target) then
       chattype = "RAID"


### PR DESCRIPTION
UnitIsSameServer returns true if user is on a connected realm (e.g. US ArgentDawn <=> TheScryers), so we should distinguish between the cases using UnitRealmRelationship, which returns 1 for same realm, 2 for coalesced (instanced/sharded together or whatever), and 3 for connected realms.

Since it seems that either whisper comms on connected realms never worked (and ~nobody plays on those realms so it took a long time to notice), or blizzard recently broke it, we simply fallback to trying raid/party. If that doesn't work, we already have a hint to the user to try grouping up.

Fixes #5018 (possibly)
