### PR TITLE
Added "Parent Frame" as option to "Glow Frame Type"

### DIFF
--- a/WeakAuras/Types.lua
+++ b/WeakAuras/Types.lua
@@ -36,7 +36,8 @@ Private.glow_action_types = {
 Private.glow_frame_types = {
   UNITFRAME = L["Unit Frame"],
   NAMEPLATE = L["Nameplate"],
-  FRAMESELECTOR = L["Frame Selector"]
+  FRAMESELECTOR = L["Frame Selector"],
+  PARENTFRAME = L["Parent Frame"]
 }
 
 ---@type table<dynamicGroupCircularTypes, string>

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -3648,6 +3648,7 @@ function Private.HandleGlowAction(actions, region)
       and region.state.unit
     )
     or (actions.glow_frame_type == "FRAMESELECTOR" and actions.glow_frame)
+    or (actions.glow_frame_type == "PARENTFRAME" and region:GetParent())
   )
   then
     local glow_frame, should_glow_frame
@@ -3670,6 +3671,9 @@ function Private.HandleGlowAction(actions, region)
       should_glow_frame = true
     elseif actions.glow_frame_type == "NAMEPLATE" and region.state.unit then
       glow_frame = WeakAuras.GetUnitNameplate(region.state.unit)
+      should_glow_frame = true
+    elseif actions.glow_frame_type == "PARENTFRAME" then
+      glow_frame = region:GetParent()
       should_glow_frame = true
     end
 

--- a/WeakAurasOptions/ActionOptions.lua
+++ b/WeakAurasOptions/ActionOptions.lua
@@ -281,12 +281,7 @@ function OptionsPrivate.GetActionOptions(data)
         end,
         name = L["Glow Frame Type"],
         order = 10.3,
-        values = {
-          UNITFRAME = L["Unit Frame"],
-          NAMEPLATE = L["Nameplate"],
-          FRAMESELECTOR = L["Frame Selector"],
-          PARENTFRAME = L["Parent Frame"]
-        },
+        values = OptionsPrivate.Private.glow_frame_types,
         hidden = function()
           return not data.actions.start.do_glow
           or data.actions.start.glow_action == nil
@@ -720,12 +715,7 @@ function OptionsPrivate.GetActionOptions(data)
         end,
         name = L["Glow Frame Type"],
         order = 30.3,
-        values = {
-          UNITFRAME = L["Unit Frame"],
-          NAMEPLATE = L["Nameplate"],
-          FRAMESELECTOR = L["Frame Selector"],
-          PARENTFRAME = L["Parent Frame"]
-        },
+        values = OptionsPrivate.Private.glow_frame_types,
         hidden = function()
           return not data.actions.finish.do_glow
           or data.actions.finish.glow_action == nil

--- a/WeakAurasOptions/ActionOptions.lua
+++ b/WeakAurasOptions/ActionOptions.lua
@@ -284,7 +284,8 @@ function OptionsPrivate.GetActionOptions(data)
         values = {
           UNITFRAME = L["Unit Frame"],
           NAMEPLATE = L["Nameplate"],
-          FRAMESELECTOR = L["Frame Selector"]
+          FRAMESELECTOR = L["Frame Selector"],
+          PARENTFRAME = L["Parent Frame"]
         },
         hidden = function()
           return not data.actions.start.do_glow
@@ -722,7 +723,8 @@ function OptionsPrivate.GetActionOptions(data)
         values = {
           UNITFRAME = L["Unit Frame"],
           NAMEPLATE = L["Nameplate"],
-          FRAMESELECTOR = L["Frame Selector"]
+          FRAMESELECTOR = L["Frame Selector"],
+          PARENTFRAME = L["Parent Frame"]
         },
         hidden = function()
           return not data.actions.finish.do_glow

--- a/WeakAurasOptions/ConditionOptions.lua
+++ b/WeakAurasOptions/ConditionOptions.lua
@@ -1246,12 +1246,7 @@ local function addControlsForChange(args, order, data, conditionVariable, totalA
       values = OptionsPrivate.Private.glow_frame_types,
       width = WeakAuras.normalWidth,
       name = blueIfNoValue2(data, conditions[i].changes[j], "value", "glow_frame_type", L["Glow Frame Type"], L["Glow Frame Type"]),
-      desc = descIfNoValue2(data, conditions[i].changes[j], "value", "glow_frame_type", propertyType, {
-        UNITFRAME = L["Unit Frame"],
-        NAMEPLATE = L["Nameplate"],
-        FRAMESELECTOR = L["Frame Selector"],
-        PARENTFRAME = L["Parent Frame"]
-      }),
+      desc = descIfNoValue2(data, conditions[i].changes[j], "value", "glow_frame_type", propertyType, OptionsPrivate.Private.glow_frame_types),
       order = order,
       get = function()
         return type(conditions[i].changes[j].value) == "table" and conditions[i].changes[j].value.glow_frame_type;

--- a/WeakAurasOptions/ConditionOptions.lua
+++ b/WeakAurasOptions/ConditionOptions.lua
@@ -1249,7 +1249,8 @@ local function addControlsForChange(args, order, data, conditionVariable, totalA
       desc = descIfNoValue2(data, conditions[i].changes[j], "value", "glow_frame_type", propertyType, {
         UNITFRAME = L["Unit Frame"],
         NAMEPLATE = L["Nameplate"],
-        FRAMESELECTOR = L["Frame Selector"]
+        FRAMESELECTOR = L["Frame Selector"],
+        PARENTFRAME = L["Parent Frame"]
       }),
       order = order,
       get = function()


### PR DESCRIPTION
# Description

Frame glow currently supports selecting a frame, but managing those values becomes cumbersome real quick. I have a WA that is set to be attached to an action button, and conditionally adds a glow to that action button. I also have a condition to hide the glow but not actually hide the WA. I've noticed that when I want to move my spells to another keybind I find myself having to go through all the tabs and replace the configured frame name, which is a lot of work and easy to make mistakes. It also makes sharing the WA a lot more effort as I have to instruct them what exactly needs to be changed on multiple tabs.

The summary of this change is that it adds a "Parent Frame" option to the "Glow Frame Type" options under "Conditions" , and the "On Show/Hide" options under "Actions".

![image](https://github.com/WeakAuras/WeakAuras2/assets/1754678/b79143db-4414-40de-bbd8-43efefa03f5c)

## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested

I made the same changes in my Addons directory before committing (stable release build) and created a WA that binds to the `PlayerFrame` and `TargetFrame`, and will apply and remove the glow when you start moving. I've tested both the Conditions and Actions using this WA though this example only contains the "Conditions" variant

```
!WA:2!fwv3sTTXx84rtB)hnz6aoT8pKKM6K0qd0omesas)Uwu7cP2GrwajPFiVs7ARniRDZQv2yU0tM2Cn5nWxNR8Jax0RpdtFc4ripbDxjhGjjm9gPJwD2Dp7VpoBUTYh7TWS3z(zVF(25X5Xp)Ah6H83bly8LzHmXdmmmQzm3SlmqY87qeXuw0LY9xrh5XeyIWAuU8XScP7ThsGl4WyHsk)quImGjwNlvZi20ll)arV1B2mMiZnqqAP(JtpoXULGLWhKLrD6EK37GS4Sup)WSVYQNC5Yzyh7JcjgJMrjClcF86pnbjifkNegwy7aQKiq(PB9I2XsKqA61KgrJdmTuVKM9LcARwQZZLNsmk8phGjEjnBQljXkLQuR8MvSK66dLiqZ3pMtcdxfhBEuCIhPdjswxLnD3HUlxSUJBDNI2owjQf3JhI6re2rO2Kyt70u9wHGcLbhp1AcIAQ21RvQsL9tIgvcMdrr(kuRgJQMYYLwZPK9RuHerekCRm0)fdPrnzI2i9PZC)ysyZ00Hp)gumF8AkuiswOPqT5fAfY6k2DeIBJc5biJxLTfL1jOpQE1x2UuP188zrnPTmNpHIh(GTwO5gfNNxP7JhMUs1LcKezmqv(2P8wS5(OiAwrSiKV8beuSolsulzWhatAfXIihIvaNodxnmkIjQ9ah3xNQENHLSAJOrLHfvtawcUp8vWxREFX3CKb65rZeswHmeUSNujaIKty3orj2mTuCJ)eWpyA7hIIJ1rwXkHKoyK6z1ifgyK3FMNpTsTjdPrk91MovwDTs8VatJ1CMdzxPBg26YDL02exCpfls9DLbcsCale37W4aeM19rzO6vphm18oRxJx4SxJSVYXhZpjwYARZytogjjW1ps5syAu0FBkwgyvu9jmUcqnHlU4R00NBk(NcGdRv0wjjkBxSAjbM5Q)DJHPjLP1TcOyc8rMWh)Htbt83ki8A88jXexKxmtKkbRYWKgWvHp5OtgpBSRpy5Jr5(6FQLYnGRyc3e(Sd0dqJBZ6qJA1aUg8Pqbt4)dxcULjFC9U3H4KPH1R2lph)gNnE0MHDv6csd(uNDsHKwi)EUndzmramJN16ooRx1QjlsYhRSGUxHnsqyTQSGJdCVlpbm5Hk1PU5LUDseg(UYW3RfaWpM(Sy6tl9Z(6vr3Ozs(vEhvq0OayPrC9dZ4Ad(yNY7K(yyTuREAmCElPAvGVmhSG2s8MY6V5)wO)olh(OaBnUG538SXmUG4t19imGV9Ytz7hq83zrycJ(DqckYlKyPKWDT7Gctigc)auulIQbi8KfHQWA7NQK0cTd9sKsw06Q(9QncQb0(CvtEIq27aDsQDoTJKT)RVIWaMZu8eL8M2SNvLsLDad9Te6osxAfuCbEwxPBFk4AA49nH7AaZoSEPkLwotwd)VCWDg6Tu3nAxDt8DPBo8uN2BCRO(DvM5TfiE)ThfmmJIo5YHbQ(QeCQD6zxaM2eU9lE(mWpbL0et5EWpRTSWkWQ5Ghaxh(fOYidNY3OiefqCK2g5IcdtDyXbW6nuyWgNYvb2PEiOUY2aoWMV2MaB1q7l02JmVbS9lphGbc8OGrIcnBRi9tjkEJrU4BnYVc)wMah(DTO26Te1zY8)ysWvLDddfc2(EvV9oRUsy1Uva0qhKOfrosKc(kebMbEmS3ZUGY7EIIo7QJa4HnGUWUqhfEdpfeNqLxDBQ6o9e5X05Pw4P1uNMobPMyNZe4zcJEPSIwqcT0IriaOWtmGDow4bHqBTidIaMMWAAKVZ)8W)9
```

## Checklist
<!-- These can be checked off after the pull request is submitted, in case you want discussion before they are completely ready -->

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

<!-- Is there any additional work that needs to be done? If so, add it to the above list -->
