### PR TITLE
ensure we always compute the correct rect for a dynamic group

### DIFF
--- a/WeakAuras/RegionTypes/DynamicGroup.lua
+++ b/WeakAuras/RegionTypes/DynamicGroup.lua
@@ -1537,6 +1537,15 @@ local function modify(parent, region, data)
       Private.StartProfileSystem("dynamicgroup")
       Private.StartProfileAura(data.id)
       local numVisible, minX, maxX, maxY, minY = 0, nil, nil, nil, nil
+      local isRestricted = pcall(region.GetLeft, region) == false
+      if isRestricted then
+        -- workaround for restricted anchor families (mostly PRD)
+        -- if region is in a restricted anchor family, we're not allowed to get the rect of its children
+        -- and via Blizzard's extremely finite wisdom, the personal resource display is one such restricted family
+        -- so, temporarily reanchor to unrestrict us & child auras
+        region:RealClearAllPoints()
+        region:SetPoint("CENTER", UIParent, "CENTER")
+      end
       for active, regionData in ipairs(self.sortedChildren) do
         if regionData.shown then
           numVisible = numVisible + 1
@@ -1575,6 +1584,9 @@ local function modify(parent, region, data)
             self.background:SetPoint("BOTTOMLEFT", region, "BOTTOMLEFT", minX + -1 * data.borderOffset - regionLeft, minY + -1 * data.borderOffset - regionBottom)
             self.background:SetPoint("TOPRIGHT", region, "BOTTOMLEFT", maxX + data.borderOffset - regionLeft, maxY + data.borderOffset - regionBottom)
           end
+        end
+        if isRestricted then
+          self:ReAnchor()
         end
       else
         self:Hide()

--- a/WeakAuras/RegionTypes/DynamicGroup.lua
+++ b/WeakAuras/RegionTypes/DynamicGroup.lua
@@ -1537,7 +1537,7 @@ local function modify(parent, region, data)
       Private.StartProfileSystem("dynamicgroup")
       Private.StartProfileAura(data.id)
       local numVisible, minX, maxX, maxY, minY = 0, nil, nil, nil, nil
-      local isRestricted = pcall(region.GetLeft, region) == false
+      local isRestricted = region:IsAnchoringRestricted()
       if isRestricted then
         -- workaround for restricted anchor families (mostly PRD)
         -- if region is in a restricted anchor family, we're not allowed to get the rect of its children

--- a/WeakAuras/RegionTypes/RegionPrototype.lua
+++ b/WeakAuras/RegionTypes/RegionPrototype.lua
@@ -650,6 +650,7 @@ function Private.regionPrototype.create(region)
   region.RunCode = RunCode;
   region.GlowExternal = GlowExternal;
 
+  region.ReAnchor = UpdatePosition;
   region.SetAnchor = SetAnchor;
   region.SetOffset = SetOffset;
   region.SetXOffset = SetXOffset;

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -5442,6 +5442,11 @@ function Private.ensurePRDFrame()
   personalRessourceDisplayFrame = CreateFrame("Frame", "WeakAurasAttachToPRD", UIParent);
   personalRessourceDisplayFrame:Hide();
   personalRessourceDisplayFrame.attachedVisibleFrames = {};
+  -- force an early frame draw; otherwise this frame won't be drawn until the next frame,
+  -- and any attached auras won't have a valid rect
+  personalRessourceDisplayFrame:SetPoint("CENTER", UIParent, "CENTER");
+  personalRessourceDisplayFrame:SetSize(16, 16)
+  personalRessourceDisplayFrame:GetSize()
   Private.personalRessourceDisplayFrame = personalRessourceDisplayFrame;
 
   local moverFrame = CreateFrame("Frame", "WeakAurasPRDMoverFrame", personalRessourceDisplayFrame);


### PR DESCRIPTION
This is actually 2 problems in one:

- On initial spinup, our PRD anchor doesn't have a valid rect for 1 frame which would be fine, except we're creating it in the same frame we're anchoring dynamic groups to it. Thus, the dynamic group's children also won't have a valid rect. Fix this by forcing an early draw of the PRD anchor via an explicit GetSize call. (see https://warcraft.wiki.gg/wiki/API_ScriptRegion_IsRectValid for more details)
- After initial spinup, our PRD anchor is anchored to NamePlate1 (or something that's attached to it, depending on user's addons). Unfortunately for us, Blizzard in their extremely finite wisdom decided to make NamePlate1 a restricted region. Thus, calls to GetRect & friends on any frame in its anchor family will error. This went unnoticed because we explicitly suppress errors on this to avoid user shenanigans breaking WeakAuras. Fix this problem by checking if GetLeft errors: if so, temporarily reanchor the dynamic group to UIParent before computing a new rect for it.

Fixes #5023
