### PR TITLE
AuraBar: add some alias textures, and option to use texture picker

### DIFF
--- a/WeakAuras/RegionTypes/AuraBar.lua
+++ b/WeakAuras/RegionTypes/AuraBar.lua
@@ -404,10 +404,10 @@ local barPrototype = {
 
           local texture = self.additionalBarsTextures and self.additionalBarsTextures[index];
           if texture then
-            local texturePath = SharedMedia:Fetch("statusbar", texture) or ""
-            extraTexture:SetTexture(texturePath, extraTextureWrapMode, extraTextureWrapMode)
+            local texturePath = SharedMedia:Fetch("statusbar_atlas", texture) or SharedMedia:Fetch("statusbar", texture) or ""
+            Private.SetTextureOrAtlas(extraTexture, texturePath, extraTextureWrapMode, extraTextureWrapMode)
           else
-            extraTexture:SetTexture(self:GetStatusBarTexture(), extraTextureWrapMode, extraTextureWrapMode);
+            Private.SetTextureOrAtlas(extraTexture, self:GetStatusBarTexture(), extraTextureWrapMode, extraTextureWrapMode)
           end
 
           local xOffset = 0;
@@ -553,10 +553,10 @@ local barPrototype = {
 
   -- Blizzard like SetStatusBarTexture
   ["SetStatusBarTexture"] = function(self, texture)
-    self.fg:SetTexture(texture);
-    self.bg:SetTexture(texture);
+    Private.SetTextureOrAtlas(self.fg, texture)
+    Private.SetTextureOrAtlas(self.bg, texture)
     for index, extraTexture in ipairs(self.extraTextures) do
-      extraTexture:SetTexture(texture, extraTextureWrapMode, extraTextureWrapMode);
+      Private.SetTextureOrAtlas(extraTexture, texture, extraTextureWrapMode, extraTextureWrapMode)
     end
   end,
 
@@ -1210,7 +1210,12 @@ local function modify(parent, region, data)
   end
 
   -- Update texture settings
-  local texturePath = SharedMedia:Fetch("statusbar", data.texture) or "";
+  local texturePath
+  if data.textureSource == "Picker" then
+    texturePath = data.textureInput or ""
+  else
+    texturePath = SharedMedia:Fetch("statusbar_atlas", data.texture) or SharedMedia:Fetch("statusbar", data.texture) or ""
+  end
   bar:SetStatusBarTexture(texturePath);
   bar:SetBackgroundColor(data.backgroundColor[1], data.backgroundColor[2], data.backgroundColor[3], data.backgroundColor[4]);
   -- Update spark settings

--- a/WeakAuras/Types.lua
+++ b/WeakAuras/Types.lua
@@ -3151,6 +3151,30 @@ LSM:Register("statusbar", "Thick Stripes", [[Interface\AddOns\WeakAuras\Media\Te
 LSM:Register("statusbar", "Thin Stripes", [[Interface\AddOns\WeakAuras\Media\Textures\Statusbar_Stripes_Thin]])
 LSM:Register("border", "Drop Shadow", [[Interface\AddOns\WeakAuras\Media\Textures\Border_DropShadow]])
 
+if PowerBarColor then
+  local function capitalizeFirstLetter(str)
+    -- Split the string into words separated by underscores
+    local words = {}
+    for word in string.gmatch(str, "[^_]+") do
+      table.insert(words, word)
+    end
+    -- Capitalize the first letter of each word
+    for i, word in ipairs(words) do
+      words[i] = word:sub(1, 1):upper() .. word:sub(2):lower()
+    end
+    return table.concat(words, " ")
+  end
+
+  for power, data in pairs(PowerBarColor) do
+    if type(power) == "string" and data.atlas then
+      local name = "Blizzard " .. capitalizeFirstLetter(power)
+      LSM:Register("statusbar_atlas", name, data.atlas)
+    elseif data.atlasElementName then
+      LSM:Register("statusbar_atlas", "Blizzard " .. data.atlasElementName, "UI-HUD-UnitFrame-Player-PortraitOff-Bar-" .. data.atlasElementName)
+    end
+  end
+end
+
 ---@type table<string, string>
 Private.duration_types = {
   seconds = L["Seconds"],

--- a/WeakAurasOptions/AceGUI-Widgets/WeakAurasStatusbarAtlasWidget.lua
+++ b/WeakAurasOptions/AceGUI-Widgets/WeakAurasStatusbarAtlasWidget.lua
@@ -1,0 +1,241 @@
+-- Widget is based on the AceGUIWidget-DropDown.lua supplied with AceGUI-3.0
+-- Original Widget created by Yssaril, modified by WeakAuras Team to handle Atlas
+
+local AceGUI = LibStub("AceGUI-3.0")
+local Media = LibStub("LibSharedMedia-3.0")
+
+local AGSMW = LibStub("AceGUISharedMediaWidgets-1.0")
+
+do
+	local widgetType = "WA_LSM30_StatusbarAtlas"
+	local widgetVersion = 1
+
+	local contentFrameCache = {}
+	local function ReturnSelf(self)
+		self:ClearAllPoints()
+		self:Hide()
+		self.check:Hide()
+		table.insert(contentFrameCache, self)
+	end
+
+	local function ContentOnClick(this, button)
+		local self = this.obj
+		self:Fire("OnValueChanged", this.text:GetText())
+		if self.dropdown then
+			self.dropdown = AGSMW:ReturnDropDownFrame(self.dropdown)
+		end
+	end
+
+	local function GetContentLine()
+		local frame
+		if next(contentFrameCache) then
+			frame = table.remove(contentFrameCache)
+		else
+			frame = CreateFrame("Button", nil, UIParent)
+				--frame:SetWidth(200)
+				frame:SetHeight(18)
+				frame:SetHighlightTexture([[Interface\QuestFrame\UI-QuestTitleHighlight]], "ADD")
+				frame:SetScript("OnClick", ContentOnClick)
+			local check = frame:CreateTexture("OVERLAY")
+				check:SetWidth(16)
+				check:SetHeight(16)
+				check:SetPoint("LEFT",frame,"LEFT",1,-1)
+				check:SetTexture("Interface\\Buttons\\UI-CheckBox-Check")
+				check:Hide()
+			frame.check = check
+			local bar = frame:CreateTexture("ARTWORK")
+				bar:SetHeight(16)
+				bar:SetPoint("LEFT",check,"RIGHT",1,0)
+				bar:SetPoint("RIGHT",frame,"RIGHT",-1,0)
+			frame.bar = bar
+			local text = frame:CreateFontString(nil,"OVERLAY","GameFontWhite")
+
+				local font, size = text:GetFont()
+				text:SetFont(font,size,"OUTLINE")
+
+				text:SetPoint("TOPLEFT", check, "TOPRIGHT", 3, 0)
+				text:SetPoint("BOTTOMRIGHT", frame, "BOTTOMRIGHT", -2, 0)
+				text:SetJustifyH("LEFT")
+				text:SetText("Test Test Test Test Test Test Test")
+			frame.text = text
+			frame.ReturnSelf = ReturnSelf
+		end
+		frame:Show()
+		return frame
+	end
+
+	local function OnAcquire(self)
+		self:SetHeight(44)
+		self:SetWidth(200)
+	end
+
+	local function OnRelease(self)
+		self:SetText("")
+		self:SetLabel("")
+		self:SetDisabled(false)
+
+		self.value = nil
+		self.list = nil
+		self.open = nil
+		self.hasClose = nil
+
+		self.frame:ClearAllPoints()
+		self.frame:Hide()
+	end
+
+	local function SetValue(self, value) -- Set the value to an item in the List.
+		if self.list then
+			self:SetText(value or "")
+		end
+		self.value = value
+	end
+
+	local function GetValue(self)
+		return self.value
+	end
+
+	local function SetList(self, list) -- Set the list of values for the dropdown (key => value pairs)
+    self.list = list or Media:HashTable("statusbar")
+	end
+
+
+	local function SetText(self, text) -- Set the text displayed in the box.
+		self.frame.text:SetText(text or "")
+		local statusbar = self.list[text] ~= text and self.list[text] or Media:Fetch('statusbar', text)
+		if type(statusbar) == "string" and C_Texture.GetAtlasInfo(statusbar) ~= nil then
+			self.bar:SetAtlas(statusbar)
+		else
+			self.bar:SetTexture(statusbar)
+		end
+	end
+
+	local function SetLabel(self, text) -- Set the text for the label.
+		self.frame.label:SetText(text or "")
+	end
+
+	local function AddItem(self, key, value) -- Add an item to the list.
+		self.list = self.list or {}
+		self.list[key] = value
+	end
+	local SetItemValue = AddItem -- Set the value of a item in the list. <<same as adding a new item>>
+
+	local function SetMultiselect(self, flag) end -- Toggle multi-selecting. <<Dummy function to stay inline with the dropdown API>>
+	local function GetMultiselect() return false end-- Query the multi-select flag. <<Dummy function to stay inline with the dropdown API>>
+	local function SetItemDisabled(self, key) end-- Disable one item in the list. <<Dummy function to stay inline with the dropdown API>>
+
+	local function SetDisabled(self, disabled) -- Disable the widget.
+		self.disabled = disabled
+		if disabled then
+			self.frame:Disable()
+		else
+			self.frame:Enable()
+		end
+	end
+
+	local function textSort(a,b)
+		return string.upper(a) < string.upper(b)
+	end
+
+	local sortedlist = {}
+	local function ToggleDrop(this)
+		local self = this.obj
+		if self.dropdown then
+			self.dropdown = AGSMW:ReturnDropDownFrame(self.dropdown)
+			AceGUI:ClearFocus()
+		else
+			AceGUI:SetFocus(self)
+			self.dropdown = AGSMW:GetDropDownFrame()
+			local width = self.frame:GetWidth()
+			self.dropdown:SetPoint("TOPLEFT", self.frame, "BOTTOMLEFT")
+			self.dropdown:SetPoint("TOPRIGHT", self.frame, "BOTTOMRIGHT", width < 160 and (160 - width) or 0, 0)
+			for k, v in pairs(self.list) do
+				sortedlist[#sortedlist+1] = k
+			end
+			table.sort(sortedlist, textSort)
+			for i, k in ipairs(sortedlist) do
+				local f = GetContentLine()
+				f.text:SetText(k)
+				--print(k)
+				if k == self.value then
+					f.check:Show()
+				end
+
+				local statusbar = self.list[k] ~= k and self.list[k] or Media:Fetch('statusbar',k)
+				if type(statusbar) == "string" and C_Texture.GetAtlasInfo(statusbar) ~= nil then
+					f.bar:SetAtlas(statusbar)
+				else
+					f.bar:SetTexture(statusbar)
+				end
+				f.obj = self
+				f.dropdown = self.dropdown
+				self.dropdown:AddFrame(f)
+			end
+			wipe(sortedlist)
+		end
+	end
+
+	local function ClearFocus(self)
+		if self.dropdown then
+			self.dropdown = AGSMW:ReturnDropDownFrame(self.dropdown)
+		end
+	end
+
+	local function OnHide(this)
+		local self = this.obj
+		if self.dropdown then
+			self.dropdown = AGSMW:ReturnDropDownFrame(self.dropdown)
+		end
+	end
+
+	local function Drop_OnEnter(this)
+		this.obj:Fire("OnEnter")
+	end
+
+	local function Drop_OnLeave(this)
+		this.obj:Fire("OnLeave")
+	end
+
+	local function Constructor()
+		local frame = AGSMW:GetBaseFrame()
+		local self = {}
+
+		self.type = widgetType
+		self.frame = frame
+		frame.obj = self
+		frame.dropButton.obj = self
+		frame.dropButton:SetScript("OnEnter", Drop_OnEnter)
+		frame.dropButton:SetScript("OnLeave", Drop_OnLeave)
+		frame.dropButton:SetScript("OnClick",ToggleDrop)
+		frame:SetScript("OnHide", OnHide)
+
+		local bar = frame:CreateTexture(nil, "OVERLAY")
+			bar:SetPoint("TOPLEFT", frame,"TOPLEFT",6,-25)
+			bar:SetPoint("BOTTOMRIGHT", frame,"BOTTOMRIGHT", -21, 5)
+			bar:SetAlpha(0.5)
+		self.bar = bar
+
+		self.alignoffset = 31
+
+		self.OnRelease = OnRelease
+		self.OnAcquire = OnAcquire
+		self.ClearFocus = ClearFocus
+		self.SetText = SetText
+		self.SetValue = SetValue
+		self.GetValue = GetValue
+		self.SetList = SetList
+		self.SetLabel = SetLabel
+		self.SetDisabled = SetDisabled
+		self.AddItem = AddItem
+		self.SetMultiselect = SetMultiselect
+		self.GetMultiselect = GetMultiselect
+		self.SetItemValue = SetItemValue
+		self.SetItemDisabled = SetItemDisabled
+		self.ToggleDrop = ToggleDrop
+
+		AceGUI:RegisterAsWidget(self)
+		return self
+	end
+
+	AceGUI:RegisterWidgetType(widgetType, Constructor, widgetVersion)
+
+end

--- a/WeakAurasOptions/WeakAurasOptions.toc
+++ b/WeakAurasOptions/WeakAurasOptions.toc
@@ -100,3 +100,4 @@ AceGUI-Widgets\AceGUIWidget-WeakAurasMiniTalent_Dragonflight.lua
 AceGUI-Widgets\AceGUIWidget-WeakAurasScrollArea.lua
 AceGUI-Widgets\AceGUIWidget-WeakAurasInputFocus.lua
 AceGUI-Widgets\AceGuiWidget-WeakAurasMediaSound.lua
+AceGUI-Widgets\WeakAurasStatusbarAtlasWidget.lua

--- a/WeakAurasOptions/WeakAurasOptions_Cata.toc
+++ b/WeakAurasOptions/WeakAurasOptions_Cata.toc
@@ -100,3 +100,4 @@ AceGUI-Widgets\AceGUIWidget-WeakAurasMiniTalent_Cata.lua
 AceGUI-Widgets\AceGUIWidget-WeakAurasScrollArea.lua
 AceGUI-Widgets\AceGUIWidget-WeakAurasInputFocus.lua
 AceGUI-Widgets\AceGuiWidget-WeakAurasMediaSound.lua
+AceGUI-Widgets\WeakAurasStatusbarAtlasWidget.lua

--- a/WeakAurasOptions/WeakAurasOptions_Vanilla.toc
+++ b/WeakAurasOptions/WeakAurasOptions_Vanilla.toc
@@ -98,3 +98,4 @@ AceGUI-Widgets\AceGUIWidget-WeakAurasSpinBox.lua
 AceGUI-Widgets\AceGUIWidget-WeakAurasScrollArea.lua
 AceGUI-Widgets\AceGUIWidget-WeakAurasInputFocus.lua
 AceGUI-Widgets\AceGuiWidget-WeakAurasMediaSound.lua
+AceGUI-Widgets\WeakAurasStatusbarAtlasWidget.lua

--- a/WeakAurasOptions/WeakAurasOptions_Wrath.toc
+++ b/WeakAurasOptions/WeakAurasOptions_Wrath.toc
@@ -99,3 +99,4 @@ AceGUI-Widgets\AceGUIWidget-WeakAurasMiniTalent_Wrath.lua
 AceGUI-Widgets\AceGUIWidget-WeakAurasScrollArea.lua
 AceGUI-Widgets\AceGUIWidget-WeakAurasInputFocus.lua
 AceGUI-Widgets\AceGuiWidget-WeakAurasMediaSound.lua
+AceGUI-Widgets\WeakAurasStatusbarAtlasWidget.lua


### PR DESCRIPTION
## Screenshots
![image](https://github.com/WeakAuras/WeakAuras2/assets/189656/cf9832cc-7974-4f19-bc9e-9e35405d5618)
![image](https://github.com/WeakAuras/WeakAuras2/assets/189656/5c84aa53-6a19-4d1c-b69d-3aa3dba57e95)

classic sod and cataclysm:
![image](https://github.com/WeakAuras/WeakAuras2/assets/189656/ef9072b8-69a1-4556-874a-6aa426b0314c)

dragonflight:
![image](https://github.com/WeakAuras/WeakAuras2/assets/189656/be491c30-44bf-4ebb-9764-d9a8a685eaf0)

## What could be done differently

An other possibility is to not add these aliases to LSM dropdown, and in the Texture Picker widget make a curated list of usable textures, but i don't like to add a list to maintain manually, and i don't believe average user explore the texture picker much (as i don't see much users take advantage of the model subregion)

## Notes

- WeakAurasStatusbarAtlasWidget.lua is almost a 1:1 copy of LSM30_Statusbar widget, only difference is the Atlas test for using SetAtlas in 2 places

- Funkeh raised concern on discord about mixing 2 types in the values, but we do that already with Private.SetTextureOrAtlas

- The texture picker option make auraBar intersect some functionalities with progressTexture, bonus is i think users naturally go to auraBar when they want a progress bar, it support spark and ticks
