### PR TITLE
always ReAnchor() if isRestricted, not just if numVisible > 0

### DIFF
--- a/WeakAuras/RegionTypes/DynamicGroup.lua
+++ b/WeakAuras/RegionTypes/DynamicGroup.lua
@@ -1538,7 +1538,7 @@ local function modify(parent, region, data)
       Private.StartProfileAura(data.id)
       local numVisible, minX, maxX, maxY, minY = 0, nil, nil, nil, nil
       local isRestricted = region:IsAnchoringRestricted()
-      if isRestricted then
+      if isRestricted and not WeakAuras.IsOptionsOpen() then
         -- workaround for restricted anchor families (mostly PRD)
         -- if region is in a restricted anchor family, we're not allowed to get the rect of its children
         -- and via Blizzard's extremely finite wisdom, the personal resource display is one such restricted family
@@ -1585,14 +1585,13 @@ local function modify(parent, region, data)
             self.background:SetPoint("TOPRIGHT", region, "BOTTOMLEFT", maxX + data.borderOffset - regionLeft, maxY + data.borderOffset - regionBottom)
           end
         end
-        if isRestricted then
-          self:ReAnchor()
-        end
       else
         self:Hide()
       end
       if WeakAuras.IsOptionsOpen() then
         Private.OptionsFrame().moversizer:ReAnchor()
+      elseif isRestricted then
+        self:ReAnchor()
       end
       Private.StopProfileSystem("dynamicgroup")
       Private.StopProfileAura(data.id)


### PR DESCRIPTION
otherwise the group gets 'stuck' on UIParent(CENTER) if it ever collapses due to 0 active children
Also, prevent all of this behavior during IsOptionsOpen, to avoid any potential edges case with the moversizer
Fixes #5065
