### PR TITLE
be more careful about keeping nameSource accurate

### DIFF
--- a/WeakAurasOptions/AuthorOptions.lua
+++ b/WeakAurasOptions/AuthorOptions.lua
@@ -1476,6 +1476,8 @@ local function up(data, options, index)
         local dereferencedParent = parent.references[id].options[parent.references[id].index]
         if dereferencedParent.nameSource == optionID then
           dereferencedParent.nameSource = optionID - 1
+        elseif dereferencedParent.nameSource == optionID - 1 then
+          dereferencedParent.nameSource = optionID
         end
       end
       OptionsPrivate.MoveCollapseDataUp(id, "author", path)
@@ -1505,6 +1507,8 @@ local function down(data, options, index)
         local dereferencedParent = parent.references[id].options[parent.references[id].index]
         if dereferencedParent.nameSource == optionID then
           dereferencedParent.nameSource = optionID + 1
+        elseif dereferencedParent.nameSource == optionID + 1 then
+          dereferencedParent.nameSource = optionID
         end
       end
       local childOptions = optionData.options


### PR DESCRIPTION
we already updated parentOption.nameSource when clicking up/down on the name source option, but that's not the only way to change the index of the name source. notably, moving an adjacent child option up or down can do can also move the name source, effectively usurping it. if the "new" name source isn't actually a valid name source (e.g. it's a toggle option), then WeakAuras correctly barfs on the garbage data.

Fixes #5074