### PR TITLE
add build date to pr comment & edit isntead of recreate

### DIFF
--- a/.github/pr-commenter.yml
+++ b/.github/pr-commenter.yml
@@ -1,5 +1,5 @@
 comment:
-  on-update: recreate
+  on-update: edit
 
   glob-options:
     dot: true
@@ -8,5 +8,8 @@ comment:
       files:
         - '**'
       body: |
-        {{#build_id}}An experimental build of WeakAuras with the changes in this pull request is available [here](https://nightly.link/{{repository}}/actions/artifacts/{{build_id}}.zip).{{/build_id}}
+        {{#build_id}}
+          An experimental build of WeakAuras with the changes in this pull request is available [here](https://nightly.link/{{repository}}/actions/artifacts/{{build_id}}.zip).
+          Build Time: {{datestr}}
+        {{/build_id}}
         {{^build_id}}Experimental build was unsuccessful. See the logs for details.{{/build_id}}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -59,12 +59,16 @@ jobs:
     needs: [permission_check, build]
     if: ${{ needs.permission_check.outputs.require-result == 'true' && needs.build.result == 'success' && contains(github.event.pull_request.labels.*.name, '🆕 Feature Preview')}}
     steps:
+      - id: datestr
+        run: echo "datestr=$(date)" >> $GITHUB_OUTPUT
+
       - uses: exercism/pr-commenter-action@v1.5.1
         with:
           github-token: ${{ github.token }}
           config-file: ".github/pr-commenter.yml"
           template-variables: |
             {
+              "datestr": "${{ steps.datestr.outputs.datestr }}",
               "repository": "${{ github.repository }}",
               "build_id": "${{ needs.build.outputs.artifact-id }}",
               "run_id": "${{ github.run_id }}"


### PR DESCRIPTION
slightly less spammy this way; the bot will only comment once, and then edit that comment as new builds become available.

since this makes it not as obvious when the nightly link changes, i added a timestamp to the comment.