### PR TITLE
hide dynFrame if combat starts with living threads

### DIFF
--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -4377,6 +4377,15 @@ do
       end
     end
   end);
+  dynFrame.frame:RegisterEvent("PLAYER_REGEN_ENABLED")
+  dynFrame.frame:RegisterEvent("PLAYER_REGEN_DISABLED")
+  dynFrame.frame:SetScript("OnEvent", function(self, event)
+    if event == "PLAYER_REGEN_ENABLED" and self:IsShown() then
+      self:Hide()
+    elseif event == "PLAYER_REGEN_DISABLED" and not self:IsShown() and dynFrame.size > 0 then
+      self:Show()
+    end
+  end)
 end
 
 Private.dynFrame = dynFrame;

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -1668,8 +1668,8 @@ local function scanForLoadsImpl(toCheck, event, arg1, ...)
   local encounter_id = WeakAuras.CurrentEncounter and WeakAuras.CurrentEncounter.id or 0
 
   if (event == "ENCOUNTER_START") then
-    encounter_id = tonumber (arg1)
-    CreateEncounterTable (encounter_id)
+    encounter_id = tonumber(arg1)
+    CreateEncounterTable(encounter_id)
   elseif (event == "ENCOUNTER_END") then
     encounter_id = 0
     DestroyEncounterTable()


### PR DESCRIPTION
nothing that we put into dynFrame threads is meant for in-combat execution anyways, so to avoid random unexpectedly short timeouts, pause execution if combat starts, and resume after combat ends.

There's potential for WeakAuras to be 'broken' during that combat session (due to dynamic groups being Pause()'d), but we probably couldn't have unbroken it given that ResumeAllDynamicGroups is too costly to call during combat lockdown without risking a timeout.

Fixes #4967 (or at least, reduces its likelihood)