### PR TITLE
Reputation trigger fixes

### DIFF
--- a/WeakAuras/Compatibility.lua
+++ b/WeakAuras/Compatibility.lua
@@ -71,5 +71,7 @@ Private.ExecEnv.GetFactionDataByID = C_Reputation.GetFactionDataByID or function
     isAccountWide = nil
   }
 end
-Private.ExecEnv.ExpandAllFactionHeaders = C_Reputation.ExpandAllFactionHeaders or ExpandAllFactionHeaders
+Private.ExecEnv.ExpandFactionHeader = C_Reputation.ExpandFactionHeader or ExpandFactionHeader
 Private.ExecEnv.CollapseFactionHeader = C_Reputation.CollapseFactionHeader or CollapseFactionHeader
+Private.ExecEnv.AreLegacyReputationsShown = C_Reputation.AreLegacyReputationsShown or function() return true end
+Private.ExecEnv.GetReputationSortType = C_Reputation.GetReputationSortType or function() return 0 end;

--- a/WeakAuras/Types.lua
+++ b/WeakAuras/Types.lua
@@ -1635,15 +1635,34 @@ local function InitializeReputations()
   ---@type table<string, boolean>
   Private.reputations_headers = {}
 
+  -- Ensure all factions are shown by adjusting filters
+  local showLegacy = true
+  if not Private.ExecEnv.AreLegacyReputationsShown() then
+    showLegacy = false
+    C_Reputation.SetLegacyReputationsShown(true)
+  end
+  local sortType = 0
+  if Private.ExecEnv.GetReputationSortType() > 0 then
+    sortType = Private.ExecEnv.GetReputationSortType()
+    C_Reputation.SetReputationSortType(0)
+  end
+
+  -- Dynamic expansion of all collapsed headers
   local collapsed = {}
-  for i = 1, Private.ExecEnv.GetNumFactions() do
-    local factionData = Private.ExecEnv.GetFactionDataByIndex(i)
-    if factionData.isCollapsed then
-      collapsed[factionData.name] = true
+  local keepExpanding = true
+  while keepExpanding do
+    keepExpanding = false
+    for i = Private.ExecEnv.GetNumFactions(), 1, -1 do
+      local factionData = Private.ExecEnv.GetFactionDataByIndex(i)
+      if factionData.isHeader and factionData.isCollapsed then
+        Private.ExecEnv.ExpandFactionHeader(i)
+        collapsed[factionData.name] = true
+        keepExpanding = true
+      end
     end
   end
 
-  Private.ExecEnv.ExpandAllFactionHeaders()
+  -- Process all faction data
   for i = 1, Private.ExecEnv.GetNumFactions() do
     local factionData = Private.ExecEnv.GetFactionDataByIndex(i)
     if factionData.currentStanding > 0 or not factionData.isHeader then
@@ -1660,11 +1679,20 @@ local function InitializeReputations()
     end
   end
 
+  -- Collapse headers back to their original state
   for i = Private.ExecEnv.GetNumFactions(), 1, -1 do
     local factionData = Private.ExecEnv.GetFactionDataByIndex(i)
     if collapsed[factionData.name] then
       Private.ExecEnv.CollapseFactionHeader(i)
     end
+  end
+
+  -- Restore filters if they were changed
+  if not showLegacy then
+    C_Reputation.SetLegacyReputationsShown(false)
+  end
+  if sortType > 0 then
+    C_Reputation.SetReputationSortType(sortType)
   end
 end
 

--- a/WeakAuras/Types.lua
+++ b/WeakAuras/Types.lua
@@ -1649,17 +1649,14 @@ local function InitializeReputations()
 
   -- Dynamic expansion of all collapsed headers
   local collapsed = {}
-  local keepExpanding = true
-  while keepExpanding do
-    keepExpanding = false
-    for i = Private.ExecEnv.GetNumFactions(), 1, -1 do
-      local factionData = Private.ExecEnv.GetFactionDataByIndex(i)
-      if factionData.isHeader and factionData.isCollapsed then
-        Private.ExecEnv.ExpandFactionHeader(i)
-        collapsed[factionData.name] = true
-        keepExpanding = true
-      end
+  local index = 1
+  while index <= Private.ExecEnv.GetNumFactions() do
+    local factionData = Private.ExecEnv.GetFactionDataByIndex(index)
+    if factionData.isHeader and factionData.isCollapsed then
+      Private.ExecEnv.ExpandFactionHeader(index)
+      collapsed[factionData.name] = true
     end
+    index = index + 1
   end
 
   -- Process all faction data


### PR DESCRIPTION
Ensures we collect all player factions regardlesss of display settings.

`ExpandAllFactionHeaders()` does not correctly expand all faction headers. If subheaders are present it would remove all factions under the subheader which gives us an incomplete list. This PR fixes that by expanding headers individually.