### PR TITLE
Smallfix

### DIFF
--- a/WeakAurasOptions/OptionsFrames/OptionsFrame.lua
+++ b/WeakAurasOptions/OptionsFrames/OptionsFrame.lua
@@ -917,14 +917,14 @@ function OptionsPrivate.CreateFrame()
       time = currentTime,
     }
 
-    if event == "OnEditFocusGained" or not dynamicTextCodesFrame:IsShown() then
+    if event == "OnEnterPressed" then
+      dynamicTextCodesFrame:Hide()
+    elseif event == "OnEditFocusGained" or not dynamicTextCodesFrame:IsShown() then
       dynamicTextCodesFrame:Show()
       if OptionsPrivate.currentDynamicTextInput ~= widget then
         OptionsPrivate.UpdateTextReplacements(dynamicTextCodesFrame, data)
       end
       OptionsPrivate.currentDynamicTextInput = widget
-    elseif event == "OnEnterPressed" then
-      dynamicTextCodesFrame:Hide()
     elseif not dynamicTextCodesFrame:IsMouseOver() then -- Prevents hiding when clicking inside the frame
       dynamicTextCodesFrame:Hide()
     end


### PR DESCRIPTION
```lua
attempt to index field 'currentDynamicTextInput' (a nil value)
```
error occured after tweaks in #5226.

Reproduce:
* Click subtext input field -> OnEditFocusGained -> dynamic text frame shows
* type something and click enter -> OnEditFocusLost -> frame hides -> OnEnterPressed -> frame shows -> `currentDynamicTextInput` is set to `nil`
* click a dynamic text code -> error