### PR TITLE
Tinyfix

### DIFF
--- a/WeakAuras/SubRegionTypes/Model.lua
+++ b/WeakAuras/SubRegionTypes/Model.lua
@@ -27,7 +27,7 @@ local default = function(parentType)
     model_st_us = 40,
 
     model_fileId = "235338",
-    model_path = "spells/arcanepower_state_chest.m2",
+    model_path = "environments/stars/nexusraid_runeeffects_nebula.m2",
     bar_model_clip = true
   }
 end

--- a/WeakAuras/SubRegionTypes/Model.lua
+++ b/WeakAuras/SubRegionTypes/Model.lua
@@ -194,9 +194,7 @@ local funcs = {
 
 local function create()
   local subRegion = CreateFrame("Frame", nil, UIParent)
-  if not WeakAuras.IsTWW() then
-    subRegion:SetClipsChildren(true)
-  end
+  subRegion:SetClipsChildren(true)
 
   for k, v in pairs(funcs) do
     subRegion[k] = v


### PR DESCRIPTION
https://github.com/WeakAuras/WeakAuras2/commit/a9365a0dafd77c5b89dae10290359e81565f80c5 doesn't set `subRegion:SetClipsChildren(true)` on TWW, while trying to fix https://github.com/WeakAuras/WeakAuras2/issues/5253 it seems restoring this is the fix, but you did it for a reason so i'm unsure it's correct.