### PR TITLE
Add percentage support for GenericTrigger trigger.remaining

### DIFF
--- a/WeakAuras/GenericTrigger.lua
+++ b/WeakAuras/GenericTrigger.lua
@@ -211,7 +211,7 @@ function TestForMultiSelect(trigger, arg)
 end
 
 local function singleTest(arg, trigger, name, value, operator, use_exact)
-  local number = tonumber(value)
+  local number, numberType = Private.ParseNumber(value)
   if(arg.type == "tristate") then
     return TestForTriState(trigger, arg);
   elseif(arg.type == "multiselect") then
@@ -235,7 +235,11 @@ local function singleTest(arg, trigger, name, value, operator, use_exact)
   elseif (arg.type == "string" or arg.type == "select") then
     return "(".. name .." and "..name.."==" ..(number or ("\""..(tostring(value) or "").."\""))..")";
   elseif (arg.type == "number") then
-    return "(".. name .." and "..name..(operator or "==")..(number or 0) ..")";
+    if numberType == "percent" then
+      return "(duration == 0 or ("..name.." and "..name..(operator or "==")..(number or 0).."* duration".."))";
+    else
+      return "(".. name .." and "..name..(operator or "==")..(number or 0) ..")";
+    end
   else
     -- Should be unused
     return "(".. name .." and "..name..(operator or "==")..(number or ("\""..(tostring(value) or 0).."\""))..")";

--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -5937,7 +5937,6 @@ Private.event_prototypes = {
           end
         ]];
         ret = ret..ret2:format(timeRemaining or 0, itemName);
-
       end
       return ret:format(itemName,
                         trigger.use_showgcd and "true" or "false",

--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -6141,7 +6141,6 @@ Private.event_prototypes = {
         ]]
         if timeType == "percent" then
           ret2 = ret2..[[
-
             local remainingCheck = %s * (duration or 0);
           ]]
         else
@@ -6157,7 +6156,6 @@ Private.event_prototypes = {
           end
         ]];
         ret = ret..ret2:format(timeRemaining or 0, trigger.itemSlot or 0);
-
       end
       return ret:format(trigger.use_showgcd and "true" or "false",
                         trigger.itemSlot or "0",
@@ -6528,11 +6526,9 @@ Private.event_prototypes = {
     end,
     init = function(trigger)
       local timeRemaining, timeType = Private.ParseNumber(trigger.remaining or 0)
-
         local ret = [=[
           local inverse = %s;
           local hand = %q;
-
           local duration, expirationTime, name, icon = WeakAuras.GetSwingTimerInfo(hand)
           ]=]
           if timeType == "percent" then
@@ -6551,8 +6547,6 @@ Private.event_prototypes = {
               Private.ExecEnv.ScheduleScan(expirationTime - triggerRemaining, "SWING_TIMER_UPDATE")
             end
           ]];
-
-
       return ret:format(
         (trigger.use_inverse and "true" or "false"),
         trigger.hand or "main",
@@ -9493,24 +9487,18 @@ Private.event_prototypes = {
         local stage = 0
         local stagesData = {}
 
-
         local show, expirationTime, castType, spell, icon, startTime, endTime, interruptible, spellId, remaining, _, stageTotal, duration
         spell, _, icon, startTime, endTime, _, _, interruptible, spellId = WeakAuras.UnitCastingInfo(unit)
-
-
         if spell then
           duration = ((endTime or 0) - (startTime or 0))/1000
           castType = "cast"
         else
           spell, _, icon, startTime, endTime, _, interruptible, spellId, _, stageTotal = WeakAuras.UnitChannelInfo(unit)
-
-
           if spell then
             duration = ((endTime or 0) - (startTime or 0))/1000
             castType = "channel"
             if stageTotal and stageTotal > 0 then
               empowered = true
-
               local lastFinish = 0
               for i = 1, stageTotal do
                 stagesData[i] = {

--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -6141,11 +6141,12 @@ Private.event_prototypes = {
         ]]
         if timeType == "percent" then
           ret2 = ret2..[[
-          local remainingCheck = %s;
+
+            local remainingCheck = %s * (duration or 0);
           ]]
         else
           ret2 = ret2..[[
-          local remainingCheck = %s * (duration or 0);
+            local remainingCheck = %s;
           ]]
         end
         ret2 = ret2..[[

--- a/WeakAurasOptions/LoadOptions.lua
+++ b/WeakAurasOptions/LoadOptions.lua
@@ -16,6 +16,7 @@ local getAll = OptionsPrivate.commonOptions.CreateGetAll("load")
 local setAll = OptionsPrivate.commonOptions.CreateSetAll("load", getAll)
 
 local ValidateNumeric = WeakAuras.ValidateNumeric;
+local ValidateNumericOrPercent = WeakAuras.ValidateNumericOrPercent;
 
 local spellCache = WeakAuras.spellCache;
 
@@ -461,7 +462,7 @@ function OptionsPrivate.ConstructOptions(prototype, data, startorder, triggernum
           options[name..suffix] = {
             type = "input",
             width = arg.noOperator and WeakAuras.normalWidth or WeakAuras.halfWidth,
-            validate = ValidateNumeric,
+            validate = (name == "remaining" and ValidateNumericOrPercent) or ValidateNumeric,
             name = arg.display,
             order = order,
             hidden = disabled or hidden,


### PR DESCRIPTION
Dynamic remaining time for all GenericTrigger functions based on duration. Makes rotational auras easier to maintain and reduces complexity for auras tracking spells with cooldowns that varies depending on talents. This is something I use for a ton of auras with custom triggers and would appreciate if it was  available via standard triggers :)