### PR TITLE
Fix incorrect mount form id and add balance druid premade forms

### DIFF
--- a/WeakAurasTemplates/TriggerTemplatesData.lua
+++ b/WeakAurasTemplates/TriggerTemplatesData.lua
@@ -5305,6 +5305,7 @@ for i = 1, 4 do
       }}}
   });
 end
+-- Feral/Guardian/Restoration druid forms
 for j, id in ipairs({5487, 768, 783, 114282, 210053}) do
   local title, _, icon = GetSpellInfo(id)
   if title then

--- a/WeakAurasTemplates/TriggerTemplatesData.lua
+++ b/WeakAurasTemplates/TriggerTemplatesData.lua
@@ -5305,10 +5305,10 @@ for i = 1, 4 do
       }}}
   });
 end
-for j, id in ipairs({5487, 768, 783, 114282, 1394966}) do
+for j, id in ipairs({5487, 768, 783, 114282, 210053}) do
   local title, _, icon = GetSpellInfo(id)
   if title then
-    for i = 1, 4 do
+    for i = 2, 4 do
       tinsert(templates.class.DRUID[i][resourceSection].args, {
         title = title,
         icon = icon,
@@ -5325,6 +5325,27 @@ for j, id in ipairs({5487, 768, 783, 114282, 1394966}) do
       });
     end
   end
+end
+
+-- Balance druid forms
+for j, id in ipairs({5487, 768, 783, 24858, 114282, 210053}) do
+  local title, _, icon = GetSpellInfo(id)
+  if title then
+      tinsert(templates.class.DRUID[1][resourceSection].args, {
+        title = title,
+        icon = icon,
+        triggers = {
+          [1] = {
+            trigger = {
+              type = WeakAuras.GetTriggerCategoryFor("Stance/Form/Aura"),
+              event = "Stance/Form/Aura",
+              use_form = true,
+              form = { single = j }
+            }
+          }
+        }
+      });
+    end
 end
 
 -- Astral Power

--- a/WeakAurasTemplates/TriggerTemplatesData.lua
+++ b/WeakAurasTemplates/TriggerTemplatesData.lua
@@ -5305,6 +5305,27 @@ for i = 1, 4 do
       }}}
   });
 end
+
+-- Balance druid forms
+for j, id in ipairs({5487, 768, 783, 24858, 114282, 210053}) do
+  local title, _, icon = GetSpellInfo(id)
+  if title then
+      tinsert(templates.class.DRUID[1][resourceSection].args, {
+        title = title,
+        icon = icon,
+        triggers = {
+          [1] = {
+            trigger = {
+              type = WeakAuras.GetTriggerCategoryFor("Stance/Form/Aura"),
+              event = "Stance/Form/Aura",
+              use_form = true,
+              form = { single = j }
+            }
+          }
+        }
+      });
+    end
+end
 -- Feral/Guardian/Restoration druid forms
 for j, id in ipairs({5487, 768, 783, 114282, 210053}) do
   local title, _, icon = GetSpellInfo(id)
@@ -5328,26 +5349,6 @@ for j, id in ipairs({5487, 768, 783, 114282, 210053}) do
   end
 end
 
--- Balance druid forms
-for j, id in ipairs({5487, 768, 783, 24858, 114282, 210053}) do
-  local title, _, icon = GetSpellInfo(id)
-  if title then
-      tinsert(templates.class.DRUID[1][resourceSection].args, {
-        title = title,
-        icon = icon,
-        triggers = {
-          [1] = {
-            trigger = {
-              type = WeakAuras.GetTriggerCategoryFor("Stance/Form/Aura"),
-              event = "Stance/Form/Aura",
-              use_form = true,
-              form = { single = j }
-            }
-          }
-        }
-      });
-    end
-end
 
 -- Astral Power
 tinsert(templates.class.DRUID[1][resourceSection].args, createSimplePowerTemplate(8));

--- a/WeakAurasTemplates/TriggerTemplatesData.lua
+++ b/WeakAurasTemplates/TriggerTemplatesData.lua
@@ -5306,32 +5306,11 @@ for i = 1, 4 do
   });
 end
 
--- Balance druid forms
-for j, id in ipairs({5487, 768, 783, 24858, 114282, 210053}) do
-  local title, _, icon = GetSpellInfo(id)
-  if title then
-      tinsert(templates.class.DRUID[1][resourceSection].args, {
-        title = title,
-        icon = icon,
-        triggers = {
-          [1] = {
-            trigger = {
-              type = WeakAuras.GetTriggerCategoryFor("Stance/Form/Aura"),
-              event = "Stance/Form/Aura",
-              use_form = true,
-              form = { single = j }
-            }
-          }
-        }
-      });
-    end
-end
-
--- Feral/Guardian/Restoration druid forms
-for j, id in ipairs({5487, 768, 783, 114282, 210053}) do
-  local title, _, icon = GetSpellInfo(id)
-  if title then
-    for i = 2, 4 do
+for i = 1, 4 do
+  local ids = i == 1 and {5487, 768, 783, 24858, 114282, 210053} or {5487, 768, 783, 114282, 210053}
+  for j, id in ipairs(ids) do
+    local title, _, icon = GetSpellInfo(id)
+    if title then
       tinsert(templates.class.DRUID[i][resourceSection].args, {
         title = title,
         icon = icon,
@@ -5345,7 +5324,7 @@ for j, id in ipairs({5487, 768, 783, 114282, 210053}) do
             }
           }
         }
-      });
+      })
     end
   end
 end

--- a/WeakAurasTemplates/TriggerTemplatesData.lua
+++ b/WeakAurasTemplates/TriggerTemplatesData.lua
@@ -5326,6 +5326,7 @@ for j, id in ipairs({5487, 768, 783, 24858, 114282, 210053}) do
       });
     end
 end
+
 -- Feral/Guardian/Restoration druid forms
 for j, id in ipairs({5487, 768, 783, 114282, 210053}) do
   local title, _, icon = GetSpellInfo(id)
@@ -5348,7 +5349,6 @@ for j, id in ipairs({5487, 768, 783, 114282, 210053}) do
     end
   end
 end
-
 
 -- Astral Power
 tinsert(templates.class.DRUID[1][resourceSection].args, createSimplePowerTemplate(8));


### PR DESCRIPTION

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
- Incorrect mount form id was changed in shadowlands
- balance druid missing moonkin form option

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Be each of the (non balance) druid specs, create a premade aura. The mount form is now listed
![image](https://github.com/user-attachments/assets/6459f6cf-0714-449c-b4ca-e8b08c1b99ee)

The correct trigger is made
![image](https://github.com/user-attachments/assets/6d3deac5-b1c7-4e3a-946e-1fdc381072c6)

- [x] Be balance spec, create a premade aura. The mount form and moonkin form is now listed. The correct triggers are created as above
![image](https://github.com/user-attachments/assets/4a36d7b4-8c68-4602-81ca-ebcc58a076ff)


## Checklist
<!-- These can be checked off after the pull request is submitted, in case you want discussion before they are completely ready -->

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings

<!-- Is there any additional work that needs to be done? If so, add it to the above list -->
Testing this has unveiled one issue (#5310 ), which i will also document - the form list does not update after spec change, only after reloading ui
![image](https://github.com/user-attachments/assets/d4a0eb4d-2c56-4123-88d1-06b7365c0041)


