### PR TITLE
Fix percent progress validation and parsing

### DIFF
--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -984,8 +984,8 @@ end
 ---@return boolean result
 function WeakAuras.ValidateNumericOrPercent(info, val)
   if val ~= nil and val ~= "" then
-    local percent = string.match(val, "(%d+)%%")
-    local number = percent and tonumber(percent) or tonumber(val)
+    local percent, count = val:gsub("%%", " ", 1)
+    local number = count == 1 and tonumber(percent) or tonumber(val)
     if(not number or number >= 2^31) then
       return false;
     end

--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -984,8 +984,8 @@ end
 ---@return boolean result
 function WeakAuras.ValidateNumericOrPercent(info, val)
   if val ~= nil and val ~= "" then
-    local percent, count = val:gsub("%%", " ", 1)
-    local number = count == 1 and tonumber(percent) or tonumber(val)
+    local index = val:find("%% *$")
+    local number = index and tonumber(val:sub(1, index-1)) or tonumber(val)
     if(not number or number >= 2^31) then
       return false;
     end

--- a/WeakAuras/RegionTypes/RegionPrototype.lua
+++ b/WeakAuras/RegionTypes/RegionPrototype.lua
@@ -348,8 +348,8 @@ local function SetProgressSource(self, progressSource)
 end
 
 local function SetAdjustedMin(self, adjustedMin)
-  local percent = string.match(adjustedMin, "(%d+)%%")
-  if percent then
+  local percent, count = adjustedMin:gsub("%%", " ", 1)
+  if count == 1 then
     self.adjustedMinRelPercent = tonumber(percent) / 100
     self.adjustedMin = nil
   else
@@ -360,8 +360,8 @@ local function SetAdjustedMin(self, adjustedMin)
 end
 
 local function SetAdjustedMax(self, adjustedMax)
-  local percent = string.match(adjustedMax, "(%d+)%%")
-  if percent then
+  local percent, count = adjustedMax:gsub("%%", " ", 1)
+  if count == 1 then
     self.adjustedMaxRelPercent = tonumber(percent) / 100
   else
     self.adjustedMax = tonumber(adjustedMax)

--- a/WeakAuras/RegionTypes/RegionPrototype.lua
+++ b/WeakAuras/RegionTypes/RegionPrototype.lua
@@ -348,8 +348,9 @@ local function SetProgressSource(self, progressSource)
 end
 
 local function SetAdjustedMin(self, adjustedMin)
-  local percent, count = adjustedMin:gsub("%%", " ", 1)
-  if count == 1 then
+  local index = adjustedMin:find("%% *$")
+  if index then
+    local percent = adjustedMin:sub(1, index-1)
     self.adjustedMinRelPercent = tonumber(percent) / 100
     self.adjustedMin = nil
   else
@@ -360,8 +361,9 @@ local function SetAdjustedMin(self, adjustedMin)
 end
 
 local function SetAdjustedMax(self, adjustedMax)
-  local percent, count = adjustedMax:gsub("%%", " ", 1)
-  if count == 1 then
+  local index = adjustedMax:find("%% *$")
+  if index then
+    local percent = adjustedMax:sub(1, index-1)
     self.adjustedMaxRelPercent = tonumber(percent) / 100
   else
     self.adjustedMax = tonumber(adjustedMax)


### PR DESCRIPTION
# Description

### Current implementation

The progress settings for Set Minimum Progress and Set Maximum Progress have a special validation and parsing function which is too basic and quite broken.

Current implementation of the parser is the regex `"(%d+)%%"` - digits followed by a literal %, first such match in the string.

### Examples of broken parsing

- `-12%` parsed as 12
- `12.34%` parsed as 34
- `12.34 %` not parsed
- `abcd 12% efgh` parsed as 12
- `12%34` parsed as 12

### New implementation

~~Find and replace first instance of a literal `%` with space (See 5th example for why not empty string). The rest of the work is offloaded to tonumber (which trims leading and trailing whitespace)~~

Find the `%` at the end of the string with regex `"%% *$"`. If it is found, the parsing is offloaded to tonumber on the substring before the find.

### Fixed examples

- `-12%` parsed as -12
- `12.34%` parsed as 12.34
- `12.34 %` parsed as 12.34
- `abcd 12% efgh` not parsed
- `12%34` not parsed
- `%12` not parsed
- `12% abcd` not parsed

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)