### PR TITLE
be more careful about adding new effective spell ids 

### DIFF
--- a/WeakAuras/GenericTrigger.lua
+++ b/WeakAuras/GenericTrigger.lua
@@ -2509,7 +2509,9 @@ do
               -- a) We are already tracking it, only add the wathed spell ids
               -- b) We aren't tracking it yet add it
               if self.data[newEffectiveSpellId] then
-                tinsert(self.data[newEffectiveSpellId].watched, userSpellId)
+                if not tContains(self.data[newEffectiveSpellId].watched, userSpellId) then
+                  tinsert(self.data[newEffectiveSpellId].watched, userSpellId)
+                end
               else
                 self:AddEffectiveSpellId(newEffectiveSpellId, userSpellId)
               end


### PR DESCRIPTION
the watched field contains a list of spell ids, and is consumed by SendEventsForSpell, invokes ScanEventsByID for each item in the array.

But we add an item to the array every time a new effective spell id is detected, so this array can grows very large & contain many duplicates if a spell is frequently replaced, causing a cooldown triggerFunc that tracks such a spell to be run many many times for a single SPELL_UPDATE_COOLDOWN event

So, check first if the array has the spell id before adding it. This still seems slightly wrong, but naievely swapping the array for a table<number, true> introduced problems with scheduled checks that proved elusive to fix for me as a relative outsider to this bit of code.