### PR TITLE
Model picker search with multiple words

### DIFF
--- a/WeakAurasOptions/OptionsFrames/ModelPicker.lua
+++ b/WeakAurasOptions/OptionsFrames/ModelPicker.lua
@@ -52,7 +52,7 @@ local function ConstructModelPicker(frame)
       end
       return filterList
     end
-    
+  
     local function MatchesAllFilters(text, filters)
       for _, f in ipairs(filters) do
         if not text:find(f, 1, true) then
@@ -61,9 +61,9 @@ local function ConstructModelPicker(frame)
       end
       return true
     end
-    
+  
     local filterList = ConstructFilterList(filter)
-
+  
     local function RecurseSetFilterInner(tree)
       for k, v in ipairs(tree) do
         if v.children == nil and v.text then


### PR DESCRIPTION
# Description

This change allows multiple filters to be applied in model picker search, by separating on spaces.

Before, it was difficult to find specific things like "warlock fel effects" or "runes with multiple pieces". Now, these filters can be accomplished by e.g. searching "warlock fel" or "rune 0". In my experience, this makes it a lot easier to find models I'm interested in.

- The filter string is split on space to form a filter list
  - This is safe because no model paths include a space today
- Must match all filters in the list
- Only create the filter list once

## Type of change

- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested

- [ ] Searched in the model picker without spaces
- [ ] Searched in the model picker with spaces
- [ ] Paid attention to the search speed, it seems similar to before

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

## Screenshot
![image](https://github.com/user-attachments/assets/a3f3cdf2-e1b0-42ba-974f-bdf0cf85c34b)


