### PR TITLE
fix archive clean schedule

### DIFF
--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -1367,7 +1367,8 @@ loadedFrame:SetScript("OnEvent", function(self, event, addon)
 
       if db.lastArchiveClear == nil then
         db.lastArchiveClear = time();
-      elseif db.lastArchiveClear < time() - 86400 then
+      elseif db.lastArchiveClear < time() - 2505600 --[[29 days]] then
+        db.lastArchiveClear = time();
         Private.CleanArchive(db.historyCutoff, db.migrationCutoff);
       end
       db.minimap = db.minimap or { hide = false };


### PR DESCRIPTION
turns out we were cleaning archive on almost every login, oops.

Also, reduce the frequency to once every 30 days, so that 28/29 days a user logs in there is a high chance that the addon never loads, and thus wow only rarely writes to the file. This should make it more likely that if the main addon SavedVariables are destroyed by e.g. user running out of disk space, the archive survives intact.
