### PR TITLE
Include area ID in tooltip for zone identifier

### DIFF
--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -203,7 +203,17 @@ local function get_zoneId_list()
                                          L["Parent Zone"], parentmap_name, currentmap_info.parentMapID)
   end
 
-  return ("%s|cffffd200%s|r\n%s: %d\n\n%s%s|cffffd200%s|r\n%s: i%d\n\n%s"):format(
+  local minimapZoneText = GetMinimapZoneText()
+  local currentAreaID = L["not found"]
+  for id=1,30000 do
+    local areaID = C_Map.GetAreaInfo(id)
+    if areaID == minimapZoneText then
+      currentAreaID =  "a" .. id
+      break
+    end
+  end
+
+  return ("%s|cffffd200%s|r\n%s: %d\n\n%s%s|cffffd200%s|r\n%s: i%d\n\n|cffffd200%s|r\n%s: %s\n\n%s"):format(
     Private.get_zoneId_list(),
     L["Current Zone"],
     currentmap_name,
@@ -213,6 +223,9 @@ local function get_zoneId_list()
     L["Current Instance"],
     L["Instance Id"],
     instanceId,
+    L["Current Area"],
+    minimapZoneText,
+    currentAreaID,
     bottomText
   )
 end


### PR DESCRIPTION
# Description

Currently WeakAuras allows to use areaID for zone identifier option, but finding the correct areaID is a manual process that users must handle themselves. Looking for IDs on wago.tools is not a great experience so why not just try to find the areaID ingame?

Approach I took for this PR is brute but it achieves the goal. It doesn't result in any lag (at least based on testing on my PC), so as long as `get_zoneId_list` only called when hovering field for zone identifier I think it is acceptable for such brute way.

Not all subzones have a corresponding entry in the AreaTable that matches the subzone name. In these cases we fallback to "not found". Maybe better approach would be to remove `Current Area` part from tooltip when there is no areaID found. And also do we need to change text at the bottom of the tooltip explaining where to find areaIDs?

## How Has This Been Tested
I flied over Dornogal, Isle of Dorn and Stormwind mouseovering zone identifier load condition. Works as I would expect it to.
