### PR TITLE
Specialization changes

### DIFF
--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -685,12 +685,15 @@ Private.anim_presets = {
 };
 
 WeakAuras.class_ids = {}
+WeakAuras.classes_sorted = {}
 for classID = 1, 20 do -- GetNumClasses not supported by wow classic
   local classInfo = C_CreatureInfo.GetClassInfo(classID)
   if classInfo then
     WeakAuras.class_ids[classInfo.classFile] = classInfo.classID
+    tinsert(WeakAuras.classes_sorted, classInfo.classFile)
   end
 end
+table.sort(WeakAuras.classes_sorted)
 
 if WeakAuras.IsClassicOrCata() then
   ---@param index integer
@@ -1415,7 +1418,9 @@ Private.load_prototype = {
       init = WeakAuras.IsCataOrRetail() and "arg" or nil,
       enable = WeakAuras.IsCataOrRetail(),
       hidden = not WeakAuras.IsCataOrRetail(),
-      events = {"PLAYER_TALENT_UPDATE"}
+      events = {"PLAYER_TALENT_UPDATE"},
+      sorted = true,
+      sortOrder = Private.specs_sorted,
     },
     {
       name = "talent",
@@ -2374,6 +2379,8 @@ Private.event_prototypes = {
           return WeakAuras.IsCataOrRetail() and (trigger.unit == "group" or trigger.unit == "raid" or trigger.unit == "party")
         end,
         desc = L["Requires syncing the specialization via LibSpecialization."],
+        sorted = true,
+        sortOrder = Private.specs_sorted,
       },
       {
         name = "classification",
@@ -3358,6 +3365,8 @@ Private.event_prototypes = {
           return WeakAuras.IsCataOrRetail() and (trigger.unit == "group" or trigger.unit == "raid" or trigger.unit == "party")
         end,
         desc = L["Requires syncing the specialization via LibSpecialization."],
+        sorted = true,
+        sortOrder = Private.specs_sorted,
       },
       {
         name = "role",
@@ -3926,6 +3935,8 @@ Private.event_prototypes = {
           return WeakAuras.IsCataOrRetail() and (trigger.unit == "group" or trigger.unit == "raid" or trigger.unit == "party")
         end,
         desc = L["Requires syncing the specialization via LibSpecialization."],
+        sorted = true,
+        sortOrder = Private.specs_sorted,
       },
       {
         name = "role",
@@ -4222,6 +4233,8 @@ Private.event_prototypes = {
           return trigger.unit == "group" or trigger.unit == "raid" or trigger.unit == "party"
         end,
         desc = L["Requires syncing the specialization via LibSpecialization."],
+        sorted = true,
+        sortOrder = Private.specs_sorted,
       },
       {
         name = "role",
@@ -7134,7 +7147,9 @@ Private.event_prototypes = {
         type = "multiselect",
         values = "spec_types_all",
         store = "true",
-        conditionType = "select"
+        conditionType = "select",
+        sorted = true,
+        sortOrder = Private.specs_sorted,
       },
       {
         hidden = true,
@@ -7184,6 +7199,8 @@ Private.event_prototypes = {
         values = "spec_types_all",
         conditionType = "select",
         store = true,
+        sorted = true,
+        sortOrder = Private.specs_sorted,
       },
       {
         name = "name",

--- a/WeakAuras/Types.lua
+++ b/WeakAuras/Types.lua
@@ -1810,8 +1810,10 @@ WeakAuras.spec_types_specific = {}
 
 ---@type table<number, string>
 Private.spec_types_all = {}
+Private.specs_sorted = {}
 local function update_specs()
-  for classFileName, classID in pairs(WeakAuras.class_ids) do
+  for _, classFileName in pairs(WeakAuras.classes_sorted) do
+    local classID = WeakAuras.class_ids[classFileName]
     WeakAuras.spec_types_specific[classFileName] = {}
     local numSpecs = WeakAuras.IsCataClassic() and 3 or GetNumSpecializationsForClassID(classID) -- see https://github.com/Stanzilla/WoWUIBugs/issues/559
     for i = 1, numSpecs do
@@ -1821,6 +1823,7 @@ local function update_specs()
         local classColor = WA_GetClassColor(classFileName)
         Private.spec_types_all[specId] = CreateAtlasMarkup(GetClassAtlas(classFileName:lower()))
         .. "|T"..(icon or "error")..":0|t "..(WrapTextInColorCode(tabName, classColor) or "error");
+        tinsert(Private.specs_sorted, specId)
       end
     end
   end

--- a/WeakAuras/Types.lua
+++ b/WeakAuras/Types.lua
@@ -1811,12 +1811,11 @@ WeakAuras.spec_types_specific = {}
 ---@type table<number, string>
 Private.spec_types_all = {}
 local function update_specs()
-  local cataFix = WeakAuras.IsCataClassic() and -1 or 0 -- see https://github.com/Stanzilla/WoWUIBugs/issues/559
   for classFileName, classID in pairs(WeakAuras.class_ids) do
     WeakAuras.spec_types_specific[classFileName] = {}
-    local numSpecs = WeakAuras.IsCataClassic() and 3 or GetNumSpecializationsForClassID(classID)
+    local numSpecs = WeakAuras.IsCataClassic() and 3 or GetNumSpecializationsForClassID(classID) -- see https://github.com/Stanzilla/WoWUIBugs/issues/559
     for i = 1, numSpecs do
-      local specId, tabName, _, icon = GetSpecializationInfoForClassID(classID, i + cataFix);
+      local specId, tabName, _, icon = GetSpecializationInfoForClassID(classID, i);
       if tabName then
         tinsert(WeakAuras.spec_types_specific[classFileName], "|T"..(icon or "error")..":0|t "..(tabName or "error"));
         local classColor = WA_GetClassColor(classFileName)

--- a/WeakAurasOptions/LoadOptions.lua
+++ b/WeakAurasOptions/LoadOptions.lua
@@ -909,7 +909,7 @@ function OptionsPrivate.ConstructOptions(prototype, data, startorder, triggernum
               values = WeakAuras[arg.values];
             end
           end
-          local sortOrder = arg.sorted and OptionsPrivate.Private.SortOrderForValues(values) or nil
+          local sortOrder = arg.sorted and (arg.sortOrder or OptionsPrivate.Private.SortOrderForValues(values)) or nil
           options[name..suffix] = {
             type = "select",
             width = WeakAuras.normalWidth,


### PR DESCRIPTION
# Description

Two changes made here:
- The latest Cataclysm patch made specialization indices start at 1, matching retail. This change undoes the offset needed previously.
- Specializations were previously sorted by ID. In Classic this appears rather messy. Instead this sorts (visually only) them alphabetically in class (using table.sort on the class file name) and then the specializations by index, which should match the talent pane. A small change was made to the Load Options to allow for this.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested

- [x] Checked the dropdown in both the Load tab and trigger tab for talent specializations.
- [x] Checked that an existing aura already using a talent specialization load option did not have its data changed as a result of these changes.

## Checklist

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

Here are some pictures:

- Original bug: 
![image](https://github.com/user-attachments/assets/62d490ba-cd70-4a34-96b5-29822cf0f5ca)

- Unsorted order after fixing the bug in Classic: 
![image-1](https://github.com/user-attachments/assets/9b4753f9-0f42-447a-a60d-da367cc53e3c)

- Sorted order after these changes: 
![image](https://github.com/user-attachments/assets/28a92c42-605a-497a-a114-f63fa94aa7e7)
![image](https://github.com/user-attachments/assets/76423a74-9a5e-4f2d-b51e-299972c4cbfa)
