### PR TITLE
New Mage Spell Alerts

### DIFF
--- a/WeakAuras/Types.lua
+++ b/WeakAuras/Types.lua
@@ -1977,7 +1977,7 @@ Private.texture_types = {
     ["4699056"] = "Essence Burst",
     ["4699057"] = "Snapfire",
     ["6160020"] = "Arcane Soul",
-    ["6160021"] = "Hyperthermia"
+    ["6160021"] = "Hyperthermia",
   },
   ["Icons"] = {
     ["165558"] = "Paw",

--- a/WeakAuras/Types.lua
+++ b/WeakAuras/Types.lua
@@ -1976,6 +1976,8 @@ Private.texture_types = {
     ["2888300"] = "Demonic Core Vertical",
     ["4699056"] = "Essence Burst",
     ["4699057"] = "Snapfire",
+    ["6160020"] = "Arcane Soul",
+    ["6160021"] = "Hyperthermia"
   },
   ["Icons"] = {
     ["165558"] = "Paw",


### PR DESCRIPTION
# New Mage Spell Alerts

Added the following textures under `Blizzard Alerts`:

- Arcane Soul
- Hyperthermia

<!-- A #ticketNumber will be sufficient. -->
Fixes #5521

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested
![image](https://github.com/user-attachments/assets/d0bfea5a-3111-4e0c-83a2-9fe65204a016)
Open textures menu and navigate to bottom of `Blizzard Alerts` section. See both new mage spell alerts.

![image](https://github.com/user-attachments/assets/ec264794-f900-45f0-86e2-469bef11e1ad)
![image](https://github.com/user-attachments/assets/8c2e9bac-2f0b-403e-ae7c-af3b90c1d38f)
Select each and verify they appear on screen.

## Checklist
<!-- These can be checked off after the pull request is submitted, in case you want discussion before they are completely ready -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [N/A] I have commented my code, particularly in hard-to-understand areas
- [N/A] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
