### PR TITLE
Add Money Formatting Option and Add Player Money to Currency Trigger

### DIFF
--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -11272,6 +11272,71 @@ Private.event_prototypes = {
     automaticrequired = true,
     progressType = "none"
   },
+  ["Money"] = {
+    type = "unit",
+    statesParameter = "one",
+    progressType = "none",
+    automaticrequired = true,
+    events = {
+      ["events"] = {"PLAYER_MONEY"}
+    },
+    internal_events = {"WA_DELAYED_PLAYER_ENTERING_WORLD"},
+    force_events = "WA_DELAYED_PLAYER_ENTERING_WORLD",
+    name = L["Player Money"],
+    init = function()
+      return [=[
+        local money = GetMoney()
+        local gold = floor(money / 1e4)
+        local silver = floor(money / 100 % 100)
+        local copper = money % 100
+      ]=]
+    end,
+    args = {
+      {
+        name = "money",
+        init = "money",
+        type = "number",
+        display = L["Money"],
+        store = true,
+        hidden = true,
+        test = "true",
+      },
+      {
+        name = "gold",
+        init = "gold",
+        type = "number",
+        display = Private.coin_icons.gold .. L["Gold"],
+        store = true,
+        conditionType = "number",
+      },
+      {
+        name = "silver",
+        init = "silver",
+        type = "number",
+        display = Private.coin_icons.silver .. L["Silver"],
+        store = true,
+        conditionType = "number",
+      },
+      {
+        name = "copper",
+        init = "copper",
+        type = "number",
+        display = Private.coin_icons.copper .. L["Copper"],
+        store = true,
+        conditionType = "number",
+      },
+      {
+        name = "icon",
+        init = "C_CurrencyInfo.GetCoinIcon(money)",
+        store = true,
+        hidden = true,
+        test = "true",
+      },
+    },
+    GetNameAndIcon = function()
+      return MONEY, C_CurrencyInfo.GetCoinIcon(GetMoney())
+    end,
+  },
   ["Currency"] = {
     type = "unit",
     progressType = "static",

--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -11315,7 +11315,8 @@ Private.event_prototypes = {
         type = "number",
         display = Private.coin_icons.silver .. L["Silver"],
         store = true,
-        conditionType = "number",
+        hidden = true,
+        test = "true",
       },
       {
         name = "copper",
@@ -11323,7 +11324,8 @@ Private.event_prototypes = {
         type = "number",
         display = Private.coin_icons.copper .. L["Copper"],
         store = true,
-        conditionType = "number",
+        hidden = true,
+        test = "true",
       },
       {
         name = "icon",

--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -11282,7 +11282,7 @@ Private.event_prototypes = {
     },
     internal_events = {"WA_DELAYED_PLAYER_ENTERING_WORLD"},
     force_events = "WA_DELAYED_PLAYER_ENTERING_WORLD",
-    name = L["Player Money"],
+    name = WeakAuras.newFeatureString..L["Player Money"],
     init = function()
       return [=[
         local money = GetMoney()

--- a/WeakAuras/Types.lua
+++ b/WeakAuras/Types.lua
@@ -533,7 +533,6 @@ Private.format_types = {
         local gold = floor(value / 1e4)
         local silver = floor(value / 100 % 100)
         local copper = value % 100
-        local formatCode = "%s%s %d%s %d%s"
 
         if (format == "AbbreviateNumbers") then
           gold = simpleFormatters.AbbreviateNumbers(gold)
@@ -543,10 +542,13 @@ Private.format_types = {
           gold = simpleFormatters.AbbreviateLargeNumbers(gold)
         end
 
+        local formatCode
         if precision == 1 then
           formatCode = "%s%s"
         elseif precision == 2 then
           formatCode = "%s%s %d%s"
+        else
+          formatCode = "%s%s %d%s %d%s"
         end
 
         return string.format(formatCode,


### PR DESCRIPTION
## Currency Trigger: Add Player Money
I'm not sure what makes more sense for players, finding this in the currency trigger or as its own trigger.
Adding it to the currency trigger also means I had to add additional checks and hide everything related to currencies when player money was selected. From a coding PoV, this is ugly, and I would prefer having Player Money as a seperate trigger.

## Money Formatting Option
Accepts a number:wowmoney
Has two options: 
- Gold format (big number with a "disable" option)
- Coin Precision
![image](https://github.com/user-attachments/assets/bfbaf566-5aa9-49d8-adb1-18029694e985)
![image](https://github.com/user-attachments/assets/e644aee8-35ba-42ce-9527-5e947ca3e60e)
