### PR TITLE
add sourceGUID to chat msg trigger state

### DIFF
--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -8009,6 +8009,32 @@ Private.event_prototypes = {
         conditionType = "string",
       },
       {
+        -- flags
+      },
+      {
+        -- zone Channel id
+      },
+      {
+        -- channel index
+      },
+      {
+        -- channel base name
+      },
+      {
+        -- language id
+      },
+      {
+        -- line id
+      },
+      {
+        name = "sourceGUID",
+        display = L["Source GUID"],
+        init = "arg",
+        store = true,
+        hidden = true,
+        test = "true",
+      },
+      {
         name = "cloneId",
         display = L["Clone per Event"],
         type = "toggle",


### PR DESCRIPTION
inspired by [this post in discord](https://discord.com/channels/172440238717665280/1321645681580052554/1321645681580052554).
We could & maybe should add a shim for Ambiguate in our format options, but since the source GUID is, yknow, *right there* it seems silly to not make it available