### PR TITLE
Add itemInRange condition support to Equipment Slot triggers

### DIFF
--- a/WeakAuras/GenericTrigger.lua
+++ b/WeakAuras/GenericTrigger.lua
@@ -4709,7 +4709,25 @@ local commonConditions = {
   name = {
     display = L["Name"],
     type = "string"
-  }
+  },
+  itemInRange = {
+    display = WeakAuras.newFeatureString .. L["Item in Range"],
+    hidden = true,
+    type = "bool",
+    test = function(state, needle)
+      print("HERE", not state, not state.itemId, not state.show, not UnitExists('target'))
+      if not state or not state.itemId or not state.show or not UnitExists('target') then
+        return false
+      end
+      if InCombatLockdown() and not UnitCanAttack('player', 'target') then
+        return false
+      end
+      return C_Item.IsItemInRange(state.itemId, 'target') == (needle == 1)
+    end,
+    events = Private.AddTargetConditionEvents({
+      "WA_SPELL_RANGECHECK",
+    })
+  },
 }
 
 ---@type fun(variables: table)
@@ -4790,6 +4808,10 @@ function GenericTrigger.GetTriggerConditions(data, triggernum)
 
     if prototype.nameFunc then
       result.name = commonConditions.name;
+    end
+
+    if prototype.hasItemID then
+      result.itemInRange = commonConditions.itemInRange
     end
 
     for _, v in pairs(prototype.args) do

--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -6081,19 +6081,29 @@ Private.event_prototypes = {
     statesParameter = "one",
     args = {
       {
+        name = "itemId",
+        display = WeakAuras.newFeatureString .. L["ItemId"],
+        hidden = true,
+        init = "item",
+        test = "true",
+        store = true,
+        conditionType = "number",
+        operator_types = "only_equal",
+      },
+      {
         name = "itemInRange",
         display = WeakAuras.newFeatureString .. L["Item in Range"],
         hidden = true,
         test = "true",
         conditionType = "bool",
         conditionTest = function(state, needle)
-          if not state or not state.name or not state.show or not UnitExists('target') then
+          if not state or not state.itemId or not state.show or not UnitExists('target') then
             return false
           end
           if InCombatLockdown() and not UnitCanAttack('player', 'target') then
             return false
           end
-          return C_Item.IsItemInRange(state.name, 'target') == (needle == 1)
+          return C_Item.IsItemInRange(state.itemId, 'target') == (needle == 1)
         end,
         conditionEvents = AddTargetConditionEvents({
           "WA_SPELL_RANGECHECK",

--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -6081,6 +6081,28 @@ Private.event_prototypes = {
     statesParameter = "one",
     args = {
       {
+        name = "itemInRange",
+        display = WeakAuras.newFeatureString .. L["Item in Range"],
+        hidden = true,
+        test = "true",
+        conditionType = "bool",
+        conditionTest = function(state, needle)
+          if not state or not state.show or not UnitExists('target') then
+            return false
+          end
+          if InCombatLockdown() and not UnitCanAttack('player', 'target') then
+            return false
+          end
+          local itemSlot = state.trigger.itemSlot
+          local item = GetInventoryItemID("player", itemSlot or 0)
+          local itemName = item and C_Item.GetItemInfo(item) or nil
+          return C_Item.IsItemInRange(itemName, 'target') == (needle == 1)
+        end,
+        conditionEvents = AddTargetConditionEvents({
+          "WA_SPELL_RANGECHECK",
+        })
+      },
+      {
         name = "itemSlot",
         required = true,
         display = L["Equipment Slot"],

--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -6087,16 +6087,13 @@ Private.event_prototypes = {
         test = "true",
         conditionType = "bool",
         conditionTest = function(state, needle)
-          if not state or not state.show or not UnitExists('target') then
+          if not state or not state.name or not state.show or not UnitExists('target') then
             return false
           end
           if InCombatLockdown() and not UnitCanAttack('player', 'target') then
             return false
           end
-          local itemSlot = state.trigger.itemSlot
-          local item = GetInventoryItemID("player", itemSlot or 0)
-          local itemName = item and C_Item.GetItemInfo(item) or nil
-          return C_Item.IsItemInRange(itemName, 'target') == (needle == 1)
+          return C_Item.IsItemInRange(state.name, 'target') == (needle == 1)
         end,
         conditionEvents = AddTargetConditionEvents({
           "WA_SPELL_RANGECHECK",

--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -2195,6 +2195,8 @@ local function AddTargetConditionEvents(result, useFocus)
   return result
 end
 
+Private.AddTargetConditionEvents = AddTargetConditionEvents
+
 local unitHelperFunctions = {
   UnitChangedForceEventsWithPets = function(trigger)
     local events = {}
@@ -5835,7 +5837,7 @@ Private.event_prototypes = {
       local ret = [=[
         local itemname = %s;
         local name = C_Item.GetItemInfo(itemname or 0) or "Invalid"
-        local _, _, _, _, icon = C_Item.GetItemInfoInstant(itemname or 0)
+        local itemId, _, _, _, icon = C_Item.GetItemInfoInstant(itemname or 0)
         local showgcd = %s
         local startTime, duration, enabled, gcdCooldown = WeakAuras.GetItemCooldown(itemname, showgcd);
         local expirationTime = startTime + duration
@@ -5870,6 +5872,16 @@ Private.event_prototypes = {
         display = L["Item"],
         type = "item",
         test = "true"
+      },
+      {
+        name = "itemId",
+        display = WeakAuras.newFeatureString .. L["ItemId"],
+        hidden = true,
+        init = "itemId",
+        test = "true",
+        store = true,
+        conditionType = "number",
+        operator_types = "only_equal",
       },
       {
         name = "remaining",
@@ -5926,25 +5938,6 @@ Private.event_prototypes = {
         conditionTest = function(state, needle)
           return state and state.show and (not state.gcdCooldown and state.expirationTime and state.expirationTime > GetTime() or state.enabled == 0) == (needle == 1)
         end,
-      },
-      {
-        name = "itemInRange",
-        display = L["Item in Range"],
-        hidden = true,
-        test = "true",
-        conditionType = "bool",
-        conditionTest = function(state, needle)
-          if not state or not state.show or not UnitExists('target') then
-            return false
-          end
-          if InCombatLockdown() and not UnitCanAttack('player', 'target') then
-            return false
-          end
-          return C_Item.IsItemInRange(state.itemname, 'target') == (needle == 1)
-        end,
-        conditionEvents = AddTargetConditionEvents({
-          "WA_SPELL_RANGECHECK",
-        })
       },
       {
         hidden = true,
@@ -6091,25 +6084,6 @@ Private.event_prototypes = {
         operator_types = "only_equal",
       },
       {
-        name = "itemInRange",
-        display = WeakAuras.newFeatureString .. L["Item in Range"],
-        hidden = true,
-        test = "true",
-        conditionType = "bool",
-        conditionTest = function(state, needle)
-          if not state or not state.itemId or not state.show or not UnitExists('target') then
-            return false
-          end
-          if InCombatLockdown() and not UnitCanAttack('player', 'target') then
-            return false
-          end
-          return C_Item.IsItemInRange(state.itemId, 'target') == (needle == 1)
-        end,
-        conditionEvents = AddTargetConditionEvents({
-          "WA_SPELL_RANGECHECK",
-        })
-      },
-      {
         name = "itemSlot",
         required = true,
         display = L["Equipment Slot"],
@@ -6233,6 +6207,7 @@ Private.event_prototypes = {
       }
     },
     automaticrequired = true,
+    hasItemID = true,
     progressType = "timed"
   },
   ["Cooldown Ready (Item)"] = {
@@ -6249,7 +6224,7 @@ Private.event_prototypes = {
       local ret = [[
         local itemName = %s
         local name = C_Item.GetItemInfo(itemName) or "Invalid"
-        local _, _, _, _, icon = C_Item.GetItemInfoInstant(itemName)
+        local itemId, _, _, _, icon = C_Item.GetItemInfoInstant(itemName)
       ]]
 
       local itemName = type(trigger.itemName) == "number" and trigger.itemName or string.format("%q", trigger.itemName or "0")
@@ -6268,6 +6243,16 @@ Private.event_prototypes = {
         display = L["Item"],
         type = "item",
         init = "arg"
+      },
+      {
+        name = "itemId",
+        display = WeakAuras.newFeatureString .. L["ItemId"],
+        hidden = true,
+        init = "itemId",
+        test = "true",
+        store = true,
+        conditionType = "number",
+        operator_types = "only_equal",
       },
       {
         name = "name",
@@ -6330,6 +6315,16 @@ Private.event_prototypes = {
         type = "select",
         values = "item_slot_types",
         init = "arg"
+      },
+      {
+        name = "itemId",
+        display = WeakAuras.newFeatureString .. L["ItemId"],
+        hidden = true,
+        init = "item",
+        test = "true",
+        store = true,
+        conditionType = "number",
+        operator_types = "only_equal",
       },
       {
         name = "name",
@@ -7533,8 +7528,9 @@ Private.event_prototypes = {
       local ret = [[
         local itemName = %s
         local exactSpellMatch = %s
+        local itemId = C_Item.GetItemInfo(itemName)
         if not exactSpellMatch and tonumber(itemName) then
-          itemName = C_Item.GetItemInfo(itemName)
+          itemName = itemId
         end
         local count = C_Item.GetItemCount(itemName or "", %s, %s, %s, %s);
         local reagentQuality, reagentQualityTexture
@@ -7562,6 +7558,16 @@ Private.event_prototypes = {
         type = "item",
         showExactOption = true,
         test = "true"
+      },
+      {
+        name = "itemId",
+        display = WeakAuras.newFeatureString .. L["ItemId"],
+        hidden = true,
+        init = "itemId",
+        test = "true",
+        store = true,
+        conditionType = "number",
+        operator_types = "only_equal",
       },
       {
         name = "name",
@@ -8684,7 +8690,7 @@ Private.event_prototypes = {
       local ret = [[
         local inverse = %s
         local triggerItemName = %s
-        local _, _, _, _, icon = C_Item.GetItemInfoInstant(triggerItemName)
+        local itemId, _, _, _, icon = C_Item.GetItemInfoInstant(triggerItemName)
         local itemSlot = %s
       ]]
 
@@ -8716,6 +8722,16 @@ Private.event_prototypes = {
         required = true,
         test = "true",
         showExactOption = true
+      },
+      {
+        name = "itemId",
+        display = WeakAuras.newFeatureString .. L["ItemId"],
+        hidden = true,
+        init = "itemId",
+        test = "true",
+        store = true,
+        conditionType = "number",
+        operator_types = "only_equal",
       },
       {
         name = "itemSlot",
@@ -9092,7 +9108,6 @@ Private.event_prototypes = {
         test = "(inverse and itemSetName == nil) or (not inverse and itemSetName)"
       }
     },
-    hasItemID = true,
     automaticrequired = true,
     progressType = "static"
   },


### PR DESCRIPTION
# Description

This PR adds the `Item in Range` conditional used by `Cooldown Progress (Item)` triggers to `Cooldown Progress (Slot)` triggers.

The motivation for the change is that many item slots in Classic for which you'd care about the cooldown can also have range limitations. Examples include:

- Goblin Rocket Helmet
- Gnomish Net-o-Matic Projector
- Tidal Charm
- (etc, there's so many)


Fixes #5638

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested

I created a new WeakAura with a `Cooldown Progress (Slot)` trigger and used the added `Item in Range` conditional. I was able to verify its behavior for both the Helmet and Trinket 1 slots. Here is an export of that WeakAura:

```
!WA:2!DrvZUTTrqylRc4cv0wB1udK2CWWaniTOWiXaXaT3evOsCGSKkjDTtViTKCi5wtTlZUlLS8HceDkN1JGa6TEspc(jGqOOpa(qVx)e0zxr58Jbm183oZ33SZovAvFy9W6HV9rZPbCMlpxeapydXLDJIKGQYcs4VNlvq4jKl38Dku2MIj3fcliHl6XPmLFt7oE2old480q(yM7yAgm461Q2HXqIGeOOCM8ihPIiu1SOmQQMFe(JmP2uLGghdc5x8qrP4)yPMKbwufm8gzUpmcyk38Oi6Ll63SHRxFxVgoEz7KlH(Xade0a3e(4USbl)a15s8NgPJjtKomYqqw7A9r051nLRgmDT03ovMbPPhh(Er0bpWG7kFpbGL3XTND72w5i(9ZsjtaHJXB2(nlj8E9e8ybiL79i7xNtZgIE3txIVFEi4JCWdzM4f2T71602ZYzLmUw2o6M0iWBL(j8q4V24wSbdcgj9xX2d2b)ZBYkZ(QRTF4bBS5mjKgzUkk2clHKOYfefKmhrUdeR77)8UfBVev9jbxel45SW3EVS6k4svFzcbr95LxSz33y08jIlgsWakfSyCgm7o37)DYSTFVm0KNYfVSsLkvVzL11GYQXPEDZ(kJrsUIJPIgCgnuLy1avVDvTOxcHgJVz5QzRxvIORn(1ZG0OjibfCfsop0OvNUDSl2wG8shZCtGbgyuf)BwjjW7MTBjOxT3VKtcXgdzppVpG7RR0sJTXCr4zcs20ZkfwbGruj1pfNRxHU(zAQLTZXD6y703QRNx3tCo(5VWB5Dv1LEfC)sYC(hucTxZqq3t9AFCh7)DzCkFClb86CGfmP3N84do8PRiM2X16pptFNIxLvNQ10NEPFUsXzDhbcCoCU2CBGfRs(6fA51SAMwP5DDf9W9ZxBjXe5AWzPvsmX7gqsHQgy5LqdUGHdCvnEAtr5DmvZcBqGiXpbOXjQ3yLYjHTSKiT31zyEQIwZcFtfSBXVvZjiLiLAjFfMzMslMTnILgLRxmBBs(ytuwYCHze2ZSoaxx5J)hrJRnJWOdnTKJk(SwfBxCW1arcUkHPjS1YWYowF9MeHeWZfkNQJrNRIdSgsOmZblc3QakIkIrXp)JTmD9ISb3Ebazn0us5OZCYsCCgVC7Mz2TvZ6koFyfN3nboxXdgT6D7N(J)3(0qh8LJuD7QzIwcC9Igk(UnDST74qsZsivDgBEfKvh7eRxPG7cWkcdomNgU40Z7CO6jbrTB)kbLPZpKSisNmK744D1S7TgY6xjpJkj4GByYCDdGAG638qNGei4IJk(YQthreuDel0R8oM5qyXGZisAoureKO1W4l(JxwfFApf3(Gnt1KIHlOSv7fWewRGmOU0)Ph8KF6GhxF0FF())d
```

## Checklist
<!-- These can be checked off after the pull request is submitted, in case you want discussion before they are completely ready -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

<!-- Is there any additional work that needs to be done? If so, add it to the above list -->

I duplicated code from `Cooldown Progress (Equipment Slot)` nearly 1:1 as I was not familiar enough with the structure of the file to avoid doing that. If there's something smarter to do here I'm happy to fix my implementation.
