### PR TITLE
Bossmod triggers show timers regardless of bossmod settings

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -68,6 +68,7 @@ globals = {
 	"APIDocumentation",
 	"APIDocumentation_LoadUI",
 	"BigWigs",
+	"BigWigsAPI",
 	"BigWigsLoader",
 	"CUSTOM_CLASS_COLORS",
 	"DBM",

--- a/WeakAuras/Modernize.lua
+++ b/WeakAuras/Modernize.lua
@@ -2396,6 +2396,23 @@ function Private.Modernize(data, oldSnapshot)
     end
   end
 
+  if data.internalVersion < 84 then
+    if data.triggers then
+      for _, triggerData in ipairs(data.triggers) do
+        local trigger = triggerData.trigger
+        if trigger and trigger.type == "addons" then
+          if trigger.event == "Boss Mod Timer" or trigger.event == "BigWigs Timer" or trigger.event == "DBM Timer" then
+            -- if trigger don't filter bars, show only those active in the addon config for triggers made before this option was added
+            -- show disabled bars when looking for specific ids/name
+            if not (trigger.use_message or trigger.use_spellId) then
+              trigger.use_isBarEnabled = true
+            end
+          end
+        end
+      end
+    end
+  end
+
   data.internalVersion = max(data.internalVersion or 0, WeakAuras.InternalVersion())
 end
 

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -3,7 +3,7 @@ local AddonName = ...
 ---@class Private
 local Private = select(2, ...)
 
-local internalVersion = 83
+local internalVersion = 84
 
 -- Lua APIs
 local insert = table.insert


### PR DESCRIPTION
This make bigwigs, dbm (still active on classic), and bossmod triggers show timers regardless of bossmod bars settings

This is accomplished for BigWigs by using events `BigWigs_Timer` ~~and `BigWigs_CooldownTimer`~~ instead of `BigWigs_StartBar`
And for DBM by using `DBM_TimerBegin` instead of `DBM_TimerStart`

A new option allows to filter depending on the state of the bar in bossmod settings

Change in DBM: https://github.com/DeadlyBossMods/DeadlyBossMods/commit/3bf425b87a9b2196d8206f523e0202741e1e9b47
Change in BigWigs: https://github.com/BigWigsMods/BigWigs/commit/3d6a290bc2dab298b1992468bd370176db297e9a

Thanks @Justw8 and @MysticalOS