### PR TITLE
Fix an issue with word wrapping in the Discord thanks list

### DIFF
--- a/WeakAurasOptions/OptionsFrames/OptionsFrame.lua
+++ b/WeakAurasOptions/OptionsFrames/OptionsFrame.lua
@@ -468,13 +468,13 @@ function OptionsPrivate.CreateFrame()
     local lineLength = 0
     local currentLine = {}
     for _, patreon in ipairs(list) do
-      if lineLength + #patreon + 2 * #currentLine > 130 then
+      if lineLength + #patreon + 2 > 130 then
         tinsert(patreonLines, table.concat(currentLine, ", ") .. ", ")
         currentLine = {}
         tinsert(currentLine, patreon)
-        lineLength = #patreon
+        lineLength = #patreon + 2
       else
-        lineLength = lineLength + #patreon
+        lineLength = lineLength + #patreon + 2
         tinsert(currentLine, patreon)
       end
     end


### PR DESCRIPTION
# Description

Specifically the line would reach 130 characters before lineLength reached 130 characters, and that would cause automatic wrapping. This was because the comma and the period was not added to the line length.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Before: 
![image](https://github.com/user-attachments/assets/fdb83b47-89bc-491d-a867-6ad78f0bbf91)

After: 
![image](https://github.com/user-attachments/assets/c72d5783-0f64-4b36-8edb-d467e82d6c9c)


## Checklist
<!-- These can be checked off after the pull request is submitted, in case you want discussion before they are completely ready -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

<!-- Is there any additional work that needs to be done? If so, add it to the above list -->
