### PR TITLE
Event(s) field for text editor frame

### DIFF
--- a/WeakAurasOptions/OptionsFrames/TextEditor.lua
+++ b/WeakAurasOptions/OptionsFrames/TextEditor.lua
@@ -895,7 +895,7 @@ local function ConstructTextEditor(frame)
   local eventEditorLabel = eventEditor.frame:CreateFontString(nil, "OVERLAY","GameFontNormalSmall")
   eventEditorLabel:SetPoint("RIGHT", eventEditor.frame, "TOPLEFT", 0, -24)
   eventEditorLabel:SetFont(STANDARD_TEXT_FONT, 10, "")
-  eventEditorLabel:SetText("Event(s)")
+  eventEditorLabel:SetText(L["Event(s)]")
   if fontPath then
     eventEditor.editBox:SetFont(fontPath, WeakAurasSaved.editor_font_size, "")
   end

--- a/WeakAurasOptions/OptionsFrames/TextEditor.lua
+++ b/WeakAurasOptions/OptionsFrames/TextEditor.lua
@@ -895,7 +895,7 @@ local function ConstructTextEditor(frame)
   local eventEditorLabel = eventEditor.frame:CreateFontString(nil, "OVERLAY","GameFontNormalSmall")
   eventEditorLabel:SetPoint("RIGHT", eventEditor.frame, "TOPLEFT", 0, -24)
   eventEditorLabel:SetFont(STANDARD_TEXT_FONT, 10, "")
-  eventEditorLabel:SetText(L["Event(s)]")
+  eventEditorLabel:SetText(L["Event(s)"])
   if fontPath then
     eventEditor.editBox:SetFont(fontPath, WeakAurasSaved.editor_font_size, "")
   end


### PR DESCRIPTION
# Description

Forcing users to leave the code editor to change events is very disruptive. My suggested solution to this is a small editbox at the very top of the Code Editor frame
![image](https://github.com/user-attachments/assets/5ca7b8c0-b72a-4397-a53e-2ce1bec52b4b)

## Type of change

Please delete options that are not relevant.


- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Tested with various paths, it appears to correctly only show up when path includes a trigger number.
- [X] Doesn't show up when 'Every Frame' is selected
- [X] Correctly saves on Close(), doesn't save on CancelClose()


## Checklist
<!-- These can be checked off after the pull request is submitted, in case you want discussion before they are completely ready -->

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings

<!-- Is there any additional work that needs to be done? If so, add it to the above list -->
