### PR TITLE
IsAuraStandby

### DIFF
--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -6428,6 +6428,10 @@ function WeakAuras.IsAuraLoaded(id)
   return Private.loaded[id]
 end
 
+function WeakAuras.IsAuraStandby(id)
+  return Private.loaded[id] == false
+end
+
 function Private.ExecEnv.CreateSpellChecker()
   local matcher = {
     names = {},


### PR DESCRIPTION
# Description

Support for checking whether or not an aura is standby, instead of loaded (as `WeakAuras.IsAuraLoaded` returns false for standby auras)
https://github.com/WeakAuras/WeakAuras2/issues/5905
I don't know if a seperate new function like this is fine, or a 2nd return for `WeakAuras.IsAuraLoaded` would be better.

I'm aware that this whole thing is very niche and I'm probably the first person to ask for it. It's not exactly a breaking change or anything that'd require maintenance going forward, so I hope it's okay.

## Type of change

- [x ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested

Create a new Aura, "New 1". `WeakAuras.IsAuraLoaded("New 1")` returns true, `WeakAuras.IsAuraStandby("New 1")` returns false.
Change the load setting to "in combat" and don't be in combat: `WeakAuras.IsAuraStandby("New 1")` returns true (and IsAuraLoaded false). 
Change the load setting to "never": both return false.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
