### PR TITLE
Add Celestial Dungeon load option instance type

### DIFF
--- a/WeakAuras/Types.lua
+++ b/WeakAuras/Types.lua
@@ -3162,12 +3162,13 @@ if not WeakAuras.IsClassicEra() then
     [205] = L["Follower Dungeon"],
     [208] = L["Delve"],
     [216] = L["Quest Party"],
-    [220] = L["Story Raid"]
+    [220] = L["Story Raid"],
+    [237] = WeakAuras.IsMists() and L["Dungeon (Celestial)"] or unused,
   }
 
   Private.instance_difficulty_types[0] =L["None"]
 
-  for i = 1, 220 do
+  for i = 1, 240 do
     local name, type = GetDifficultyInfo(i)
     if name then
       if instance_difficulty_names[i] then


### PR DESCRIPTION
# Description

Add Celestial Dungeon load option instance type
Fixes #5987

## Type of change

- [x ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested

I checked that it shows on MoP Classic and doesn't show on Retail.
I verified it loads an aura in celestials, but not outside

## Checklist
<!-- These can be checked off after the pull request is submitted, in case you want discussion before they are completely ready -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings