### PR TITLE
feat(load): add Group Parity (Even/Odd) load condition

### DIFF
--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -1955,31 +1955,39 @@ Private.load_prototype = {
       display= L["Group Parity"],
       type   = "select",
       width  = WeakAuras.normalWidth,
-      -- Show in options but don't force-load auras by itself
       optional = true,
-      -- Re-evaluate whenever parity can change
       events = { "PLAYER_ENTERING_WORLD", "GROUP_ROSTER_UPDATE", "ENCOUNTER_START", "ENCOUNTER_END" },
-      -- Values for the dropdown
       values = function()
-      return {
-        any  = L["Any"],
-        even = L["Even"],
-        odd  = L["Odd"],
-      }
+        return {
+          any  = L["Any"],
+          even = L["Even"],
+          odd  = L["Odd"],
+        }
       end,
-      -- The actual load test (single expression). v is the selected value: "any"/"even"/"odd".
-  test = [[
-    (function(v)
-      if v == "any" then return true end
-      if not IsInRaid() then return false end
-      local idx = UnitInRaid("player"); if not idx then return false end
-      local _, _, g = GetRaidRosterInfo(idx + 1); if not g then return false end
-      if v == "even" then return (g % 2 == 0) end
-      if v == "odd"  then return (g % 2 == 1) end
-      return true
-    end)(%q)
-  ]],
-},
+      test = [[
+        (function(v)
+          -- normalize the incoming selection
+          v = tostring(v or "any")
+          local vl = v:lower()
+      
+          -- "any" always passes
+          if vl == "any" then return true end
+      
+          -- compute parity
+          if not IsInRaid() then return false end
+          local idx = UnitInRaid("player"); if not idx then return false end
+          local _, _, g = GetRaidRosterInfo(idx); if not g then return false end
+          local isEven = (math.fmod(g, 2) == 0)
+      
+          -- if selection is "even" (in any case / locale), require even; otherwise treat as odd
+          if vl == "even" then
+            return isEven
+          else
+            return not isEven
+          end
+        end)(%q)
+      ]],
+    },
     {
       name = "group_leader",
       display = WeakAuras.newFeatureString .. L["Group Leader/Assist"],

--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -1964,7 +1964,6 @@ Private.load_prototype = {
           odd  = L["Odd"],
         }
       end,
-      -- 👇 add a description with the newFeatureString appended
       desc = L["Matches your current raid subgroup parity (Even/Odd). Only applies while in a raid."] .. WeakAuras.newFeatureString,
       test = [[
         (function(v)

--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -1951,6 +1951,38 @@ Private.load_prototype = {
       optional = true,
     },
     {
+  name   = "group_parity",
+  display= L["Group Parity"],
+  type   = "select",
+  width  = WeakAuras.normalWidth,
+  init   = "arg",            -- make the selected value available to the test
+  -- Show in options but don't force-load auras by itself
+  optional = true,
+  -- Re-evaluate whenever parity can change
+  events = { "PLAYER_ENTERING_WORLD", "GROUP_ROSTER_UPDATE", "ENCOUNTER_START", "ENCOUNTER_END" },
+  -- Values for the dropdown
+  values = function()
+    return {
+      any  = L["Any"],
+      even = L["Even"],
+      odd  = L["Odd"],
+    }
+  end,
+  -- The actual load test (single expression). v is the selected value: "any"/"even"/"odd".
+  test = [[
+    (function(v)
+      if v == "any" then return true end
+      if not IsInRaid() then return false end
+      local idx = UnitInRaid("player"); if not idx then return false end
+      local _, _, g = GetRaidRosterInfo(idx + 1); if not g then return false end
+      if v == "even" then return (g % 2 == 0) end
+      if v == "odd"  then return (g % 2 == 1) end
+      return true
+    end)(%q)
+  ]],
+},
+
+    {
       name = "group_leader",
       display = WeakAuras.newFeatureString .. L["Group Leader/Assist"],
       type = "multiselect",

--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -1956,7 +1956,7 @@ Private.load_prototype = {
       type   = "select",
       width  = WeakAuras.normalWidth,
       optional = true,
-      events = { "PLAYER_ENTERING_WORLD", "GROUP_ROSTER_UPDATE", "ENCOUNTER_START", "ENCOUNTER_END" },
+      events = { "PLAYER_ENTERING_WORLD", "GROUP_ROSTER_UPDATE", "ENCOUNTER_START", "ENCOUNTER_END", "PLAYER_LOGIN" },
       values = function()
         return {
           any  = L["Any"],
@@ -1964,22 +1964,18 @@ Private.load_prototype = {
           odd  = L["Odd"],
         }
       end,
+      -- 👇 add a description with the newFeatureString appended
+      desc = L["Matches your current raid subgroup parity (Even/Odd). Only applies while in a raid."] .. WeakAuras.newFeatureString,
       test = [[
         (function(v)
-          -- normalize the incoming selection
-          v = tostring(v or "any")
-          local vl = v:lower()
-      
-          -- "any" always passes
+          v = tostring(v or "any"); local vl = v:lower()
           if vl == "any" then return true end
-      
-          -- compute parity
+    
           if not IsInRaid() then return false end
           local idx = UnitInRaid("player"); if not idx then return false end
           local _, _, g = GetRaidRosterInfo(idx); if not g then return false end
           local isEven = (math.fmod(g, 2) == 0)
-      
-          -- if selection is "even" (in any case / locale), require even; otherwise treat as odd
+    
           if vl == "even" then
             return isEven
           else

--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -1951,24 +1951,23 @@ Private.load_prototype = {
       optional = true,
     },
     {
-  name   = "group_parity",
-  display= L["Group Parity"],
-  type   = "select",
-  width  = WeakAuras.normalWidth,
-  init   = "arg",            -- make the selected value available to the test
-  -- Show in options but don't force-load auras by itself
-  optional = true,
-  -- Re-evaluate whenever parity can change
-  events = { "PLAYER_ENTERING_WORLD", "GROUP_ROSTER_UPDATE", "ENCOUNTER_START", "ENCOUNTER_END" },
-  -- Values for the dropdown
-  values = function()
-    return {
-      any  = L["Any"],
-      even = L["Even"],
-      odd  = L["Odd"],
-    }
-  end,
-  -- The actual load test (single expression). v is the selected value: "any"/"even"/"odd".
+      name   = "group_parity",
+      display= L["Group Parity"],
+      type   = "select",
+      width  = WeakAuras.normalWidth,
+      -- Show in options but don't force-load auras by itself
+      optional = true,
+      -- Re-evaluate whenever parity can change
+      events = { "PLAYER_ENTERING_WORLD", "GROUP_ROSTER_UPDATE", "ENCOUNTER_START", "ENCOUNTER_END" },
+      -- Values for the dropdown
+      values = function()
+      return {
+        any  = L["Any"],
+        even = L["Even"],
+        odd  = L["Odd"],
+      }
+      end,
+      -- The actual load test (single expression). v is the selected value: "any"/"even"/"odd".
   test = [[
     (function(v)
       if v == "any" then return true end
@@ -1981,7 +1980,6 @@ Private.load_prototype = {
     end)(%q)
   ]],
 },
-
     {
       name = "group_leader",
       display = WeakAuras.newFeatureString .. L["Group Leader/Assist"],


### PR DESCRIPTION
## Summary
Adds a new Load condition: **Group Parity (Even/Odd)**.

This lets users load auras only when they are in an even- or odd-numbered raid subgroup.
Useful for mechanics that split the raid into two teams (e.g., alternating assignments, movement mechanics).

## Implementation
- New load prototype `group_parity` in `Prototypes.lua`
- Options auto-generated in the Load tab (`Any`, `Even`, `Odd`)
- Evaluates on `PLAYER_ENTERING_WORLD`, `GROUP_ROSTER_UPDATE`, `ENCOUNTER_START`, `ENCOUNTER_END`
- Uses `UnitInRaid("player")` + `GetRaidRosterInfo(idx)` to determine subgroup
- Event-driven, no polling, negligible performance impact

## Testing
- Verified in raid groups 1–8
- Correctly loads on odd/even groups, independent of party size
- Export/import round-trips preserve `load.group_parity`

## Notes
- Default is `Any` (always loads in raid)
- Backwards compatible
- Strings (`Group Parity`, `Any`, `Even`, `Odd`, description) are ready for Crowdin translation