### PR TITLE
Bump BigWigsMods/packager to master for build and pull request workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
           -e "s/--@end-experimental@/--@end-experimental@\]=====\]/" WeakAuras/Init.lua
 
       - name: Create Package
-        uses: BigWigsMods/packager@v2
+        uses: BigWigsMods/packager@master
         env:
           CF_API_KEY: ${{ secrets.CF_API_KEY }}
           GITHUB_OAUTH: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -43,7 +43,7 @@ jobs:
           -e "s/--@end-non-experimental@\]=====\]/--@end-non-experimental/" WeakAuras/Init.lua
 
       - name: Create Package
-        uses: BigWigsMods/packager@v2
+        uses: BigWigsMods/packager@master
         with:
           args: -d -z
 


### PR DESCRIPTION
Changed the GitHub Actions workflows to use BigWigsMods/packager@master instead of @v2 for package creation. This ensures the latest packager updates are used during build and pull request workflows.
Shut fix build issues.

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] No tests have been run yet

## Checklist
<!-- These can be checked off after the pull request is submitted, in case you want discussion before they are completely ready -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
