### PR TITLE
Remove atlas file from Wrath Titan Reforge

### DIFF
--- a/WeakAuras/WeakAuras_Wrath.toc
+++ b/WeakAuras/WeakAuras_Wrath.toc
@@ -40,7 +40,6 @@ DefaultOptions.lua
 SubscribableObject.lua
 Features.lua
 TimeMachine.lua
-Atlas_Wrath.lua
 Types_Wrath.lua
 Types.lua
 Prototypes.lua


### PR DESCRIPTION
as it was not running the workflow and C_Texture.GetAtlasElements() is working properly.
I was slowly catching up what you just changed recently on your project.