### PR TITLE
Titan: Raid Launch Fixes

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -34,9 +34,10 @@ body:
     description: What version of World of Warcraft are are you running?
     options:
       - Retail (Default)
-      - Beta (WoW 11.0)
-      - Classic Era
+      - Mists of Pandaria Classic
       - Cataclysm Classic
+      - Titan Reforged
+      - Classic Era
   validations:
     required: true
 

--- a/WeakAuras/Types.lua
+++ b/WeakAuras/Types.lua
@@ -1672,23 +1672,22 @@ Private.power_types = {
 if WeakAuras.IsRetail() then
   Private.power_types[99] = STAGGER
   Private.power_types[19] = POWER_TYPE_ESSENCE
-elseif WeakAuras.IsCataClassic() then
-  Private.power_types[8] = nil
-  Private.power_types[12] = nil
-  Private.power_types[13] = nil
-  Private.power_types[16] = nil
-  Private.power_types[17] = nil
-  Private.power_types[18] = nil
 elseif WeakAuras.IsMists() then
-  Private.power_types[8] = nil
+  for _, k in ipairs{8, 13, 16, 17, 18} do
+    Private.power_types[k] = nil
+  end
   Private.power_types[14] = BURNING_EMBERS
-  Private.power_types[13] = nil
   Private.power_types[15] = POWER_TYPE_DEMONIC_FURY
-  Private.power_types[16] = nil
-  Private.power_types[17] = nil
-  Private.power_types[18] = nil
   Private.power_types[28] = SHADOW_ORBS
   Private.power_types[99] = L["Stagger"]
+elseif WeakAuras.IsCataClassic() then
+  for _, k in ipairs{8, 12, 13, 16, 17, 18} do
+    Private.power_types[k] = nil
+  end
+elseif WeakAuras.IsWrathClassic() then
+  for k = 7, 18 do
+    Private.power_types[k] = nil
+  end
 end
 
 if WeakAuras.IsCataOrMists() then
@@ -3132,10 +3131,14 @@ Private.instance_types = {
   ratedarena = L["Rated Arena"]
 }
 
-if WeakAuras.IsClassicEra() then
+if WeakAuras.IsClassicOrWrath() then
   Private.instance_types["ratedpvp"] = nil
-  Private.instance_types["arena"] = nil
   Private.instance_types["ratedarena"] = nil
+  Private.instance_types["flexible"] = nil
+  Private.instance_types["scenario"] = nil
+  if WeakAuras.IsClassicEra() then
+    Private.instance_types["arena"] = nil
+  end
 end
 
 ---@type table
@@ -3209,11 +3212,12 @@ if not WeakAuras.IsClassicEra() then
     [232] = unused, -- event party
     [236] = L["Lorewalking"],
     [237] = WeakAuras.IsMists() and L["Dungeon (Celestial)"] or unused,
+    [244] = L["25 Player Raid (Titan Reforged)"],
   }
 
   Private.instance_difficulty_types[0] =L["None"]
 
-  for i = 1, 240 do
+  for i = 1, 260 do
     local name, type = GetDifficultyInfo(i)
     if name then
       if instance_difficulty_names[i] then
@@ -3251,32 +3255,24 @@ Private.group_types = {
 }
 
 ---@type table<string, string>
+Private.difficulty_types = {
+  none   = L["None"],
+  normal = PLAYER_DIFFICULTY1,
+  heroic = PLAYER_DIFFICULTY2,
+}
 if WeakAuras.IsRetail() then
-  Private.difficulty_types = {
-    none = L["None"],
-    normal = PLAYER_DIFFICULTY1,
-    heroic = PLAYER_DIFFICULTY2,
-    mythic = PLAYER_DIFFICULTY6,
-    timewalking = PLAYER_DIFFICULTY_TIMEWALKER,
-    lfr = PLAYER_DIFFICULTY3,
-    challenge = PLAYER_DIFFICULTY5
-  }
-elseif WeakAuras.IsCataClassic() then
-  Private.difficulty_types = {
-    none = L["None"],
-    lfr = PLAYER_DIFFICULTY3,
-    normal = PLAYER_DIFFICULTY1,
-    heroic = PLAYER_DIFFICULTY2,
-  }
+  Private.difficulty_types.mythic = PLAYER_DIFFICULTY6
+  Private.difficulty_types.timewalking = PLAYER_DIFFICULTY_TIMEWALKER
+  Private.difficulty_types.lfr = PLAYER_DIFFICULTY3
+  Private.difficulty_types.challenge = PLAYER_DIFFICULTY5
 elseif WeakAuras.IsMists() then
-  Private.difficulty_types = {
-    none = L["None"],
-    normal = PLAYER_DIFFICULTY1,
-    heroic = PLAYER_DIFFICULTY2,
-    mythic = PLAYER_DIFFICULTY6,
-    lfr = PLAYER_DIFFICULTY3,
-    challenge = PLAYER_DIFFICULTY5
-  }
+  Private.difficulty_types.mythic = PLAYER_DIFFICULTY6
+  Private.difficulty_types.lfr = PLAYER_DIFFICULTY3
+  Private.difficulty_types.challenge = PLAYER_DIFFICULTY5
+elseif WeakAuras.IsCataClassic() then
+  Private.difficulty_types.lfr = PLAYER_DIFFICULTY3
+elseif WeakAuras.IsWrathClassic() then
+  Private.difficulty_types.titan = L["Titan Reforged"]
 end
 
 ---@type table<string, string>
@@ -4314,6 +4310,10 @@ Private.difficulty_info = {
   [226] = {
     size = "twenty",
     difficulty = "normal",
+  },
+  [244] = {
+    size = "twentyfive",
+    difficulty = "titan",
   },
 }
 

--- a/WeakAuras/Types_Wrath.lua
+++ b/WeakAuras/Types_Wrath.lua
@@ -30,6 +30,12 @@ function Private.InitializeEncounterAndZoneLists()
       }
     },
     {
+      L["Vault of Archavon"],
+      {
+        { L["Archavon the Stone Watcher"], 772 },
+      }
+    },
+    {
       L["World Bosses"],
       {
         { L["Azuregos"], 3440 },


### PR DESCRIPTION
# Description

- Correcting difficultySize, difficulty, and instance types, including handling for the newly introduced difficulty: 'Raid: 25 Titan-Reforged' https://wago.tools/db2/Difficulty?build=3.80.0.64393
- Introducing Difficulty: 'titan' = L["Titan Reforged"]
- Raised the GetDifficultyInfo loop by a arbitrarily number so that we might be able to detect new difficulties in the future.
- Updated the talent-known trigger to use MiniTalentWidget and refactor so it doesnt expose variables as globals, is nil safe, less shadowing (just hero talent).
- The power types for Titan have been corrected and several conditional removal checks have been refactored.
- Implemented a collection of activation fixes.
- The bug report template has been updated to include all the latest World of Warcraft expansions.
- Corrected lockoutSchool to use C_Spell.GetSchoolString, aligning it with the existing usage in the types table, and it is also marked as deprecated.
- Added Vault of Archavon to Wrath encounter list.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested

- [x] Tested on Titan Reforged

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
