### PR TITLE
Classic/TBC/Wrath: add groupRole and fetchRole to BuffTrigger2

### DIFF
--- a/WeakAuras/BuffTrigger2.lua
+++ b/WeakAuras/BuffTrigger2.lua
@@ -3181,7 +3181,7 @@ function BuffTrigger.Add(data)
 
       local groupTrigger = trigger.unit == "group" or trigger.unit == "raid" or trigger.unit == "party"
       local effectiveIgnoreSelf = (groupTrigger or trigger.unit == "nameplate") and trigger.ignoreSelf
-      local effectiveGroupRole = WeakAuras.IsWrathOrCataOrMistsOrRetail() and (groupTrigger and trigger.useGroupRole and trigger.group_role) or nil
+      local effectiveGroupRole = groupTrigger and trigger.useGroupRole and trigger.group_role or nil
       local effectiveRaidRole = WeakAuras.IsClassicOrTBCOrWrathOrCataOrMists() and (groupTrigger and trigger.useRaidRole and trigger.raid_role) or nil
       local effectiveClass = groupTrigger and trigger.useClass and trigger.class
       local effectiveSpecId = WeakAuras.IsCataOrMistsOrRetail() and (groupTrigger and trigger.useActualSpec and trigger.actualSpec) or nil
@@ -3241,7 +3241,7 @@ function BuffTrigger.Add(data)
         compareFunc = matchCombineFunctions[trigger.combineMode] or matchCombineFunctions["showLowest"],
         unitExists = showIfInvalidUnit,
         fetchTooltip = not IsSingleMissing(trigger) and trigger.unit ~= "multi" and trigger.fetchTooltip,
-        fetchRole = WeakAuras.IsCataOrMistsOrRetail() and trigger.unit ~= "multi" and trigger.fetchRole,
+        fetchRole = trigger.unit ~= "multi" and trigger.fetchRole,
         fetchRaidMark = trigger.unit ~= "multi" and trigger.fetchRaidMark,
         groupTrigger = IsGroupTrigger(trigger),
         ignoreSelf = effectiveIgnoreSelf,
@@ -3424,7 +3424,7 @@ function BuffTrigger.GetAdditionalProperties(data, triggernum)
     props["refreshTime"] = { display = L["Since Apply/Refresh"], formatter = "timed" }
   end
 
-  if WeakAuras.IsCataOrMistsOrRetail() and trigger.unit ~= "multi" and trigger.fetchRole then
+  if trigger.unit ~= "multi" and trigger.fetchRole then
     props["role"] = { display = L["Assigned Role"] }
     props["roleIcon"] = { display = L["Assigned Role Icon"] }
   end

--- a/WeakAurasOptions/BuffTrigger2.lua
+++ b/WeakAurasOptions/BuffTrigger2.lua
@@ -833,7 +833,6 @@ local function GetBuffTriggerOptions(data, triggernum)
       width = WeakAuras.doubleWidth,
       hidden = function()
         return not (trigger.type == "aura2" and trigger.unit ~= "multi")
-               or WeakAuras.IsClassicOrTBCOrWrath()
       end
     },
     fetchRaidMark = {
@@ -919,7 +918,6 @@ local function GetBuffTriggerOptions(data, triggernum)
       order = 67.1,
       hidden = function() return
         not (trigger.type == "aura2" and (trigger.unit == "group" or trigger.unit == "raid" or trigger.unit == "party"))
-        or WeakAuras.IsClassicOrTBC()
       end
     },
     group_role = {
@@ -929,7 +927,6 @@ local function GetBuffTriggerOptions(data, triggernum)
       values = OptionsPrivate.Private.role_types,
       hidden = function() return
         not (trigger.type == "aura2" and (trigger.unit == "group" or trigger.unit == "raid" or trigger.unit == "party") and trigger.useGroupRole)
-        or WeakAuras.IsClassicOrTBC()
       end,
       order = 67.2
     },
@@ -940,7 +937,6 @@ local function GetBuffTriggerOptions(data, triggernum)
       width = WeakAuras.normalWidth,
       hidden = function() return
         not (trigger.type == "aura2" and (trigger.unit == "group" or trigger.unit == "raid" or trigger.unit == "party") and not trigger.useGroupRole)
-        or WeakAuras.IsClassicOrTBC()
       end
     },
     useRaidRole = {


### PR DESCRIPTION
# Description
This adds `groupRole` and `fetchRole` support to BuffTrigger for Classic/TBC/Wrath.

The functionality is already used in other triggers and code paths; this change mainly aligns BuffTrigger2 with existing behavior for consistency.
Role detection is based on the standard WoW API:
[UnitGroupRolesAssigned](https://warcraft.wiki.gg/wiki/API_UnitGroupRolesAssigned)

I tested this mainly for availability to ensure it works correctly in Classic/TBC/Wrath.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
