### PR TITLE
Update for Midnight compatibility

### DIFF
--- a/WeakAuras/Init.lua
+++ b/WeakAuras/Init.lua
@@ -664,12 +664,7 @@ if WeakAuras.IsWrathClassic() then
   end)
 elseif WeakAuras.IsMidnight() then
   C_Timer.After(1, function()
-    WeakAuras.prettyPrint("WeakAuras does not support Midnight due to Blizzard restricting addons. Read more at https://patreon.com/WeakAuras")
-  end)
-  libsAreOk = false
-elseif WeakAuras.IsTWW() then
-  C_Timer.After(1, function()
-    WeakAuras.prettyPrint("WeakAuras does not support Midnight due to Blizzard's new addon restrictions. Read more at https://patreon.com/WeakAuras")
+    WeakAuras.prettyPrint("WeakAuras support for Midnight is limited due to Blizzard restricting addons. Read more at https://patreon.com/WeakAuras")
   end)
 end
 

--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -1447,6 +1447,17 @@ Private.load_prototype = {
       events = {"PLAYER_MOUNT_DISPLAY_CHANGED"}
     },
     {
+      name = "restricted",
+      display = WeakAuras.newFeatureString .. L["Restricted"],
+      type = "tristate",
+      width = WeakAuras.normalWidth,
+      init = WeakAuras.IsRetail() and "arg" or nil,
+      optional = true,
+      enable = WeakAuras.IsRetail(),
+      hidden = not WeakAuras.IsRetail(),
+      events = {"ADDON_RESTRICTION_STATE_CHANGED"}
+    },
+    {
       name = "hardcore",
       display = L["Hardcore"],
       type = "tristate",
@@ -2572,7 +2583,7 @@ Private.event_prototypes = {
         store = true,
         hidden = true,
         test = "true",
-        init = "raidMarkIndex > 0 and '{rt'..raidMarkIndex..'}' or ''"
+        init = "getaccessiblevalue(raidMarkIndex, 0) > 0 and '{rt'..raidMarkIndex..'}' or ''"
       },
       {
         name = "dead",
@@ -2670,7 +2681,7 @@ Private.event_prototypes = {
         type = "string",
         multiline = true,
         store = true,
-        init = "select(6, strsplit('-', UnitGUID(unit) or ''))",
+        init = "select(6, strsplit('-', getaccessiblevalue(UnitGUID(unit)) or ''))",
         conditionType = "string",
         preamble = "local npcIdChecker = Private.ExecEnv.ParseStringCheck(%q)",
         test = "npcIdChecker:Check(npcId)",
@@ -3499,7 +3510,7 @@ Private.event_prototypes = {
         type = "string",
         multiline = true,
         store = true,
-        init = "select(6, strsplit('-', UnitGUID(unit) or ''))",
+        init = "select(6, strsplit('-', getaccessiblevalue(UnitGUID(unit)) or ''))",
         conditionType = "string",
         preamble = "local npcIdChecker = Private.ExecEnv.ParseStringCheck(%q)",
         test = "npcIdChecker:Check(npcId)",
@@ -3575,7 +3586,7 @@ Private.event_prototypes = {
         store = true,
         hidden = true,
         test = "true",
-        init = "raidMarkIndex > 0 and '{rt'..raidMarkIndex..'}' or ''"
+        init = "getaccessiblevalue(raidMarkIndex, 0) > 0 and '{rt'..raidMarkIndex..'}' or ''"
       },
       {
         type = "header",
@@ -4103,7 +4114,7 @@ Private.event_prototypes = {
         type = "string",
         multiline = true,
         store = true,
-        init = "select(6, strsplit('-', UnitGUID(unit) or ''))",
+        init = "select(6, strsplit('-', getaccessiblevalue(UnitGUID(unit)) or ''))",
         conditionType = "string",
         preamble = "local npcIdChecker = Private.ExecEnv.ParseStringCheck(%q)",
         test = "npcIdChecker:Check(npcId)",
@@ -4179,7 +4190,7 @@ Private.event_prototypes = {
         store = true,
         hidden = true,
         test = "true",
-        init = "raidMarkIndex > 0 and '{rt'..raidMarkIndex..'}' or ''"
+        init = "getaccessiblevalue(raidMarkIndex, 0) > 0 and '{rt'..raidMarkIndex..'}' or ''"
       },
       {
         type = "header",
@@ -4478,7 +4489,7 @@ Private.event_prototypes = {
         store = true,
         hidden = true,
         test = "true",
-        init = "raidMarkIndex > 0 and '{rt'..raidMarkIndex..'}' or ''"
+        init = "getaccessiblevalue(raidMarkIndex, 0) > 0 and '{rt'..raidMarkIndex..'}' or ''"
       },
       {
         type = "header",
@@ -4609,7 +4620,7 @@ Private.event_prototypes = {
         display = L["Source NPC Id"],
         type = "string",
         multiline = true,
-        init = "select(6, strsplit('-', sourceGUID or ''))",
+        init = "select(6, strsplit('-', getaccessiblevalue(sourceGUID) or ''))",
         store = true,
         conditionType = "string",
         preamble = "local sourceNpcIdChecker = Private.ExecEnv.ParseStringCheck(%q)",
@@ -4751,7 +4762,7 @@ Private.event_prototypes = {
         display = L["Destination NPC Id"],
         type = "string",
         multiline = true,
-        init = "select(6, strsplit('-', destGUID or ''))",
+        init = "select(6, strsplit('-', getaccessiblevalue(destGUID) or ''))",
         store = true,
         conditionType = "string",
         preamble = "local destNpcIdChecker = Private.ExecEnv.ParseStringCheck(%q)",
@@ -9490,7 +9501,7 @@ Private.event_prototypes = {
         type = "string",
         multiline = true,
         store = true,
-        init = "select(6, strsplit('-', UnitGUID(unit) or ''))",
+        init = "select(6, strsplit('-', getaccessiblevalue(UnitGUID(unit)) or ''))",
         conditionType = "string",
         preamble = "local npcIdChecker = Private.ExecEnv.ParseStringCheck(%q)",
         test = "npcIdChecker:Check(npcId)",
@@ -9739,8 +9750,8 @@ Private.event_prototypes = {
         local destUnit = unit .. '-target'
         local sourceName, sourceRealm = WeakAuras.UnitNameWithRealm(unit)
         local destName, destRealm = WeakAuras.UnitNameWithRealm(destUnit)
-        destName = destName or ""
-        destRealm = destRealm or ""
+        destName = getaccessiblevalue(destName) or ""
+        destRealm = getaccessiblevalue(destRealm) or ""
         local smart = %s
         local remainingCheck = %s
         local inverseTrigger = %s
@@ -9781,9 +9792,9 @@ Private.event_prototypes = {
         if empowered and showChargedDuration then
           endTime = endTime + GetUnitEmpowerHoldAtMaxTime(unit)
         end
-        interruptible = not interruptible
-        expirationTime = endTime and endTime > 0 and (endTime / 1000) or 0
-        remaining = expirationTime - GetTime()
+        if canaccessvalue(interruptible) then interruptible = not interruptible end
+        expirationTime = getaccessiblevalue(endTime) and endTime > 0 and (endTime / 1000) or 0
+        remaining =  expirationTime - GetTime()
 
         if remainingCheck and remaining >= remainingCheck and remaining > 0 then
           Private.ExecEnv.ScheduleCastCheck(expirationTime - remainingCheck, unit)
@@ -9962,7 +9973,7 @@ Private.event_prototypes = {
       {
         name = "duration",
         hidden = true,
-        init = "endTime and startTime and (endTime - startTime)/1000 or 0",
+        init = "getaccessiblevalue(endTime) and getaccessiblevalue(startTime) and (endTime - startTime)/1000 or 0",
         test = "true",
         store = true
       },
@@ -10008,7 +10019,7 @@ Private.event_prototypes = {
         type = "string",
         multiline = true,
         store = true,
-        init = "select(6, strsplit('-', UnitGUID(unit) or ''))",
+        init = "select(6, strsplit('-', getaccessiblevalue(UnitGUID(unit)) or ''))",
         conditionType = "string",
         preamble = "local npcIdChecker = Private.ExecEnv.ParseStringCheck(%q)",
         test = "npcIdChecker:Check(npcId)",
@@ -10077,7 +10088,7 @@ Private.event_prototypes = {
         store = true,
         hidden = true,
         test = "true",
-        init = "raidMarkIndex > 0 and '{rt'..raidMarkIndex..'}' or ''"
+        init = "getaccessiblevalue(raidMarkIndex, 0) > 0 and '{rt'..raidMarkIndex..'}' or ''"
       },
       {
         name = "nameplateType",

--- a/WeakAuras/RegionTypes/DynamicGroup.lua
+++ b/WeakAuras/RegionTypes/DynamicGroup.lua
@@ -405,7 +405,7 @@ local anchorers = {
       for _, regionData in ipairs(activeRegions) do
         local unit = regionData.region.state and regionData.region.state.unit
         if unit then
-          local frame = WeakAuras.GetUnitFrame(unit) or WeakAuras.HiddenFrames
+          local frame = select(2, pcall(WeakAuras.GetUnitFrame, unit)) or WeakAuras.HiddenFrames
           if frame then
             frames[frame] = frames[frame] or {}
             tinsert(frames[frame], regionData)

--- a/WeakAuras/WeakAuras.toc
+++ b/WeakAuras/WeakAuras.toc
@@ -1,4 +1,4 @@
-## Interface: 110207
+## Interface: 120000
 ## Title: WeakAuras
 ## Author: The WeakAuras Team
 ## Version: @project-version@

--- a/WeakAurasArchive/WeakAurasArchive.toc
+++ b/WeakAurasArchive/WeakAurasArchive.toc
@@ -1,4 +1,4 @@
-## Interface: 110207
+## Interface: 120000
 ## Title: WeakAuras Archive
 ## Author: The WeakAuras Team
 ## Version: @project-version@

--- a/WeakAurasModelPaths/WeakAurasModelPaths.toc
+++ b/WeakAurasModelPaths/WeakAurasModelPaths.toc
@@ -1,4 +1,4 @@
-## Interface: 110207
+## Interface: 120000
 ## Title: WeakAuras Model Paths
 ## Author: The WeakAuras Team
 ## Version: @project-version@

--- a/WeakAurasOptions/OptionsFrames/OptionsFrame.lua
+++ b/WeakAurasOptions/OptionsFrames/OptionsFrame.lua
@@ -1613,28 +1613,5 @@ function OptionsPrivate.CreateFrame()
   local left, right, top, bottom = w/2,-w/2, 0, h-25
   frame:SetClampRectInsets(left, right, top, bottom)
 
-  if WeakAuras.IsTWW() then
-    local midnightWarning = CreateFrame("Frame", nil, frame, "BackdropTemplate")
-    midnightWarning:SetBackdrop({
-      bgFile = "Interface\\Addons\\WeakAuras\\Media\\Textures\\Square_FullWhite.tga",
-      edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
-      tile = true,
-      tileSize = 16,
-      edgeSize = 16,
-      insets = { left = 4, right = 4, top = 4, bottom = 4 }
-    })
-
-    midnightWarning:SetBackdropBorderColor(1, 0, 0, 1);
-    midnightWarning:SetBackdropColor(0, 0, 0, 1)
-
-    midnightWarning:SetPoint("TOPLEFT", frame, "BOTTOMLEFT")
-    midnightWarning:SetPoint("TOPRIGHT", frame, "BOTTOMRIGHT")
-    midnightWarning:SetHeight(50)
-
-    local text = midnightWarning:CreateFontString(nil, "OVERLAY", "GameFontNormalLarge")
-    text:SetPoint("LEFT", midnightWarning, "LEFT", 10, 0)
-    text:SetText(L["WeakAuras will not support Midnight. On release of the prepatch, WeakAuras will be disabled.\nRead more on our Patreon page https://patreon.com/WeakAuras"])
-  end
-
   return frame
 end

--- a/WeakAurasOptions/WeakAurasOptions.toc
+++ b/WeakAurasOptions/WeakAurasOptions.toc
@@ -1,4 +1,4 @@
-## Interface: 110207
+## Interface: 120000
 ## Title: WeakAuras Options
 ## Author: The WeakAuras Team
 ## Version: @project-version@

--- a/WeakAurasTemplates/WeakAurasTemplates.toc
+++ b/WeakAurasTemplates/WeakAurasTemplates.toc
@@ -1,4 +1,4 @@
-## Interface: 110207
+## Interface: 120000
 ## Title: WeakAuras Templates
 ## Author: The WeakAuras Team
 ## Version: @project-version@


### PR DESCRIPTION
# Description

This is somewhat of a quick-fix for the Midnight changes. Basically all places that caused problems in combat or during M+ dungeons have been wrapped with the new secret value access APIs, and not being able to access values is treated as them being nil or false in most cases.

This does result in some auras starting to become a bit janky when the restrictions kick in (e.g. buffs/debuffs not updating anymore), so I also added an option to unload auras that would cause problems with addon restrictions.

I still get an error message when logging in about calling `coroutine.resume` and that somehow being prohibited, but I couldn't figure out a solution for this. It doesn't seem to cause any real problems though.

Changes in detail:

- Update Retail ToC version
- Wrap places where potentially secret values are read in new secret value access APIs
- Wrap calls to `WeakAuras.GetUnitFrame` in `pcall`, cause the lib behind it can trigger secret value access errors right now
- Add a load option to load/unload auras based on addon restriction state
- Replace the Midnight warning on login with one hinting at the new addon restrictions
- Remove the Midnight force breakage (libsAreOk) and the warning banner at the bottom

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested

- [x] Using my own auras on Retail, in open world combat and M+ dungeon runs

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
