### PR TITLE
refactor Format %unit logic and fix a Wago export issue

### DIFF
--- a/WeakAuras/Modernize.lua
+++ b/WeakAuras/Modernize.lua
@@ -2489,6 +2489,16 @@ function Private.Modernize(data, oldSnapshot)
     end
   end
 
+  if data.load.instance_type and data.load.instance_type.multi then
+    local multi = {}
+    for k, v in pairs(data.load.instance_type.multi) do
+      if tonumber(k) then
+        multi[tonumber(k)] = v
+      end
+    end
+    data.load.instance_type.multi = multi
+  end
+
   data.internalVersion = max(data.internalVersion or 0, WeakAuras.InternalVersion())
 end
 

--- a/WeakAuras/Types.lua
+++ b/WeakAuras/Types.lua
@@ -835,37 +835,22 @@ Private.format_types = {
 
       if realm == "never" then
         nameFunc = function(unit)
-          return unit and WeakAuras.UnitName(unit) or ""
+          return unit
         end
       elseif realm == "star" then
         nameFunc = function(unit)
-          if not unit then
-            return ""
-          end
-          local name, realm = WeakAuras.UnitName(unit)
-          if realm then
-            return name .. "*"
-          end
-          return name or ""
+          local _, realm = WeakAuras.UnitName(unit)
+          return realm and unit.."*" or unit
         end
       elseif realm == "differentServer" then
         nameFunc = function(unit)
-          if not unit then
-            return ""
-          end
-          local name, realm = WeakAuras.UnitName(unit)
-          if realm then
-            return name .. "-" .. realm
-          end
-          return name or ""
+          local _, realm = WeakAuras.UnitName(unit)
+          return realm and unit.."-"..realm or unit
         end
       elseif realm == "always" then
         nameFunc = function(unit)
-          if not unit then
-            return ""
-          end
-          local name, realm = WeakAuras.UnitNameWithRealmCustomName(unit)
-          return name .. "-" .. realm
+          local _, realm = WeakAuras.UnitNameWithRealmCustomName(unit)
+          return unit.."-"..realm
         end
       end
 
@@ -888,23 +873,62 @@ Private.format_types = {
       if colorFunc then
         if abbreviateFunc then
           return function(unit)
-            local name = abbreviateFunc(nameFunc(unit))
-            return colorFunc(unit, name)
+            if type(unit) == "string" then
+              unit = {strsplit(",", unit)}
+            end
+            if type(unit) == "table" then
+              local name = {}
+              for i = 1, #unit do
+                unit[i] = unit[i]:match("^%s*(.-)%s*$")
+                name[#name + 1] = UnitExists(unit[i]) and colorFunc(unit[i], abbreviateFunc(nameFunc(unit[i]))) or nil
+              end
+              return table.concat(name, ", ")
+            end
           end
         else
           return function(unit)
-            local name = nameFunc(unit)
-            return colorFunc(unit, name)
+            if type(unit) == "string" then
+              unit = {strsplit(",", unit)}
+            end
+            if type(unit) == "table" then
+              local name = {}
+              for i = 1, #unit do
+                unit[i] = unit[i]:match("^%s*(.-)%s*$")
+                name[#name + 1] = UnitExists(unit[i]) and colorFunc(unit[i], nameFunc(unit[i])) or nil
+              end
+              return table.concat(name, ", ")
+            end
           end
         end
       else
         if abbreviateFunc then
           return function(unit)
-            local name = nameFunc(unit)
-            return abbreviateFunc(name)
+            if type(unit) == "string" then
+              unit = {strsplit(",", unit)}
+            end
+            if type(unit) == "table" then
+              local name = {}
+              for i = 1, #unit do
+                unit[i] = unit[i]:match("^%s*(.-)%s*$")
+                name[#name + 1] = UnitExists(unit[i]) and abbreviateFunc(nameFunc(unit[i])) or nil
+              end
+              return table.concat(name, ", ")
+            end
           end
         else
-          return nameFunc
+          return function(unit)
+            if type(unit) == "string" then
+              unit = {strsplit(",", unit)}
+            end
+            if type(unit) == "table" then
+              local name = {}
+              for i = 1, #unit do
+                unit[i] = unit[i]:match("^%s*(.-)%s*$")
+                name[#name + 1] = UnitExists(unit[i]) and nameFunc(unit[i]) or nil
+              end
+              return table.concat(name, ", ")
+            end
+          end
         end
       end
     end

--- a/WeakAuras/Types_Wrath.lua
+++ b/WeakAuras/Types_Wrath.lua
@@ -50,6 +50,46 @@ function Private.InitializeEncounterAndZoneLists()
       }
     },
     {
+      L["Naxxramas"],
+      {
+        -- The Arachnid Quarter
+        { L["Anub'Rekhan"], 1107 },
+        { L["Grand Widow Faerlina"], 1110 },
+        { L["Maexxna"], 1116 },
+        -- The Plague Quarter
+        { L["Noth the Plaguebringer"], 1117 },
+        { L["Heigan the Unclean"], 1112 },
+        { L["Loatheb"], 1115 },
+        -- The Military Quarter
+        { L["Instructor Razuvious"], 1113 },
+        { L["Gothik the Harvester"], 1109 },
+        { L["The Four Horsemen"], 1121 },
+        -- The Construct Quarter
+        { L["Patchwerk"], 1118 },
+        { L["Grobbulus"], 1111 },
+        { L["Gluth"], 1108 },
+        { L["Thaddius"], 1120 },
+        -- Frostwyrm Lair
+        { L["Sapphiron"], 1119 },
+        { L["Kel'Thuzad"], 1114 }
+      }
+    },
+    {
+      L["The Obsidian Sanctum"],
+      {
+        { L["Tenebron"], 736 },
+        { L["Shadron"], 738 },
+        { L["Vesperon"], 740 },
+        { L["Sartharion"], 742 },
+      }
+    },
+    {
+      L["The Eye of Eternity"],
+      {
+        { L["Malygos"], 734 },
+      }
+    },
+    {
       L["Vault of Archavon"],
       {
         { L["Archavon the Stone Watcher"], 772 },

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -1607,7 +1607,7 @@ local function GetInstanceTypeAndSize()
     end
     return size, difficulty, instanceType, instanceId, difficultyIndex
   end
-  return "none", "none", nil, nil, 0
+  return "none", "none", nil, instanceId, 0
 end
 
 ---@return string instanceType
@@ -6326,7 +6326,7 @@ do
 
   function WeakAuras.UnitNameWithRealmCustomName(unit)
     ownRealm = ownRealm or select(2, UnitFullName("player"))
-    local name, realm =  WeakAuras.UnitFullName(unit)
+    local name, realm = WeakAuras.UnitFullName(unit)
     return name or "", realm or ownRealm or ""
   end
 end


### PR DESCRIPTION
1
If instance_type.multi is used in load conditions, importing the aura to Wago and then exporting it will cause the instance_type IDs to change from number (e.g. [244] = true) to string (e.g. ["244"] = true), which results in errors.
I’m not sure when this issue will be fixed on Wago, so I added code in Modernize to convert the instance_type IDs back to number when importing into WeakAuras. Even if Wago fixes the problem in the future, this code should not cause extra issues.

2
Add instanceId to map info return values outside instances so that the corresponding instanceId can also be used as a load condition in non-instance areas (e.g. Northrend - i571).

3
Previously, when using the affected or unaffected fields in Buff Triggers, it was not possible to apply class color to multiple units via Format %unit, which required additional code to achieve coloring—this was inconvenient. Therefore, I adjusted the relevant Format %unit code so that it now works with affected/unaffected.
The difference in behavior after the adjustment is that if the input value is name (e.g., unitName/affected), the output will also be name. If the input value is unit (e.g., unit/affectedUnits), the output will remain unit (previously it would output name instead). This is intentional: if the user wants name, they can always use name as input to obtain name. If they use unit as input, it implies they want unit as the result. If they need colored name, they can switch the input to name. Additionally, in scenarios where users want colored unit as the output, they can now achieve that as well.

4
Also added encounterIDs for phase 3 of the Titan Forged server.