### PR TITLE
Fix Circular Texture subregion disappearing with inverse at full progress

### DIFF
--- a/WeakAuras/Init.lua
+++ b/WeakAuras/Init.lua
@@ -256,6 +256,7 @@ Private.frames = {}
 --- @field ignoreOptionsEventErrors boolean|nil
 --- @field showNilIsFalse boolean|nil
 --- @field groupOffset boolean|nil
+--- @field circularTextureInverseLegacy boolean|nil
 
 --- @alias dynamicGroupCenterType
 --- | "LR"

--- a/WeakAuras/Modernize.lua
+++ b/WeakAuras/Modernize.lua
@@ -2493,6 +2493,10 @@ function Private.Modernize(data, oldSnapshot)
     data.information.showNilIsFalse = true
   end
 
+  if data.internalVersion < 90 then
+    data.information.circularTextureInverseLegacy = true
+  end
+
   data.internalVersion = max(data.internalVersion or 0, WeakAuras.InternalVersion())
 end
 

--- a/WeakAuras/SubRegionTypes/CircularProgressTexture.lua
+++ b/WeakAuras/SubRegionTypes/CircularProgressTexture.lua
@@ -211,6 +211,9 @@ local funcs = {
           local progress
           if duration == 0 then
             progress = 0
+            if self.inverse and not self.inverseLegacy then
+              progress = 1 - progress
+            end
           else
             progress = remaining / self.progressData.duration
             if self.inverse then
@@ -224,6 +227,9 @@ local funcs = {
           local progress
           if duration == 0 then
             progress = 0
+            if self.inverse and not self.inverseLegacy then
+              progress = 1 - progress
+            end
           else
             progress = remaining / self.progressData.duration
             if self.inverse then
@@ -296,6 +302,7 @@ local function modify(parent, region, parentData, data, first)
   end
 
   region.inverse = data.circularTextureInverse
+  region.inverseLegacy = parentData.information.circularTextureInverseLegacy
 
   Private.CircularProgressTextureBase.modify(region.circularTexture, {
     crop_x = 1 + data.circularTextureCrop_x,

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -3,7 +3,7 @@ local AddonName = ...
 ---@class Private
 local Private = select(2, ...)
 
-local internalVersion = 89
+local internalVersion = 90
 
 -- Lua APIs
 local insert = table.insert

--- a/WeakAurasOptions/InformationOptions.lua
+++ b/WeakAurasOptions/InformationOptions.lua
@@ -216,6 +216,9 @@ function OptionsPrivate.GetInformationOptions(data)
       name = L["Offset by 1px"],
       onParent = true,
       regionType = "group"
+    },
+    circularTextureInverseLegacy = {
+      name = L["Circular Texture: Skip inverse when duration is zero"]
     }
   }
 
@@ -224,7 +227,8 @@ function OptionsPrivate.GetInformationOptions(data)
     ignoreOptionsEventErrors = true,
     showNilIsFalse = true,
     forceEvents = true,
-    groupOffset = true
+    groupOffset = true,
+    circularTextureInverseLegacy = true
   }
 
   --- @type table<string, boolean>


### PR DESCRIPTION
## Summary
- Fixes the Circular Texture subregion disappearing when "Inverse" is checked and duration reaches 0
- The inverse calculation was inside the `duration ~= 0` else block, so it was skipped at zero duration
- Gated behind a new compatibility option `circularTextureInverseLegacy` (auto-enabled for existing auras via Modernize at internalVersion < 90)
- Old auras keep the old behavior; new auras get the fix where inverse always applies, matching the static progress branch
- Bumps internalVersion to 90

Fixes #5904

## Test plan
- [ ] Create a **new** aura with a Circular Texture subregion with "Inverse" checked
- [ ] Verify the texture remains visible when timed progress completes (duration becomes 0)
- [ ] Verify old auras (with compat option enabled) keep the old behavior
- [ ] Toggling the compat option off on an old aura should apply the fix
- [ ] Verify normal (non-inverse) circular textures still work correctly