### PR TITLE
Fix regression in TSU helpers for creating/updating states

### DIFF
--- a/WeakAuras/GenericTrigger.lua
+++ b/WeakAuras/GenericTrigger.lua
@@ -4704,7 +4704,7 @@ function GenericTrigger.GetOverlayInfo(data, triggernum)
           count = variables.additionalProgress;
         end
       else
-        local allStates = setmetatable({}, Private.allstatesMetatable)
+        local allStates = Private.GetNewAllStates(data)
         Private.ActivateAuraEnvironment(data.id);
         RunTriggerFunc(allStates, events[data.id][triggernum], data.id, triggernum, "OPTIONS");
         Private.ActivateAuraEnvironment(nil);

--- a/WeakAuras/TSUHelpers.lua
+++ b/WeakAuras/TSUHelpers.lua
@@ -7,6 +7,15 @@ local Private = select(2, ...)
 ---@alias key string | integer
 ---@alias states table<key, state>
 
+----@type fun(state: state)
+local function fixMissingFields(state)
+  if type(state) ~= "table" then return end
+  -- set show
+  if state.show == nil then
+    state.show = true
+  end
+end
+
 
 ---@type fun(states: states, key: key): boolean
 local remove = function(states, key)
@@ -149,3 +158,30 @@ Private.allstatesMetatable = {
     SetChanged = setChanged,
   }
 }
+
+local function addFixMissingFields(func)
+  return function(states, key, ...)
+    local changed = func(states, key, ...)
+    fixMissingFields(states[key])
+    return changed
+  end
+end
+
+Private.allstatesMetatableLegacy = {
+  __index = {
+    Update = addFixMissingFields(createOrUpdate),
+    Replace = addFixMissingFields(createOrReplace),
+    Remove = remove,
+    RemoveAll = removeAll,
+    Get = get,
+    IsChanged = isChanged,
+    SetChanged = setChanged,
+  }
+}
+
+Private.GetNewAllStates = function(data)
+  if data.information.showNilIsFalse then
+    return setmetatable({}, Private.allstatesMetatableLegacy)
+  end
+  return setmetatable({}, Private.allstatesMetatable)
+end

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -4642,7 +4642,7 @@ function WeakAuras.GetTriggerStateForTrigger(id, triggernum)
     return Private.GetGlobalConditionState();
   end
   if triggerState[id][triggernum] == nil then
-    triggerState[id][triggernum] = setmetatable({}, Private.allstatesMetatable)
+    triggerState[id][triggernum] = Private.GetNewAllStates(WeakAuras.GetData(id))
   end
   return triggerState[id][triggernum];
 end
@@ -5011,7 +5011,7 @@ function Private.UpdatedTriggerState(id)
 
   local changed = false;
   for triggernum = 1, triggerState[id].numTriggers do
-    triggerState[id][triggernum] = triggerState[id][triggernum] or setmetatable({}, Private.allstatesMetatable)
+    triggerState[id][triggernum] = triggerState[id][triggernum] or Private.GetNewAllStates(WeakAuras.GetData(id))
 
     local anyStateShown = false;
 


### PR DESCRIPTION
For existing auras allstates:Update/Replace need to set show to true, because otherwise the missing show immediately hides the aura.

Fixes: #6169
