### PR TITLE
Fix bug: AdditionalProgress is not showing up when using circular mode.

### DIFF
--- a/WeakAuras/RegionTypes/ProgressTexture.lua
+++ b/WeakAuras/RegionTypes/ProgressTexture.lua
@@ -388,7 +388,9 @@ local function ApplyAdditionalProgressCircular(self, additionalProgress, min, ma
 
       if ((endProgress - startProgress) == 0) then
         extraSpinner:SetProgress(0, 0)
+        extraSpinner:Hide() -- JT fix additionalProgress not showing up
       else
+        extraSpinner:Show() -- JT fix additionalProgress not showing up
         local color = self.overlays[index];
         if (color) then
           extraSpinner:SetColor(unpack(color));

--- a/WeakAuras/RegionTypes/ProgressTexture.lua
+++ b/WeakAuras/RegionTypes/ProgressTexture.lua
@@ -388,9 +388,9 @@ local function ApplyAdditionalProgressCircular(self, additionalProgress, min, ma
 
       if ((endProgress - startProgress) == 0) then
         extraSpinner:SetProgress(0, 0)
-        extraSpinner:Hide() -- JT fix additionalProgress not showing up
+        extraSpinner:Hide()
       else
-        extraSpinner:Show() -- JT fix additionalProgress not showing up
+        extraSpinner:Show()
         local color = self.overlays[index];
         if (color) then
           extraSpinner:SetColor(unpack(color));


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
<!-- A #ticketNumber will be sufficient. -->
Fixes #NOT REPORTED

AdditionalProgress is not showing up when using circular mode. It shows at first time the aura triggered. But never show again.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Create an aura with ProgressTexture
- [x] Choose Custom Trigger with additionalProgress(different color and shorter for easy to show the bug)
- [x] Trigger the aura. It works okay at first time.
- [x] Trigger the aura again. The additionalProgress won't show any more.
- [x] After fix the extraSpinners Show/Hide, the issue gone.

## Checklist
<!-- These can be checked off after the pull request is submitted, in case you want discussion before they are completely ready -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

<!-- Is there any additional work that needs to be done? If so, add it to the above list -->

Nope. This is the kind of problem that's easy to fix, but hardly anyone notices it.