### PR TITLE
patches

### DIFF
--- a/WeakAuras/GenericTrigger.lua
+++ b/WeakAuras/GenericTrigger.lua
@@ -4481,7 +4481,7 @@ do
 end
 
 -- combat assist next cast
-if not WeakAuras.IsWrathClassic() and C_AssistedCombat and C_AssistedCombat.GetNextCastSpell then
+if not WeakAuras.IsTBCOrWrathOrMists() and C_AssistedCombat and C_AssistedCombat.GetNextCastSpell then
   local assistedCombatFrame
 
   local function assistedCombatUpdate(self, elapsed)

--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -12311,7 +12311,7 @@ Private.event_prototypes = {
   },
 };
 
-if not WeakAuras.IsWrathClassic() and C_AssistedCombat and C_AssistedCombat.GetNextCastSpell then
+if not WeakAuras.IsTBCOrWrathOrMists() and C_AssistedCombat and C_AssistedCombat.GetNextCastSpell then
   Private.event_prototypes["Assisted Combat Next Cast"] = {
     type = "spell",
     events = { "SPELLS_CHANGED"},

--- a/WeakAuras/WeakAuras_Mists.toc
+++ b/WeakAuras/WeakAuras_Mists.toc
@@ -1,4 +1,4 @@
-## Interface: 50503, 50504
+## Interface: 50504
 ## Title: WeakAuras
 ## Author: The WeakAuras Team
 ## Version: @project-version@

--- a/WeakAuras/WeakAuras_TBC.toc
+++ b/WeakAuras/WeakAuras_TBC.toc
@@ -1,4 +1,4 @@
-## Interface: 20505
+## Interface: 20505, 20506
 ## Title: WeakAuras
 ## Author: The WeakAuras Team
 ## Version: @project-version@

--- a/WeakAurasArchive/WeakAurasArchive_Mists.toc
+++ b/WeakAurasArchive/WeakAurasArchive_Mists.toc
@@ -1,4 +1,4 @@
-## Interface: 50503, 50504
+## Interface: 50504
 ## Title: WeakAuras Archive
 ## Author: The WeakAuras Team
 ## Version: @project-version@

--- a/WeakAurasArchive/WeakAurasArchive_TBC.toc
+++ b/WeakAurasArchive/WeakAurasArchive_TBC.toc
@@ -1,4 +1,4 @@
-## Interface: 20505
+## Interface: 20505, 20506
 ## Title: WeakAuras Archive
 ## Author: The WeakAuras Team
 ## Version: @project-version@

--- a/WeakAurasModelPaths/WeakAurasModelPaths_Mists.toc
+++ b/WeakAurasModelPaths/WeakAurasModelPaths_Mists.toc
@@ -1,4 +1,4 @@
-## Interface: 50503, 50504
+## Interface: 50504
 ## Title: WeakAuras Model Paths
 ## Author: The WeakAuras Team
 ## Version: @project-version@

--- a/WeakAurasModelPaths/WeakAurasModelPaths_TBC.toc
+++ b/WeakAurasModelPaths/WeakAurasModelPaths_TBC.toc
@@ -1,4 +1,4 @@
-## Interface: 20505
+## Interface: 20505, 20506
 ## Title: WeakAuras Model Paths
 ## Author: The WeakAuras Team
 ## Version: @project-version@

--- a/WeakAurasOptions/WeakAurasOptions_Mists.toc
+++ b/WeakAurasOptions/WeakAurasOptions_Mists.toc
@@ -1,4 +1,4 @@
-## Interface: 50503, 50504
+## Interface: 50504
 ## Title: WeakAuras Options
 ## Author: The WeakAuras Team
 ## Version: @project-version@

--- a/WeakAurasOptions/WeakAurasOptions_TBC.toc
+++ b/WeakAurasOptions/WeakAurasOptions_TBC.toc
@@ -1,4 +1,4 @@
-## Interface: 20505
+## Interface: 20505, 20506
 ## Title: WeakAuras Options
 ## Author: The WeakAuras Team
 ## Version: @project-version@

--- a/WeakAurasTemplates/WeakAurasTemplates_Mists.toc
+++ b/WeakAurasTemplates/WeakAurasTemplates_Mists.toc
@@ -1,4 +1,4 @@
-## Interface: 50503, 50504
+## Interface: 50504
 ## Title: WeakAuras Templates
 ## Author: The WeakAuras Team
 ## Version: @project-version@

--- a/WeakAurasTemplates/WeakAurasTemplates_TBC.toc
+++ b/WeakAurasTemplates/WeakAurasTemplates_TBC.toc
@@ -1,4 +1,4 @@
-## Interface: 20505
+## Interface: 20505, 20506
 ## Title: WeakAuras Templates
 ## Author: The WeakAuras Team
 ## Version: @project-version@


### PR DESCRIPTION
### Description
TBC Anniversary PTR is currently open. I did some quick clicking around though every Trigger and Region and did not notice anything obvious issues besides the Assisted Combat trigger.

Update TOCs for TBC Anniversary/PTR and Mists.
Also disables the Assisted Combat trigger, since the assisted combat API is not supported there even if the namespace is present.

@InfusOnWoW `C_NamePlate.GetNamePlateSize()` got added in MoP and TBC
might be the new thing for:
https://github.com/WeakAuras/WeakAuras2/blob/b8103b634b69ee8f5730ddb3a5e8c8efba2d33a9/WeakAuras/WeakAuras.lua#L5860-L5913
