### PR TITLE
Add Font Flag Slug and Smooth Scaling

### DIFF
--- a/WeakAuras/RegionTypes/Text.lua
+++ b/WeakAuras/RegionTypes/Text.lua
@@ -160,7 +160,11 @@ local function modify(parent, region, data)
 
   text:SetTextHeight(data.fontSize);
   fontObject:SetShadowColor(unpack(data.shadowColor))
-  fontObject:SetShadowOffset(data.shadowXOffset, data.shadowYOffset)
+  if data.outline == "OUTLINE|SLUG" then
+    fontObject:SetShadowOffset(0, 0)
+  else
+    fontObject:SetShadowOffset(data.shadowXOffset, data.shadowYOffset)
+  end
 
   text:ClearAllPoints();
   text:SetPoint(data.justify, region, data.justify);

--- a/WeakAuras/RegionTypes/Text.lua
+++ b/WeakAuras/RegionTypes/Text.lua
@@ -6,6 +6,7 @@ local Private = select(2, ...)
 
 local SharedMedia = LibStub("LibSharedMedia-3.0");
 local L = WeakAuras.L;
+local FontStringScaleAnimationMode = Enum and Enum.FontStringScaleAnimationMode
 
 local defaultFont = WeakAuras.defaultFont
 local defaultFontSize = WeakAuras.defaultFontSize
@@ -112,6 +113,13 @@ local function modify(parent, region, data)
 
   local fontPath = SharedMedia:Fetch("font", data.font);
   local outline = data.outline == "None" and "" or data.outline
+  local slugFont = data.outline == "SLUG" or data.outline == "OUTLINE|SLUG"
+  if text.SetScaleAnimationMode and FontStringScaleAnimationMode then
+    text:SetScaleAnimationMode(slugFont and FontStringScaleAnimationMode.Vertex or FontStringScaleAnimationMode.FontSize)
+  end
+  if text.SetSmoothScaling then
+    text:SetSmoothScaling(data.smoothScaling or false) -- doesn't accept nil
+  end
   text:SetFont(fontPath, data.fontSize, outline);
   if not text:GetFont() and fontPath then -- workaround font not loading correctly
     local objectName = "WeakAuras-Font-" .. data.font

--- a/WeakAuras/SubRegionTypes/SubText.lua
+++ b/WeakAuras/SubRegionTypes/SubText.lua
@@ -6,6 +6,7 @@ local Private = select(2, ...)
 
 local SharedMedia = LibStub("LibSharedMedia-3.0");
 local L = WeakAuras.L;
+local FontStringScaleAnimationMode = Enum and Enum.FontStringScaleAnimationMode
 
 local screenWidth, screenHeight = math.ceil(GetScreenWidth() / 20) * 20, math.ceil(GetScreenHeight() / 20) * 20
 
@@ -211,6 +212,13 @@ local function modify(parent, region, parentData, data, first)
 
   local fontPath = SharedMedia:Fetch("font", data.text_font);
   local fontType = data.text_fontType == "None" and "" or data.text_fontType
+  local slugFont = data.text_fontType == "SLUG" or data.text_fontType == "OUTLINE|SLUG"
+  if text.SetScaleAnimationMode and FontStringScaleAnimationMode then
+    text:SetScaleAnimationMode(slugFont and FontStringScaleAnimationMode.Vertex or FontStringScaleAnimationMode.FontSize)
+  end
+  if text.SetSmoothScaling then
+    text:SetSmoothScaling(data.text_smoothScaling or false) -- doesn't accept nil
+  end
   text:SetFont(fontPath, data.text_fontSize, fontType);
   if not text:GetFont() and fontPath then -- workaround font not loading correctly
     local objectName = "WeakAuras-Font-" .. data.text_font

--- a/WeakAuras/SubRegionTypes/SubText.lua
+++ b/WeakAuras/SubRegionTypes/SubText.lua
@@ -237,7 +237,11 @@ local function modify(parent, region, parentData, data, first)
   text:SetTextHeight(data.text_fontSize);
 
   fontObject:SetShadowColor(unpack(data.text_shadowColor))
-  fontObject:SetShadowOffset(data.text_shadowXOffset, data.text_shadowYOffset)
+  if data.text_fontType == "OUTLINE|SLUG" then
+    fontObject:SetShadowOffset(0, 0)
+  else
+    fontObject:SetShadowOffset(data.text_shadowXOffset, data.text_shadowYOffset)
+  end
   fontObject:SetJustifyH(data.text_justify or "CENTER")
 
   if (data.text_automaticWidth == "Fixed") then

--- a/WeakAuras/Types.lua
+++ b/WeakAuras/Types.lua
@@ -1561,8 +1561,10 @@ Private.tick_placement_modes = {
 ---@type table<string, string>
 Private.font_flags = {
   None = L["None"],
+  ["SLUG"] = WeakAuras.newFeatureString .. L["Slug"],
   MONOCHROME = L["Monochrome"],
   OUTLINE = L["Outline"],
+  ["OUTLINE|SLUG"] = WeakAuras.newFeatureString .. L["Slug Outline"],
   THICKOUTLINE  = L["Thick Outline"],
   ["MONOCHROME|OUTLINE"] = L["Monochrome Outline"],
   ["MONOCHROME|THICKOUTLINE"] = L["Monochrome Thick Outline"]

--- a/WeakAurasOptions/RegionOptions/Text.lua
+++ b/WeakAurasOptions/RegionOptions/Text.lua
@@ -143,7 +143,13 @@ local function createOptions(id, data)
       hasAlpha = true,
       order = 47
     },
-
+    smoothScaling = {
+      type = "toggle",
+      width = WeakAuras.normalWidth,
+      name = WeakAuras.newFeatureString .. L["Smooth Font"],
+      desc = L["Smooths text height, preventing it from snapping to the nearest whole number when scaled."],
+      order = 47.5
+    },
     fontFlagsDescription = {
       order = 48,
       width = WeakAuras.doubleWidth,
@@ -151,6 +157,7 @@ local function createOptions(id, data)
       control = "WeakAurasExpandSmall",
       name = function()
         local textFlags = OptionsPrivate.Private.font_flags[data.outline]
+        local hideShadow = data.outline == "OUTLINE|SLUG"
         local color = format("%02x%02x%02x%02x",
                              data.shadowColor[4] * 255, data.shadowColor[1] * 255,
                              data.shadowColor[2] * 255, data.shadowColor[3]*255)
@@ -175,7 +182,12 @@ local function createOptions(id, data)
           textWidth = " "..L["and with width |cFFFF0000%s|r and %s"]:format(data.fixedWidth, wordWarp)
         end
 
-        local secondline = L["|cFFffcc00Font Flags:|r |cFFFF0000%s|r and shadow |c%sColor|r with offset |cFFFF0000%s/%s|r%s%s"]:format(textFlags, color, data.shadowXOffset, data.shadowYOffset, textJustify, textWidth)
+        local secondline
+        if hideShadow then
+          secondline = L["|cFFffcc00Font Flags:|r |cFFFF0000%s|r%s%s"]:format(textFlags, textJustify, textWidth)
+        else
+          secondline = L["|cFFffcc00Font Flags:|r |cFFFF0000%s|r and shadow |c%sColor|r with offset |cFFFF0000%s/%s|r%s%s"]:format(textFlags, color, data.shadowXOffset, data.shadowYOffset, textJustify, textWidth)
+        end
 
         return secondline
       end,
@@ -215,14 +227,27 @@ local function createOptions(id, data)
       width = WeakAuras.normalWidth,
       name = L["Shadow Color"],
       order = 48.3,
-      hidden = hiddenFontExtra
+      hidden = function()
+        return hiddenFontExtra() or data.outline == "OUTLINE|SLUG"
+      end
+    },
+    shadowColorSpace = {
+      type = "description",
+      name = "",
+      width = WeakAuras.normalWidth,
+      order = 48.3,
+      hidden = function()
+        return hiddenFontExtra() or data.outline ~= "OUTLINE|SLUG"
+      end
     },
 
     text_font_space3 = {
       type = "description",
       name = "",
       order = 48.4,
-      hidden = hiddenFontExtra,
+      hidden = function()
+        return hiddenFontExtra() or data.outline == "OUTLINE|SLUG"
+      end,
       width = indentWidth
     },
     shadowXOffset = {
@@ -234,7 +259,9 @@ local function createOptions(id, data)
       softMax = 15,
       bigStep = 1,
       order = 48.5,
-      hidden = hiddenFontExtra
+      hidden = function()
+        return hiddenFontExtra() or data.outline == "OUTLINE|SLUG"
+      end
     },
     shadowYOffset = {
       type = "range",
@@ -245,7 +272,9 @@ local function createOptions(id, data)
       softMax = 15,
       bigStep = 1,
       order = 48.6,
-      hidden = hiddenFontExtra
+      hidden = function()
+        return hiddenFontExtra() or data.outline == "OUTLINE|SLUG"
+      end
     },
 
     text_font_space4 = {

--- a/WeakAurasOptions/RegionOptions/Text.lua
+++ b/WeakAurasOptions/RegionOptions/Text.lua
@@ -143,12 +143,12 @@ local function createOptions(id, data)
       hasAlpha = true,
       order = 47
     },
-    smoothScaling = {
-      type = "toggle",
+    outline = {
+      type = "select",
       width = WeakAuras.normalWidth,
-      name = WeakAuras.newFeatureString .. L["Smooth Font"],
-      desc = L["Smooths text height, preventing it from snapping to the nearest whole number when scaled."],
-      order = 47.5
+      name = L["Outline"],
+      order = 47.5,
+      values = OptionsPrivate.Private.font_flags,
     },
     fontFlagsDescription = {
       order = 48,
@@ -156,22 +156,20 @@ local function createOptions(id, data)
       type = "execute",
       control = "WeakAurasExpandSmall",
       name = function()
-        local textFlags = OptionsPrivate.Private.font_flags[data.outline]
         local hideShadow = data.outline == "OUTLINE|SLUG"
         local color = format("%02x%02x%02x%02x",
                              data.shadowColor[4] * 255, data.shadowColor[1] * 255,
                              data.shadowColor[2] * 255, data.shadowColor[3]*255)
 
-        local textJustify = ""
+        local text = ""
         if data.justify == "CENTER" then
           -- CENTER is default
         elseif data.justify == "LEFT" then
-          textJustify = " " .. L["and aligned left"]
+          text = L["Aligned left"]
         elseif data.justify == "RIGHT" then
-          textJustify = " " ..  L["and aligned right"]
+          text =  L["Aligned right"]
         end
 
-        local textWidth = ""
         if data.automaticWidth == "Fixed" then
           local wordWarp = ""
           if data.wordWrap == "WordWrap" then
@@ -179,17 +177,36 @@ local function createOptions(id, data)
           else
             wordWarp = L["eliding"]
           end
-          textWidth = " "..L["and with width |cFFFF0000%s|r and %s"]:format(data.fixedWidth, wordWarp)
+          if text == "" then
+            text = L["Width |cFFFF0000%s|r and %s"]:format(data.fixedWidth, wordWarp)
+          else
+            text = text .. " " .. L["and with width |cFFFF0000%s|r and %s"]:format(data.fixedWidth, wordWarp)
+          end
         end
 
-        local secondline
-        if hideShadow then
-          secondline = L["|cFFffcc00Font Flags:|r |cFFFF0000%s|r%s%s"]:format(textFlags, textJustify, textWidth)
+        if data.smoothScaling then
+          if text == "" then
+            text = L["Smooth scaling"]
+          else
+            text = text .. " " .. L["and smooth scaling"]
+          end
+        end
+
+        if not hideShadow then
+          if text == "" then
+            text = text .. " " .. L["Shadow |c%sColor|r with offset |cFFFF0000%s/%s|r"]
+                                  :format(color, data.shadowXOffset, data.shadowYOffset)
+          else
+            text = text .. " " .. L["and shadow |c%sColor|r with offset |cFFFF0000%s/%s|r"]
+                                  :format(color, data.shadowXOffset, data.shadowYOffset)
+          end
+        end
+
+        if text == "" then
+          return L["|cFFffcc00Font Flags:|r none"]
         else
-          secondline = L["|cFFffcc00Font Flags:|r |cFFFF0000%s|r and shadow |c%sColor|r with offset |cFFFF0000%s/%s|r%s%s"]:format(textFlags, color, data.shadowXOffset, data.shadowYOffset, textJustify, textWidth)
+          return L["|cFFffcc00Font Flags:|r"] .. " " .. text
         end
-
-        return secondline
       end,
       func = function(info, button)
         local collapsed = OptionsPrivate.IsCollapsed("text", "text", "fontflags", true)
@@ -213,14 +230,15 @@ local function createOptions(id, data)
       hidden = hiddenFontExtra,
       width = indentWidth
     },
-    outline = {
-      type = "select",
+    smoothScaling = {
+      type = "toggle",
       width = WeakAuras.normalWidth - indentWidth,
-      name = L["Outline"],
+      name = WeakAuras.newFeatureString .. L["Smooth Font"],
+      desc = L["Smooths text height, preventing it from snapping to the nearest whole number when scaled."],
       order = 48.2,
-      values = OptionsPrivate.Private.font_flags,
       hidden = hiddenFontExtra
     },
+
     shadowColor = {
       type = "color",
       hasAlpha = true,

--- a/WeakAurasOptions/SubRegionOptions/SubText.lua
+++ b/WeakAurasOptions/SubRegionOptions/SubText.lua
@@ -113,40 +113,45 @@ local function createOptions(parentData, data, index, subIndex)
       hasAlpha = true,
       order = 15,
     },
-    text_smoothScaling = {
-      type = "toggle",
+     text_fontType = {
+      type = "select",
       width = WeakAuras.normalWidth,
-      name = WeakAuras.newFeatureString .. L["Smooth Font"],
-      desc = L["Smooths text height, preventing it from snapping to the nearest whole number when scaled."],
-      order = 16
+      name = L["Outline"],
+      order = 16,
+      values = OptionsPrivate.Private.font_flags,
     },
     text_fontFlagsDescription = {
       type = "execute",
       control = "WeakAurasExpandSmall",
       name = function()
-        local textFlags = OptionsPrivate.Private.font_flags[data.text_fontType]
         local hideShadow = data.text_fontType == "OUTLINE|SLUG"
         local color = format("%02x%02x%02x%02x",
                              data.text_shadowColor[4] * 255, data.text_shadowColor[1] * 255,
                              data.text_shadowColor[2] * 255, data.text_shadowColor[3]*255)
 
-        local textJustify = ""
+        local text = ""
         if data.text_justify == "CENTER" then
           -- CENTER is default
         elseif data.text_justify == "LEFT" then
-          textJustify = " " .. L["and aligned left"]
+          text = L["Aligned left"]
         elseif data.text_justify == "RIGHT" then
-          textJustify = " " ..  L["and aligned right"]
+          text = L["Aligned right"]
         end
 
-        local textRotate = ""
         if data.rotateText == "LEFT" then
-          textRotate = " " .. L["and rotated left"]
+          if text == "" then
+            text = L["Rotated left"]
+          else
+            text = text .. " " .. L["and rotated left"]
+          end
         elseif data.rotateText == "RIGHT" then
-          textRotate = " " .. L["and rotated right"]
+          if text == "" then
+            text = L["Rotated right"]
+          else
+            text = text .. " " .. L["and rotated right"]
+          end
         end
 
-        local textWidth = ""
         if data.text_automaticWidth == "Fixed" then
           local wordWarp = ""
           if data.text_wordWrap == "WordWrap" then
@@ -154,20 +159,35 @@ local function createOptions(parentData, data, index, subIndex)
           else
             wordWarp = L["eliding"]
           end
-          textWidth = " "..L["and with width |cFFFF0000%s|r and %s"]:format(data.text_fixedWidth, wordWarp)
+          if text == "" then
+            text = L["Width |cFFFF0000%s|r and %s"]:format(data.text_fixedWidth, wordWarp)
+          else
+            text = text .. " "..L["and with width |cFFFF0000%s|r and %s"]:format(data.text_fixedWidth, wordWarp)
+          end
         end
 
-        local secondline
-        if hideShadow then
-          secondline = L["|cFFffcc00Font Flags:|r |cFFFF0000%s|r%s%s%s"]
-            :format(textFlags, textRotate, textJustify, textWidth)
+         if data.text_smoothScaling then
+          if text == "" then
+            text = L["Smooth scaling"]
+          else
+            text = text .. " " .. L["and smooth scaling"]
+          end
+        end
+
+         if not hideShadow then
+          if text == "" then
+            text = text .. " " .. L["Shadow |c%sColor|r with offset |cFFFF0000%s/%s|r"]
+                                  :format(color, data.text_shadowXOffset, data.text_shadowYOffset)
+          else
+            text = text .. " " .. L["and shadow |c%sColor|r with offset |cFFFF0000%s/%s|r"]
+                                  :format(color, data.text_shadowXOffset, data.text_shadowYOffset)
+          end
+        end
+        if text == "" then
+          return L["|cFFffcc00Font Flags:|r none"]
         else
-          secondline = L["|cFFffcc00Font Flags:|r |cFFFF0000%s|r and shadow |c%sColor|r with offset |cFFFF0000%s/%s|r%s%s%s"]
-            :format(textFlags, color, data.text_shadowXOffset, data.text_shadowYOffset,
-                    textRotate, textJustify, textWidth)
+          return L["|cFFffcc00Font Flags:|r"] .. " " .. text
         end
-
-        return secondline
       end,
       width = WeakAuras.doubleWidth,
       order = 44,
@@ -193,12 +213,12 @@ local function createOptions(parentData, data, index, subIndex)
       hidden = hiddenFontExtra,
       width = indentWidth
     },
-    text_fontType = {
-      type = "select",
+    text_smoothScaling = {
+      type = "toggle",
       width = WeakAuras.normalWidth - indentWidth,
-      name = L["Outline"],
+      name = WeakAuras.newFeatureString .. L["Smooth Font"],
+      desc = L["Smooths text height, preventing it from snapping to the nearest whole number when scaled."],
       order = 46,
-      values = OptionsPrivate.Private.font_flags,
       hidden = hiddenFontExtra
     },
     text_shadowColor = {

--- a/WeakAurasOptions/SubRegionOptions/SubText.lua
+++ b/WeakAurasOptions/SubRegionOptions/SubText.lua
@@ -37,16 +37,9 @@ local function createOptions(parentData, data, index, subIndex)
     __order = 1,
     text_visible = {
       type = "toggle",
-      width = WeakAuras.halfWidth,
+      width = WeakAuras.normalWidth,
       order = 9,
       name = L["Show Text"],
-    },
-    text_color = {
-      type = "color",
-      width = WeakAuras.halfWidth,
-      name = L["Color"],
-      hasAlpha = true,
-      order = 10,
     },
     text_text = {
       type = "input",
@@ -93,6 +86,7 @@ local function createOptions(parentData, data, index, subIndex)
       control = "WeakAurasIcon",
       image = "Interface\\AddOns\\WeakAuras\\Media\\Textures\\sidebar",
     },
+
     text_font = {
       type = "select",
       width = WeakAuras.normalWidth,
@@ -111,11 +105,27 @@ local function createOptions(parentData, data, index, subIndex)
       softMax = 72,
       step = 1,
     },
+
+    text_color = {
+      type = "color",
+      width = WeakAuras.normalWidth,
+      name = L["Color"],
+      hasAlpha = true,
+      order = 15,
+    },
+    text_smoothScaling = {
+      type = "toggle",
+      width = WeakAuras.normalWidth,
+      name = WeakAuras.newFeatureString .. L["Smooth Font"],
+      desc = L["Smooths text height, preventing it from snapping to the nearest whole number when scaled."],
+      order = 16
+    },
     text_fontFlagsDescription = {
       type = "execute",
       control = "WeakAurasExpandSmall",
       name = function()
         local textFlags = OptionsPrivate.Private.font_flags[data.text_fontType]
+        local hideShadow = data.text_fontType == "OUTLINE|SLUG"
         local color = format("%02x%02x%02x%02x",
                              data.text_shadowColor[4] * 255, data.text_shadowColor[1] * 255,
                              data.text_shadowColor[2] * 255, data.text_shadowColor[3]*255)
@@ -148,9 +158,14 @@ local function createOptions(parentData, data, index, subIndex)
         end
 
         local secondline
-          = L["|cFFffcc00Font Flags:|r |cFFFF0000%s|r and shadow |c%sColor|r with offset |cFFFF0000%s/%s|r%s%s%s"]
+        if hideShadow then
+          secondline = L["|cFFffcc00Font Flags:|r |cFFFF0000%s|r%s%s%s"]
+            :format(textFlags, textRotate, textJustify, textWidth)
+        else
+          secondline = L["|cFFffcc00Font Flags:|r |cFFFF0000%s|r and shadow |c%sColor|r with offset |cFFFF0000%s/%s|r%s%s%s"]
             :format(textFlags, color, data.text_shadowXOffset, data.text_shadowYOffset,
                     textRotate, textJustify, textWidth)
+        end
 
         return secondline
       end,
@@ -171,14 +186,13 @@ local function createOptions(parentData, data, index, subIndex)
       }
     },
 
-    text_font_space = {
+    text_font_space2 = {
       type = "description",
       name = "",
       order = 45,
       hidden = hiddenFontExtra,
       width = indentWidth
     },
-
     text_fontType = {
       type = "select",
       width = WeakAuras.normalWidth - indentWidth,
@@ -193,14 +207,27 @@ local function createOptions(parentData, data, index, subIndex)
       width = WeakAuras.normalWidth,
       name = L["Shadow Color"],
       order = 47,
-      hidden = hiddenFontExtra
+      hidden = function()
+        return hiddenFontExtra() or data.text_fontType == "OUTLINE|SLUG"
+      end
+    },
+    text_shadowColorSpace = {
+      type = "description",
+      name = "",
+      width = WeakAuras.normalWidth,
+      order = 47,
+      hidden = function()
+        return hiddenFontExtra() or data.text_fontType ~= "OUTLINE|SLUG"
+      end
     },
 
     text_font_space3 = {
       type = "description",
       name = "",
       order = 47.5,
-      hidden = hiddenFontExtra,
+      hidden = function()
+        return hiddenFontExtra() or data.text_fontType == "OUTLINE|SLUG"
+      end,
       width = indentWidth
     },
     text_shadowXOffset = {
@@ -212,7 +239,9 @@ local function createOptions(parentData, data, index, subIndex)
       softMax = 15,
       bigStep = 1,
       order = 48,
-      hidden = hiddenFontExtra
+      hidden = function()
+        return hiddenFontExtra() or data.text_fontType == "OUTLINE|SLUG"
+      end
     },
     text_shadowYOffset = {
       type = "range",
@@ -223,7 +252,9 @@ local function createOptions(parentData, data, index, subIndex)
       softMax = 15,
       bigStep = 1,
       order = 49,
-      hidden = hiddenFontExtra
+      hidden = function()
+        return hiddenFontExtra() or data.text_fontType == "OUTLINE|SLUG"
+      end
     },
 
     text_font_space4 = {


### PR DESCRIPTION
# Description

Fixes #6253

Adds two additional font rendering options for text regions and text sub-regions:

- **Slug / Slug Outline**
- **Smooth Scaling**

Slug support is added as additional font flag choices in the existing font flag selector. This keeps it tied to the text rendering mode instead of adding a separate toggle, and allows the supported combinations to stay explicit.

When a Slug font flag is selected, the font string scale animation mode is updated to `Enum.FontStringScaleAnimationMode.Vertex`. When Slug is not selected, it is restored to `Enum.FontStringScaleAnimationMode.FontSize`, so the font string does not stay in the Slug rendering state after switching back.

Plain `SLUG` keeps shadow color and shadow offset configurable. `OUTLINE|SLUG` does not support controllable shadow color/offset, so those controls are hidden and the runtime uses the default black outline/shadow behavior instead.

`Smooth Scaling` uses the newer `FontString:SetSmoothScaling` API. It prevents scaled font string text height from snapping to whole-number values, producing smoother text scaling. The call is guarded because the API is not available on every client, and the value is normalized to `false` because `SetSmoothScaling` does not accept `nil`.

On Titan currently Slug or Slug Outline has no effect and is not guarded, which is fine imo.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested

- Tested on TBC / MoP / Titan
- Awaiting Classic Era tests

