### PR TITLE
ci: automate WoW TOC interface updates

### DIFF
--- a/.github/workflows/update-wow-interface.yml
+++ b/.github/workflows/update-wow-interface.yml
@@ -1,0 +1,31 @@
+name: Update WoW TOC Interface
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "37 4 * * 1"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update:
+    if: github.repository == 'WeakAuras/WeakAuras2'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - id: toc
+        uses: Nnoggie/wow-interface-updater@5d4857867ca38a2a26041ae2c527ec3a4f522af5 # v1
+
+      - uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
+        if: steps.toc.outputs.changed == 'true'
+        with:
+          branch: automation/wow-interface
+          delete-branch: true
+          commit-message: "chore: update WoW TOC interface versions"
+          title: "chore: update WoW TOC interface versions"
+          body: ${{ steps.toc.outputs.pr-body }}

--- a/.github/workflows/update-wow-interface.yml
+++ b/.github/workflows/update-wow-interface.yml
@@ -3,7 +3,7 @@ name: Update WoW TOC Interface
 on:
   workflow_dispatch:
   schedule:
-    - cron: "37 4 * * 1"
+    - cron: "0 10 * * 1"
 
 permissions:
   contents: write

--- a/WeakAuras/WeakAuras_Cata.toc
+++ b/WeakAuras/WeakAuras_Cata.toc
@@ -1,3 +1,4 @@
+# WOW_INTERFACE_TARGETS: cata
 ## Interface: 40402
 ## Title: WeakAuras
 ## Author: The WeakAuras Team

--- a/WeakAuras/WeakAuras_Mists.toc
+++ b/WeakAuras/WeakAuras_Mists.toc
@@ -1,4 +1,4 @@
-# WOW_INTERFACE_TARGETS: mists
+# WOW_INTERFACE_TARGETS: mists-test, mists
 ## Interface: 50504
 ## Title: WeakAuras
 ## Author: The WeakAuras Team

--- a/WeakAuras/WeakAuras_Mists.toc
+++ b/WeakAuras/WeakAuras_Mists.toc
@@ -1,3 +1,4 @@
+# WOW_INTERFACE_TARGETS: mists
 ## Interface: 50504
 ## Title: WeakAuras
 ## Author: The WeakAuras Team

--- a/WeakAuras/WeakAuras_TBC.toc
+++ b/WeakAuras/WeakAuras_TBC.toc
@@ -1,3 +1,4 @@
+# WOW_INTERFACE_TARGETS: tbc
 ## Interface: 20506
 ## Title: WeakAuras
 ## Author: The WeakAuras Team

--- a/WeakAuras/WeakAuras_TBC.toc
+++ b/WeakAuras/WeakAuras_TBC.toc
@@ -1,4 +1,4 @@
-# WOW_INTERFACE_TARGETS: tbc
+# WOW_INTERFACE_TARGETS: tbc-test, tbc
 ## Interface: 20506
 ## Title: WeakAuras
 ## Author: The WeakAuras Team

--- a/WeakAuras/WeakAuras_Vanilla.toc
+++ b/WeakAuras/WeakAuras_Vanilla.toc
@@ -1,3 +1,4 @@
+# WOW_INTERFACE_TARGETS: vanilla
 ## Interface: 11509
 ## Title: WeakAuras
 ## Author: The WeakAuras Team

--- a/WeakAuras/WeakAuras_Wrath.toc
+++ b/WeakAuras/WeakAuras_Wrath.toc
@@ -1,5 +1,5 @@
-# WOW_INTERFACE_TARGETS: wrath-titan, wrath
-## Interface: 38002, 30405
+# WOW_INTERFACE_TARGETS: wrath-titan
+## Interface: 38002
 ## Title: WeakAuras
 ## Author: The WeakAuras Team
 ## Version: @project-version@

--- a/WeakAuras/WeakAuras_Wrath.toc
+++ b/WeakAuras/WeakAuras_Wrath.toc
@@ -1,4 +1,5 @@
-## Interface: 30405, 38001
+# WOW_INTERFACE_TARGETS: wrath-titan, wrath
+## Interface: 38002, 30405
 ## Title: WeakAuras
 ## Author: The WeakAuras Team
 ## Version: @project-version@

--- a/WeakAurasArchive/WeakAurasArchive_Cata.toc
+++ b/WeakAurasArchive/WeakAurasArchive_Cata.toc
@@ -1,3 +1,4 @@
+# WOW_INTERFACE_TARGETS: cata
 ## Interface: 40402
 ## Title: WeakAuras Archive
 ## Author: The WeakAuras Team

--- a/WeakAurasArchive/WeakAurasArchive_Mists.toc
+++ b/WeakAurasArchive/WeakAurasArchive_Mists.toc
@@ -1,4 +1,4 @@
-# WOW_INTERFACE_TARGETS: mists
+# WOW_INTERFACE_TARGETS: mists-test, mists
 ## Interface: 50504
 ## Title: WeakAuras Archive
 ## Author: The WeakAuras Team

--- a/WeakAurasArchive/WeakAurasArchive_Mists.toc
+++ b/WeakAurasArchive/WeakAurasArchive_Mists.toc
@@ -1,3 +1,4 @@
+# WOW_INTERFACE_TARGETS: mists
 ## Interface: 50504
 ## Title: WeakAuras Archive
 ## Author: The WeakAuras Team

--- a/WeakAurasArchive/WeakAurasArchive_TBC.toc
+++ b/WeakAurasArchive/WeakAurasArchive_TBC.toc
@@ -1,3 +1,4 @@
+# WOW_INTERFACE_TARGETS: tbc
 ## Interface: 20506
 ## Title: WeakAuras Archive
 ## Author: The WeakAuras Team

--- a/WeakAurasArchive/WeakAurasArchive_TBC.toc
+++ b/WeakAurasArchive/WeakAurasArchive_TBC.toc
@@ -1,4 +1,4 @@
-# WOW_INTERFACE_TARGETS: tbc
+# WOW_INTERFACE_TARGETS: tbc-test, tbc
 ## Interface: 20506
 ## Title: WeakAuras Archive
 ## Author: The WeakAuras Team

--- a/WeakAurasArchive/WeakAurasArchive_Vanilla.toc
+++ b/WeakAurasArchive/WeakAurasArchive_Vanilla.toc
@@ -1,3 +1,4 @@
+# WOW_INTERFACE_TARGETS: vanilla
 ## Interface: 11509
 ## Title: WeakAuras Archive
 ## Author: The WeakAuras Team

--- a/WeakAurasArchive/WeakAurasArchive_Wrath.toc
+++ b/WeakAurasArchive/WeakAurasArchive_Wrath.toc
@@ -1,4 +1,5 @@
-## Interface: 30405, 38001
+# WOW_INTERFACE_TARGETS: wrath-titan, wrath
+## Interface: 38002, 30405
 ## Title: WeakAuras Archive
 ## Author: The WeakAuras Team
 ## Version: @project-version@

--- a/WeakAurasArchive/WeakAurasArchive_Wrath.toc
+++ b/WeakAurasArchive/WeakAurasArchive_Wrath.toc
@@ -1,5 +1,5 @@
-# WOW_INTERFACE_TARGETS: wrath-titan, wrath
-## Interface: 38002, 30405
+# WOW_INTERFACE_TARGETS: wrath-titan
+## Interface: 38002
 ## Title: WeakAuras Archive
 ## Author: The WeakAuras Team
 ## Version: @project-version@

--- a/WeakAurasModelPaths/WeakAurasModelPaths_Cata.toc
+++ b/WeakAurasModelPaths/WeakAurasModelPaths_Cata.toc
@@ -1,3 +1,4 @@
+# WOW_INTERFACE_TARGETS: cata
 ## Interface: 40402
 ## Title: WeakAuras Model Paths
 ## Author: The WeakAuras Team

--- a/WeakAurasModelPaths/WeakAurasModelPaths_Mists.toc
+++ b/WeakAurasModelPaths/WeakAurasModelPaths_Mists.toc
@@ -1,3 +1,4 @@
+# WOW_INTERFACE_TARGETS: mists
 ## Interface: 50504
 ## Title: WeakAuras Model Paths
 ## Author: The WeakAuras Team

--- a/WeakAurasModelPaths/WeakAurasModelPaths_Mists.toc
+++ b/WeakAurasModelPaths/WeakAurasModelPaths_Mists.toc
@@ -1,4 +1,4 @@
-# WOW_INTERFACE_TARGETS: mists
+# WOW_INTERFACE_TARGETS: mists-test, mists
 ## Interface: 50504
 ## Title: WeakAuras Model Paths
 ## Author: The WeakAuras Team

--- a/WeakAurasModelPaths/WeakAurasModelPaths_TBC.toc
+++ b/WeakAurasModelPaths/WeakAurasModelPaths_TBC.toc
@@ -1,4 +1,4 @@
-# WOW_INTERFACE_TARGETS: tbc
+# WOW_INTERFACE_TARGETS: tbc-test, tbc
 ## Interface: 20506
 ## Title: WeakAuras Model Paths
 ## Author: The WeakAuras Team

--- a/WeakAurasModelPaths/WeakAurasModelPaths_TBC.toc
+++ b/WeakAurasModelPaths/WeakAurasModelPaths_TBC.toc
@@ -1,3 +1,4 @@
+# WOW_INTERFACE_TARGETS: tbc
 ## Interface: 20506
 ## Title: WeakAuras Model Paths
 ## Author: The WeakAuras Team

--- a/WeakAurasModelPaths/WeakAurasModelPaths_Vanilla.toc
+++ b/WeakAurasModelPaths/WeakAurasModelPaths_Vanilla.toc
@@ -1,3 +1,4 @@
+# WOW_INTERFACE_TARGETS: vanilla
 ## Interface: 11509
 ## Title: WeakAuras Model Paths
 ## Author: The WeakAuras Team

--- a/WeakAurasModelPaths/WeakAurasModelPaths_Wrath.toc
+++ b/WeakAurasModelPaths/WeakAurasModelPaths_Wrath.toc
@@ -1,4 +1,5 @@
-## Interface: 30405, 38001
+# WOW_INTERFACE_TARGETS: wrath-titan, wrath
+## Interface: 38002, 30405
 ## Title: WeakAuras Model Paths
 ## Author: The WeakAuras Team
 ## Version: @project-version@

--- a/WeakAurasModelPaths/WeakAurasModelPaths_Wrath.toc
+++ b/WeakAurasModelPaths/WeakAurasModelPaths_Wrath.toc
@@ -1,5 +1,5 @@
-# WOW_INTERFACE_TARGETS: wrath-titan, wrath
-## Interface: 38002, 30405
+# WOW_INTERFACE_TARGETS: wrath-titan
+## Interface: 38002
 ## Title: WeakAuras Model Paths
 ## Author: The WeakAuras Team
 ## Version: @project-version@

--- a/WeakAurasOptions/WeakAurasOptions_Cata.toc
+++ b/WeakAurasOptions/WeakAurasOptions_Cata.toc
@@ -1,3 +1,4 @@
+# WOW_INTERFACE_TARGETS: cata
 ## Interface: 40402
 ## Title: WeakAuras Options
 ## Author: The WeakAuras Team

--- a/WeakAurasOptions/WeakAurasOptions_Mists.toc
+++ b/WeakAurasOptions/WeakAurasOptions_Mists.toc
@@ -1,4 +1,4 @@
-# WOW_INTERFACE_TARGETS: mists
+# WOW_INTERFACE_TARGETS: mists-test, mists
 ## Interface: 50504
 ## Title: WeakAuras Options
 ## Author: The WeakAuras Team

--- a/WeakAurasOptions/WeakAurasOptions_Mists.toc
+++ b/WeakAurasOptions/WeakAurasOptions_Mists.toc
@@ -1,3 +1,4 @@
+# WOW_INTERFACE_TARGETS: mists
 ## Interface: 50504
 ## Title: WeakAuras Options
 ## Author: The WeakAuras Team

--- a/WeakAurasOptions/WeakAurasOptions_TBC.toc
+++ b/WeakAurasOptions/WeakAurasOptions_TBC.toc
@@ -1,3 +1,4 @@
+# WOW_INTERFACE_TARGETS: tbc
 ## Interface: 20506
 ## Title: WeakAuras Options
 ## Author: The WeakAuras Team

--- a/WeakAurasOptions/WeakAurasOptions_TBC.toc
+++ b/WeakAurasOptions/WeakAurasOptions_TBC.toc
@@ -1,4 +1,4 @@
-# WOW_INTERFACE_TARGETS: tbc
+# WOW_INTERFACE_TARGETS: tbc-test, tbc
 ## Interface: 20506
 ## Title: WeakAuras Options
 ## Author: The WeakAuras Team

--- a/WeakAurasOptions/WeakAurasOptions_Vanilla.toc
+++ b/WeakAurasOptions/WeakAurasOptions_Vanilla.toc
@@ -1,3 +1,4 @@
+# WOW_INTERFACE_TARGETS: vanilla
 ## Interface: 11509
 ## Title: WeakAuras Options
 ## Author: The WeakAuras Team

--- a/WeakAurasOptions/WeakAurasOptions_Wrath.toc
+++ b/WeakAurasOptions/WeakAurasOptions_Wrath.toc
@@ -1,5 +1,5 @@
-# WOW_INTERFACE_TARGETS: wrath-titan, wrath
-## Interface: 38002, 30405
+# WOW_INTERFACE_TARGETS: wrath-titan
+## Interface: 38002
 ## Title: WeakAuras Options
 ## Author: The WeakAuras Team
 ## Version: @project-version@

--- a/WeakAurasOptions/WeakAurasOptions_Wrath.toc
+++ b/WeakAurasOptions/WeakAurasOptions_Wrath.toc
@@ -1,4 +1,5 @@
-## Interface: 30405, 38001
+# WOW_INTERFACE_TARGETS: wrath-titan, wrath
+## Interface: 38002, 30405
 ## Title: WeakAuras Options
 ## Author: The WeakAuras Team
 ## Version: @project-version@

--- a/WeakAurasTemplates/WeakAurasTemplates_Cata.toc
+++ b/WeakAurasTemplates/WeakAurasTemplates_Cata.toc
@@ -1,3 +1,4 @@
+# WOW_INTERFACE_TARGETS: cata
 ## Interface: 40402
 ## Title: WeakAuras Templates
 ## Author: The WeakAuras Team

--- a/WeakAurasTemplates/WeakAurasTemplates_Mists.toc
+++ b/WeakAurasTemplates/WeakAurasTemplates_Mists.toc
@@ -1,3 +1,4 @@
+# WOW_INTERFACE_TARGETS: mists
 ## Interface: 50504
 ## Title: WeakAuras Templates
 ## Author: The WeakAuras Team

--- a/WeakAurasTemplates/WeakAurasTemplates_Mists.toc
+++ b/WeakAurasTemplates/WeakAurasTemplates_Mists.toc
@@ -1,4 +1,4 @@
-# WOW_INTERFACE_TARGETS: mists
+# WOW_INTERFACE_TARGETS: mists-test, mists
 ## Interface: 50504
 ## Title: WeakAuras Templates
 ## Author: The WeakAuras Team

--- a/WeakAurasTemplates/WeakAurasTemplates_TBC.toc
+++ b/WeakAurasTemplates/WeakAurasTemplates_TBC.toc
@@ -1,4 +1,4 @@
-# WOW_INTERFACE_TARGETS: tbc
+# WOW_INTERFACE_TARGETS: tbc-test, tbc
 ## Interface: 20506
 ## Title: WeakAuras Templates
 ## Author: The WeakAuras Team

--- a/WeakAurasTemplates/WeakAurasTemplates_TBC.toc
+++ b/WeakAurasTemplates/WeakAurasTemplates_TBC.toc
@@ -1,3 +1,4 @@
+# WOW_INTERFACE_TARGETS: tbc
 ## Interface: 20506
 ## Title: WeakAuras Templates
 ## Author: The WeakAuras Team

--- a/WeakAurasTemplates/WeakAurasTemplates_Vanilla.toc
+++ b/WeakAurasTemplates/WeakAurasTemplates_Vanilla.toc
@@ -1,3 +1,4 @@
+# WOW_INTERFACE_TARGETS: vanilla
 ## Interface: 11509
 ## Title: WeakAuras Templates
 ## Author: The WeakAuras Team

--- a/WeakAurasTemplates/WeakAurasTemplates_Wrath.toc
+++ b/WeakAurasTemplates/WeakAurasTemplates_Wrath.toc
@@ -1,4 +1,5 @@
-## Interface: 30405, 38001
+# WOW_INTERFACE_TARGETS: wrath-titan, wrath
+## Interface: 38002, 30405
 ## Title: WeakAuras Templates
 ## Author: The WeakAuras Team
 ## Version: @project-version@

--- a/WeakAurasTemplates/WeakAurasTemplates_Wrath.toc
+++ b/WeakAurasTemplates/WeakAurasTemplates_Wrath.toc
@@ -1,5 +1,5 @@
-# WOW_INTERFACE_TARGETS: wrath-titan, wrath
-## Interface: 38002, 30405
+# WOW_INTERFACE_TARGETS: wrath-titan
+## Interface: 38002
 ## Title: WeakAuras Templates
 ## Author: The WeakAuras Team
 ## Version: @project-version@


### PR DESCRIPTION
# Description

Automate weekly WoW TOC interface updates using the pinned [Nnoggie/wow-interface-updater](https://github.com/Nnoggie/wow-interface-updater) action.

- add a manually dispatchable weekly workflow that creates update PRs
- annotate all 25 TOC files with their corresponding Warcraft Wiki targets
- track only Titan Reforged in the Wrath-suffixed TOCs
- normalize the current Titan Reforged interface to `38002`

The pinned BigWigs packager contains [the Titan-only Wrath TOC validation fix](https://github.com/BigWigsMods/packager/commit/ff15155ed45e697add8a6bdfe3ae9d319b95585b), so the legacy Wrath `30405` interface is no longer required for packaging.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested

- [x] Ran the pinned updater locally and confirmed `changed=false`
- [x] Verified all 25 target markers immediately precede their `## Interface:` line
- [x] Built a Titan-only package successfully with the pinned BigWigs packager
- [x] Ran `zizmor` against the new workflow with no findings
- [x] Ran `git diff --check`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings