### PR TITLE
Patches

### DIFF
--- a/WeakAuras/GenericTrigger.lua
+++ b/WeakAuras/GenericTrigger.lua
@@ -4127,7 +4127,7 @@ if WeakAuras.IsClassicOrTBCOrWrath() then
           for _, spellID in ipairs(queueableSpells) do
             -- Check the highest known rank
             local maxRank = select(7, Private.ExecEnv.GetSpellInfo(Private.ExecEnv.GetSpellName(spellID)))
-            if C_Spell.IsCurrentSpell(maxRank) then
+            if maxRank and C_Spell.IsCurrentSpell(maxRank) then
               newQueuedSpell = maxRank
               break
             end


### PR DESCRIPTION
This fixes a regression introduced in a8d977a9, where
C_Spell.IsCurrentSpell could be called with a nil spell ID when no
known spell rank was found.

Unknown queueable spells are now skipped.

Saw this on Discord, IsCurrentSpell accepts nil, C_Spell.IsCurrentSpell not.

In the error message the call gets a nil:
spellID=845
maxRank=nil

```lua
3951x WeakAuras/GenericTrigger.lua:4130: bad argument #1 to 'IsCurrentSpell' (Usage: local isCurrentSpell = C_Spell.IsCurrentSpell(spellIdentifier))
[WeakAuras/GenericTrigger.lua]:4130: in function <WeakAuras/GenericTrigger.lua:4124>


Locals:
self=Frame <WeakAuras.lua:4610>
event="CURRENT_SPELL_CAST_CHANGED"
newQueuedSpell=nil
(for state)=<table>{
 1=78
 2=845
}
(for control)=2
_=2
spellID=845
maxRank=nil
queueableSpells=<table>{
 1=78
 2=845
}
...
```