### PR TITLE
fix: Move Interface to the top in .toc files

### DIFF
--- a/WeakAuras/WeakAuras_Cata.toc
+++ b/WeakAuras/WeakAuras_Cata.toc
@@ -1,5 +1,5 @@
-# WOW_INTERFACE_TARGETS: cata
 ## Interface: 40402
+# WOW_INTERFACE_TARGETS: cata
 ## Title: WeakAuras
 ## Author: The WeakAuras Team
 ## Version: @project-version@

--- a/WeakAuras/WeakAuras_Mists.toc
+++ b/WeakAuras/WeakAuras_Mists.toc
@@ -1,6 +1,6 @@
-## Title: WeakAuras
-# WOW_INTERFACE_TARGETS: mists-test, mists
 ## Interface: 50504
+# WOW_INTERFACE_TARGETS: mists-test, mists
+## Title: WeakAuras
 ## Author: The WeakAuras Team
 ## Version: @project-version@
 ## IconTexture: Interface\AddOns\WeakAuras\Media\Textures\icon.blp

--- a/WeakAuras/WeakAuras_TBC.toc
+++ b/WeakAuras/WeakAuras_TBC.toc
@@ -1,5 +1,5 @@
-# WOW_INTERFACE_TARGETS: tbc-test, tbc
 ## Interface: 20506
+# WOW_INTERFACE_TARGETS: tbc-test, tbc
 ## Title: WeakAuras
 ## Author: The WeakAuras Team
 ## Version: @project-version@

--- a/WeakAuras/WeakAuras_Vanilla.toc
+++ b/WeakAuras/WeakAuras_Vanilla.toc
@@ -1,5 +1,5 @@
-# WOW_INTERFACE_TARGETS: vanilla
 ## Interface: 11509
+# WOW_INTERFACE_TARGETS: vanilla
 ## Title: WeakAuras
 ## Author: The WeakAuras Team
 ## Version: @project-version@

--- a/WeakAuras/WeakAuras_Wrath.toc
+++ b/WeakAuras/WeakAuras_Wrath.toc
@@ -1,5 +1,5 @@
-# WOW_INTERFACE_TARGETS: wrath-titan
 ## Interface: 38002
+# WOW_INTERFACE_TARGETS: wrath-titan
 ## Title: WeakAuras
 ## Author: The WeakAuras Team
 ## Version: @project-version@

--- a/WeakAurasArchive/WeakAurasArchive_Cata.toc
+++ b/WeakAurasArchive/WeakAurasArchive_Cata.toc
@@ -1,5 +1,5 @@
-# WOW_INTERFACE_TARGETS: cata
 ## Interface: 40402
+# WOW_INTERFACE_TARGETS: cata
 ## Title: WeakAuras Archive
 ## Author: The WeakAuras Team
 ## Version: @project-version@

--- a/WeakAurasArchive/WeakAurasArchive_Mists.toc
+++ b/WeakAurasArchive/WeakAurasArchive_Mists.toc
@@ -1,5 +1,5 @@
-# WOW_INTERFACE_TARGETS: mists-test, mists
 ## Interface: 50504
+# WOW_INTERFACE_TARGETS: mists-test, mists
 ## Title: WeakAuras Archive
 ## Author: The WeakAuras Team
 ## Version: @project-version@

--- a/WeakAurasArchive/WeakAurasArchive_TBC.toc
+++ b/WeakAurasArchive/WeakAurasArchive_TBC.toc
@@ -1,5 +1,5 @@
-# WOW_INTERFACE_TARGETS: tbc-test, tbc
 ## Interface: 20506
+# WOW_INTERFACE_TARGETS: tbc-test, tbc
 ## Title: WeakAuras Archive
 ## Author: The WeakAuras Team
 ## Version: @project-version@

--- a/WeakAurasArchive/WeakAurasArchive_Vanilla.toc
+++ b/WeakAurasArchive/WeakAurasArchive_Vanilla.toc
@@ -1,5 +1,5 @@
-# WOW_INTERFACE_TARGETS: vanilla
 ## Interface: 11509
+# WOW_INTERFACE_TARGETS: vanilla
 ## Title: WeakAuras Archive
 ## Author: The WeakAuras Team
 ## Version: @project-version@

--- a/WeakAurasArchive/WeakAurasArchive_Wrath.toc
+++ b/WeakAurasArchive/WeakAurasArchive_Wrath.toc
@@ -1,5 +1,5 @@
-# WOW_INTERFACE_TARGETS: wrath-titan
 ## Interface: 38002
+# WOW_INTERFACE_TARGETS: wrath-titan
 ## Title: WeakAuras Archive
 ## Author: The WeakAuras Team
 ## Version: @project-version@

--- a/WeakAurasModelPaths/WeakAurasModelPaths_Cata.toc
+++ b/WeakAurasModelPaths/WeakAurasModelPaths_Cata.toc
@@ -1,5 +1,5 @@
-# WOW_INTERFACE_TARGETS: cata
 ## Interface: 40402
+# WOW_INTERFACE_TARGETS: cata
 ## Title: WeakAuras Model Paths
 ## Author: The WeakAuras Team
 ## Version: @project-version@

--- a/WeakAurasModelPaths/WeakAurasModelPaths_Mists.toc
+++ b/WeakAurasModelPaths/WeakAurasModelPaths_Mists.toc
@@ -1,5 +1,5 @@
-# WOW_INTERFACE_TARGETS: mists-test, mists
 ## Interface: 50504
+# WOW_INTERFACE_TARGETS: mists-test, mists
 ## Title: WeakAuras Model Paths
 ## Author: The WeakAuras Team
 ## Version: @project-version@

--- a/WeakAurasModelPaths/WeakAurasModelPaths_TBC.toc
+++ b/WeakAurasModelPaths/WeakAurasModelPaths_TBC.toc
@@ -1,5 +1,5 @@
-# WOW_INTERFACE_TARGETS: tbc-test, tbc
 ## Interface: 20506
+# WOW_INTERFACE_TARGETS: tbc-test, tbc
 ## Title: WeakAuras Model Paths
 ## Author: The WeakAuras Team
 ## Version: @project-version@

--- a/WeakAurasModelPaths/WeakAurasModelPaths_Vanilla.toc
+++ b/WeakAurasModelPaths/WeakAurasModelPaths_Vanilla.toc
@@ -1,5 +1,5 @@
-# WOW_INTERFACE_TARGETS: vanilla
 ## Interface: 11509
+# WOW_INTERFACE_TARGETS: vanilla
 ## Title: WeakAuras Model Paths
 ## Author: The WeakAuras Team
 ## Version: @project-version@

--- a/WeakAurasModelPaths/WeakAurasModelPaths_Wrath.toc
+++ b/WeakAurasModelPaths/WeakAurasModelPaths_Wrath.toc
@@ -1,5 +1,5 @@
-# WOW_INTERFACE_TARGETS: wrath-titan
 ## Interface: 38002
+# WOW_INTERFACE_TARGETS: wrath-titan
 ## Title: WeakAuras Model Paths
 ## Author: The WeakAuras Team
 ## Version: @project-version@

--- a/WeakAurasOptions/WeakAurasOptions_Cata.toc
+++ b/WeakAurasOptions/WeakAurasOptions_Cata.toc
@@ -1,5 +1,5 @@
-# WOW_INTERFACE_TARGETS: cata
 ## Interface: 40402
+# WOW_INTERFACE_TARGETS: cata
 ## Title: WeakAuras Options
 ## Author: The WeakAuras Team
 ## Version: @project-version@

--- a/WeakAurasOptions/WeakAurasOptions_Mists.toc
+++ b/WeakAurasOptions/WeakAurasOptions_Mists.toc
@@ -1,5 +1,5 @@
-# WOW_INTERFACE_TARGETS: mists-test, mists
 ## Interface: 50504
+# WOW_INTERFACE_TARGETS: mists-test, mists
 ## Title: WeakAuras Options
 ## Author: The WeakAuras Team
 ## Version: @project-version@

--- a/WeakAurasOptions/WeakAurasOptions_TBC.toc
+++ b/WeakAurasOptions/WeakAurasOptions_TBC.toc
@@ -1,5 +1,5 @@
-# WOW_INTERFACE_TARGETS: tbc-test, tbc
 ## Interface: 20506
+# WOW_INTERFACE_TARGETS: tbc-test, tbc
 ## Title: WeakAuras Options
 ## Author: The WeakAuras Team
 ## Version: @project-version@

--- a/WeakAurasOptions/WeakAurasOptions_Vanilla.toc
+++ b/WeakAurasOptions/WeakAurasOptions_Vanilla.toc
@@ -1,5 +1,5 @@
-# WOW_INTERFACE_TARGETS: vanilla
 ## Interface: 11509
+# WOW_INTERFACE_TARGETS: vanilla
 ## Title: WeakAuras Options
 ## Author: The WeakAuras Team
 ## Version: @project-version@

--- a/WeakAurasOptions/WeakAurasOptions_Wrath.toc
+++ b/WeakAurasOptions/WeakAurasOptions_Wrath.toc
@@ -1,5 +1,5 @@
-# WOW_INTERFACE_TARGETS: wrath-titan
 ## Interface: 38002
+# WOW_INTERFACE_TARGETS: wrath-titan
 ## Title: WeakAuras Options
 ## Author: The WeakAuras Team
 ## Version: @project-version@

--- a/WeakAurasTemplates/WeakAurasTemplates_Cata.toc
+++ b/WeakAurasTemplates/WeakAurasTemplates_Cata.toc
@@ -1,5 +1,5 @@
-# WOW_INTERFACE_TARGETS: cata
 ## Interface: 40402
+# WOW_INTERFACE_TARGETS: cata
 ## Title: WeakAuras Templates
 ## Author: The WeakAuras Team
 ## Version: @project-version@

--- a/WeakAurasTemplates/WeakAurasTemplates_Mists.toc
+++ b/WeakAurasTemplates/WeakAurasTemplates_Mists.toc
@@ -1,5 +1,5 @@
-# WOW_INTERFACE_TARGETS: mists-test, mists
 ## Interface: 50504
+# WOW_INTERFACE_TARGETS: mists-test, mists
 ## Title: WeakAuras Templates
 ## Author: The WeakAuras Team
 ## Version: @project-version@

--- a/WeakAurasTemplates/WeakAurasTemplates_TBC.toc
+++ b/WeakAurasTemplates/WeakAurasTemplates_TBC.toc
@@ -1,5 +1,5 @@
-# WOW_INTERFACE_TARGETS: tbc-test, tbc
 ## Interface: 20506
+# WOW_INTERFACE_TARGETS: tbc-test, tbc
 ## Title: WeakAuras Templates
 ## Author: The WeakAuras Team
 ## Version: @project-version@

--- a/WeakAurasTemplates/WeakAurasTemplates_Vanilla.toc
+++ b/WeakAurasTemplates/WeakAurasTemplates_Vanilla.toc
@@ -1,5 +1,5 @@
-# WOW_INTERFACE_TARGETS: vanilla
 ## Interface: 11509
+# WOW_INTERFACE_TARGETS: vanilla
 ## Title: WeakAuras Templates
 ## Author: The WeakAuras Team
 ## Version: @project-version@

--- a/WeakAurasTemplates/WeakAurasTemplates_Wrath.toc
+++ b/WeakAurasTemplates/WeakAurasTemplates_Wrath.toc
@@ -1,5 +1,5 @@
-# WOW_INTERFACE_TARGETS: wrath-titan
 ## Interface: 38002
+# WOW_INTERFACE_TARGETS: wrath-titan
 ## Title: WeakAuras Templates
 ## Author: The WeakAuras Team
 ## Version: @project-version@


### PR DESCRIPTION
# Description

Fixes an issue where entries with a singular # can break Blizzards .toc parser for some flavours, such as Mists of Pandaria. 
I re-ordered the other remaining ones for consistency, so that if the breakage is introduced anywhere else it won't affect WA. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

I moved WeakAuras Archive up, but not the others on Mists of Pandaria. 
<img width="715" height="155" alt="image" src="https://github.com/user-attachments/assets/b2e68835-c0c0-4770-aa55-34f9695042a0" />

## Checklist
<!-- These can be checked off after the pull request is submitted, in case you want discussion before they are completely ready -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

<!-- Is there any additional work that needs to be done? If so, add it to the above list -->
