### PR TITLE
fix: delete repository substores by archive ID

### DIFF
--- a/WeakAuras/ArchiveTypes/Repository.lua
+++ b/WeakAuras/ArchiveTypes/Repository.lua
@@ -114,8 +114,8 @@ local prototype = {
     return store
   end,
   Delete = function(self, image)
-    for id in pairs(image.stores) do
-      Archivist:Delete("ReadOnly", id)
+    for _, subStore in pairs(image.stores) do
+      Archivist:Delete("ReadOnly", subStore.id)
     end
   end,
 }


### PR DESCRIPTION
## Summary

- delete Repository child stores by their generated ReadOnly archive IDs
- keep logical Repository keys separate from physical Archivist identities
- preserve the existing Repository API and stored image format

## Implementation note

The store-type `Delete` callback receives the persisted Repository image. Its child records have not been opened or mixed with `subStoreMethods`, so the callback calls `Archivist:Delete` directly with each stored `subStore.id`.

## Validation

- focused Lua harness with logical keys that differ from physical substore IDs
- empty and multi-substore Repository images
- `luac -p WeakAuras/ArchiveTypes/Repository.lua`
- `git diff --check`

Closes #6290
