### PR TITLE
fix: detect mixed group squelch values

### DIFF
--- a/WeakAurasOptions/InformationOptions.lua
+++ b/WeakAurasOptions/InformationOptions.lua
@@ -183,7 +183,7 @@ function OptionsPrivate.GetInformationOptions(data)
       desc = desc .. "|cFFE0E000"..child.id..": |r"..L["Squelched"] .. "\n"
     end
     local childSquelch = child.information.squelchOnLoad and true or false
-    if not commonSquelch then
+    if commonSquelch == nil then
       commonSquelch = childSquelch
     elseif childSquelch ~= commonSquelch then
       sameSquelch = false


### PR DESCRIPTION
## Summary

- use `nil` as the explicit uninitialized reducer state
- keep valid `false` squelch values from being replaced by later children
- make mixed-value detection independent of child traversal order

## Validation

- focused Lua harness for true, false, mixed, and empty child sets
- `luac -p WeakAurasOptions/InformationOptions.lua`
- `git diff --check`

Closes #6292