### PR TITLE
fix: avoid empty author option transactions

### DIFF
--- a/WeakAurasOptions/AuthorOptions.lua
+++ b/WeakAurasOptions/AuthorOptions.lua
@@ -625,25 +625,25 @@ end
 ---@type fun(data: auraData, option: Option): fun(_, value: number)
 local function setUserNum(data, option)
   return function(_, value)
-    OptionsPrivate.Private.TimeMachine:StartTransaction()
-    if value ~= "" then
-      local num = tonumber(value)
-      if not num or math.abs(num) == math.huge or tostring(num) == "nan" then
-        OptionsPrivate.Private.TimeMachine:Reject()
-        return
-      end
-      for _, optionData in pairs(option.references) do
-        local childData = optionData.data
-        local childConfig = optionData.config
-        OptionsPrivate.Private.TimeMachine:Append({
-          uid = childData.uid,
-          actionType = "set",
-          path = expandUserPath(childData, optionData.path),
-          payload = num
-        })
-      end
-      OptionsPrivate.Private.TimeMachine:Commit()
+    if value == "" then
+      return
     end
+    OptionsPrivate.Private.TimeMachine:StartTransaction()
+    local num = tonumber(value)
+    if not num or math.abs(num) == math.huge or tostring(num) == "nan" then
+      OptionsPrivate.Private.TimeMachine:Reject()
+      return
+    end
+    for _, optionData in pairs(option.references) do
+      local childData = optionData.data
+      OptionsPrivate.Private.TimeMachine:Append({
+        uid = childData.uid,
+        actionType = "set",
+        path = expandUserPath(childData, optionData.path),
+        payload = num
+      })
+    end
+    OptionsPrivate.Private.TimeMachine:Commit()
   end
 end
 

--- a/WeakAurasOptions/AuthorOptions.lua
+++ b/WeakAurasOptions/AuthorOptions.lua
@@ -625,9 +625,6 @@ end
 ---@type fun(data: auraData, option: Option): fun(_, value: number)
 local function setUserNum(data, option)
   return function(_, value)
-    if value == "" then
-      return
-    end
     OptionsPrivate.Private.TimeMachine:StartTransaction()
     local num = tonumber(value)
     if not num or math.abs(num) == math.huge or tostring(num) == "nan" then


### PR DESCRIPTION
## Summary

- remove the branch that left empty author-number transactions open
- route empty and invalid numeric values through the same rejection path
- keep valid-number writes and commits explicit

## Validation

- focused Lua harness for empty, valid, and invalid values
- `luac -p WeakAurasOptions/AuthorOptions.lua`
- `git diff --check`

Closes #6294