### PR TITLE
fix: preserve progress texture mirror state

### DIFF
--- a/WeakAuras/BaseRegions/CircularProgressTexture.lua
+++ b/WeakAuras/BaseRegions/CircularProgressTexture.lua
@@ -112,15 +112,15 @@ local funcs = {
     self.mirror = mirror
     self:UpdateTextures()
   end,
-  --- @type fun(self: CircularProgressTextureInstance)
+  --- @type fun(self: CircularProgressTextureInstance, width: number)
   SetWidth = function(self, width)
     self.width = width
   end,
-  --- @type fun(self: CircularProgressTextureInstance)
+  --- @type fun(self: CircularProgressTextureInstance, height: number)
   SetHeight = function(self, height)
     self.height = height
   end,
-  --- @type fun(self: CircularProgressTextureInstance)
+  --- @type fun(self: CircularProgressTextureInstance, scalex: number, scaley: number)
   SetScale = function(self, scalex, scaley)
     self.scalex, self.scaley = scalex, scaley
   end,

--- a/WeakAuras/BaseRegions/CircularProgressTexture.lua
+++ b/WeakAuras/BaseRegions/CircularProgressTexture.lua
@@ -24,6 +24,8 @@ Private.CircularProgressTextureBase = {}
 --- @field offset number
 --- @field width number
 --- @field height number
+--- @field scalex number
+--- @field scaley number
 --- @field coords TextureCoords[]
 
 --- @class CircularProgressTextureOptions
@@ -110,12 +112,15 @@ local funcs = {
     self.mirror = mirror
     self:UpdateTextures()
   end,
+  --- @type fun(self: CircularProgressTextureInstance)
   SetWidth = function(self, width)
     self.width = width
   end,
+  --- @type fun(self: CircularProgressTextureInstance)
   SetHeight = function(self, height)
     self.height = height
   end,
+  --- @type fun(self: CircularProgressTextureInstance)
   SetScale = function(self, scalex, scaley)
     self.scalex, self.scaley = scalex, scaley
   end,
@@ -252,6 +257,10 @@ function Private.CircularProgressTextureBase.modify(circularTexture, options)
   circularTexture.width = options.width
   circularTexture.height = options.height
   circularTexture.offset = options.offset
+  circularTexture.scalex = 1
+  circularTexture.scaley = 1
+  circularTexture.mirror_h = false
+  circularTexture.mirror_v = false
   local offset = options.offset
   local frame = circularTexture.parentFrame
   if offset > 0 then

--- a/WeakAuras/BaseRegions/LinearProgressTexture.lua
+++ b/WeakAuras/BaseRegions/LinearProgressTexture.lua
@@ -256,7 +256,6 @@ local funcs = {
     self.mirror_v = mirror_v
   end,
 
-
   --- @type fun(self: LinearProgressTextureInstance, texRotation: number)
   SetTexRotation = function(self, texRotation)
     self.texRotation = texRotation
@@ -379,5 +378,7 @@ function Private.LinearProgressTextureBase.modify(linearTexture, options)
   linearTexture.width = options.width
   linearTexture.height = options.height
   linearTexture.offset = options.offset
+  linearTexture.mirror_h = false
+  linearTexture.mirror_v = false
   linearTexture:UpdateTextures()
 end

--- a/WeakAuras/RegionTypes/ProgressTexture.lua
+++ b/WeakAuras/RegionTypes/ProgressTexture.lua
@@ -255,6 +255,7 @@ local function ensureExtraTextures(region, count)
       width = region.width,
       height = region.height
     })
+    extraTexture:SetMirrorHV(region.mirror_h, region.mirror_v)
     extraTexture:SetOrientation(region.orientation, region.compress, region.slanted, region.slant,
                                 region.slantFirst, region.slantMode)
     region.extraTextures[i] = extraTexture;
@@ -279,6 +280,7 @@ local function ensureExtraSpinners(region, count)
       offset = 0
     })
 
+    extraSpinner:SetMirrorHV(region.mirror_h, region.mirror_v)
     extraSpinner:SetScale(region.scalex, region.scaley)
 
     region.extraSpinners[i] = extraSpinner
@@ -681,13 +683,13 @@ local funcs = {
     self.width = width;
     self:ForAllSpinners(self.foregroundSpinner.SetWidth, width)
     self:ForAllLinears(self.foreground.SetWidth, width)
-    self:Scale(self.scalex, self.scaley)
+    self:DoPosition()
   end,
   SetRegionHeight = function(self, height)
     self.height = height
     self:ForAllSpinners(self.foregroundSpinner.SetHeight, height)
     self:ForAllLinears(self.foreground.SetHeight, height)
-    self:Scale(self.scalex, self.scaley)
+    self:DoPosition()
   end,
   Scale = function(self, scalex, scaley)
     self.mirror_h = scalex < 0
@@ -794,6 +796,8 @@ local function modify(parent, region, data)
   region.height = data.height;
   region.scalex = 1;
   region.scaley = 1;
+  region.mirror_h = false
+  region.mirror_v = false
   region.aspect =  data.width / data.height;
   region.overlayclip = data.overlayclip;
 


### PR DESCRIPTION
## Summary

- preserve progress texture mirror flags during width and height changes
- initialize circular and linear base texture scale and mirror state during modification
- apply the current mirror flags to additional progress overlays created later
- complete the new circular progress function type annotations

## Why these changes are connected

#6285 makes each direct `Scale` call derive both mirror flags from its arguments. `Scale` then stores positive magnitudes, which is the existing state model.

`SetRegionWidth` and `SetRegionHeight` previously called `Scale` with those stored positive values. That made a resize recalculate both mirror flags as false. These setters now call `DoPosition`, because they need to update geometry without changing scale or mirror state.

Base texture modification initializes scale and mirror fields so reused objects cannot retain old animation state. Additional progress overlays can be created after an earlier `Scale` call, so their creation paths copy the current mirror flags.

## Validation

- focused Lua lifecycle checks using the functions from the changed files
  - negative-to-positive transitions on both axes
  - width and height changes while mirrored
  - additional linear and circular overlays created after mirroring
  - reused circular and linear base texture initialization
- `luac -p` on all three changed Lua files
- `git diff --check`

Closes #6296
