### PR TITLE
docs: add repository agent guide

### DIFF
--- a/.pkgmeta
+++ b/.pkgmeta
@@ -45,6 +45,8 @@ manual-changelog:
 ignore:
   - README.md
   - CONTRIBUTING.md
+  - AGENTS.md
+  - CLAUDE.md
   - babelfish.lua
   - update_translations.sh
   - generate_changelog.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,14 @@ Wrath/Titan. Each package has parallel `.toc` files for these clients.
 - Do not assume a WoW API exists on every client. Use the repository's current
   feature checks and compatibility patterns.
 
+## WoW API reference
+
+Always consult <https://warcraft.wiki.gg/wiki/World_of_Warcraft_API> for
+questions about the WoW API. Each function's page documents its signature,
+behavior, and the client flavors and patch versions that support it. Check it
+before you call an API in flavor-sensitive code, and trust it over memory when
+the two disagree.
+
 ## Code conventions
 
 - Use Lua 5.1 syntax. WoW supplies the globals listed in `.luacheckrc`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,9 +28,11 @@ file after its dependencies.
 - Most runtime files use `local Private = select(2, ...)` for internal state
   shared across files. Put public addon APIs on `WeakAuras` and internal APIs
   on `Private`. Do not create another global.
-- `WeakAuras/Types.lua` and `WeakAuras/Types_*.lua` define shared LuaLS and
-  EmmyLua contracts. Keep these contracts consistent with runtime table
-  shapes and function parameters.
+- `WeakAuras/Types.lua` and the per-client `WeakAuras/Types_*.lua` files fill
+  `Private` with shared option data, such as value lists and their localized
+  display names. Each `.toc` loads the flavor file before `Types.lua`. Keep
+  the flavor files consistent with each other, and keep this data consistent
+  with the runtime code that reads it.
 - `WeakAuras/Prototypes.lua`, `WeakAuras/GenericTrigger.lua`, and
   `WeakAuras/BuffTrigger2.lua` own major trigger behavior. Event dispatch and
   trigger updates are hot paths. Avoid repeated scans, temporary tables, and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,7 +89,9 @@ Always consult <https://warcraft.wiki.gg/wiki/World_of_Warcraft_API> for
 questions about the WoW API. Each function's page documents its signature,
 behavior, and the client flavors and patch versions that support it. Check it
 before you call an API in flavor-sensitive code, and trust it over memory when
-the two disagree.
+the two disagree. For historical changes to an API, such as a rename, a
+removal, or a changed signature in a given patch, reference
+<https://warcraft.wiki.gg/wiki/API_change_summaries>.
 
 ## Secure execution and taint
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -212,3 +212,17 @@ unless you ran it or GitHub reports it as passed.
   ```
 
 - Preserve unrelated work in a dirty worktree.
+
+## Keep this guide current
+
+This guide is a living document. When a review correction teaches you a
+durable, repository-wide rule or fact that this guide does not state, or shows
+that a statement here is wrong, update `AGENTS.md` in the same pull request as
+a separate commit.
+
+- Record the rule, not the incident. Verify the statement against the
+  repository first, write it in the guide's style, and put it in the section
+  where an agent would look for it.
+- Do not record feedback that only applies to one change.
+- Correct or delete a wrong statement instead of adding a second one next to
+  it. A wrong rule is worse than a missing one.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,19 +159,24 @@ check passed unless you ran it or GitHub reports it as passed.
 - Use conventional commit messages.
 - Keep each commit reviewable and keep the pull request description clear
   about the reason, behavior change, risks, and validation.
-- Read all current review comments before you revise a pull request. Reply to
-  and resolve each addressed thread when the task includes review follow-up.
-- Preserve unrelated work in a dirty worktree.
-
-## Working with GitHub PRs, Issues, and Comments
-
-- **Open every PR with the repository template.** `gh pr create` does not apply `.github/pull_request_template.md` automatically, so read that file and pass its filled-in contents as the PR body (`--body`/`--body-file`). Keep every section (Summary, Squash Commit Body, Checklist), fill them in for this change, mark the checklist items, and remove only the lines the template says are inapplicable.
-- **Keep PR titles and descriptions current.** When pushing new changes to a PR, review the title and description and update them if they no longer accurately reflect what the PR does.
-- **Reply to and resolve review conversations.** Once a review comment has been addressed, reply to the thread with a description of the resolution including the commit hash that fixed it, then mark the conversation as resolved.
-- **Sign all agent-authored content.** When posting a comment, creating an issue, or opening a PR, append a footer to the message indicating that it was written by an agent. The footer must include the name of the agent and the name of the model used. Example:
+- Open every pull request with the repository template. `gh pr create` does
+  not apply `.github/pull_request_template.md` on its own, so read that file
+  and pass its filled-in content as the body. Keep its sections, which are
+  Description, Type of change, How Has This Been Tested, and Checklist. Fill
+  each one in for this change, and delete only the type-of-change options
+  that do not apply.
+- Update the pull request title and description when new commits change what
+  the pull request does.
+- Read all current review comments before you revise a pull request. When a
+  comment is addressed, reply to its thread with what changed and the commit
+  hash, then resolve the thread.
+- Sign agent-authored content. Append a footer that names the agent and the
+  model when you post a comment, create an issue, or open a pull request.
+  Example:
 
   ```markdown
   ---
   Written by an agent (Claude Code, claude-opus-4-7).
   ```
- 
+
+- Preserve unrelated work in a dirty worktree.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,6 +112,9 @@ into secure code blocks protected actions and raises errors for users. See
   `strsplit`, `tinsert`, and `wipe`. See
   <https://warcraft.wiki.gg/wiki/Lua_functions> for the full list, and
   `.luacheckrc` for the globals WoW supplies.
+- `.luacheckrc` is maintained by hand, not generated. When you use a WoW API
+  that it does not list yet, add the global to the matching commented section
+  and keep the order of the nearby entries, or Luacheck fails in CI.
 - Use two spaces for indentation, LF line endings, a final newline, and no
   trailing whitespace. Follow `.editorconfig` for its listed exceptions.
 - Do not add semicolons to new files. In an existing file, follow its local

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,7 +93,11 @@ the two disagree.
 
 ## Code conventions
 
-- Use Lua 5.1 syntax. WoW supplies the globals listed in `.luacheckrc`.
+- Use Lua 5.1 syntax. WoW runs a customized Lua 5.1: it removes standard
+  libraries such as `io` and most of `os`, and it adds utility functions and
+  aliases such as `strsplit`, `tinsert`, and `wipe`. See
+  <https://warcraft.wiki.gg/wiki/Lua_functions> for the full list. WoW
+  supplies the globals listed in `.luacheckrc`.
 - Use two spaces for indentation, LF line endings, a final newline, and no
   trailing whitespace. Follow `.editorconfig` for its listed exceptions.
 - Do not add semicolons to new files. In an existing file, follow its local

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,8 +31,7 @@ file after its dependencies.
 - `WeakAuras/Types.lua` and the per-client `WeakAuras/Types_*.lua` files fill
   `Private` with shared option data, such as value lists and their localized
   display names. Each `.toc` loads the flavor file before `Types.lua`. Keep
-  the flavor files consistent with each other, and keep this data consistent
-  with the runtime code that reads it.
+  the flavor files consistent with each other.
 - `WeakAuras/Prototypes.lua`, `WeakAuras/GenericTrigger.lua`, and
   `WeakAuras/BuffTrigger2.lua` own major trigger behavior. Event dispatch and
   trigger updates are hot paths. Avoid repeated scans, temporary tables, and
@@ -70,35 +69,27 @@ The addon supports Cataclysm, Mists, The Burning Crusade, Classic Era, and
 Wrath/Titan. Each package has parallel `.toc` files for these clients.
 
 - Keep common behavior in common files when the WoW APIs have the same
-  contract.
-- Put real client differences in the existing flavor files, such as
-  `WeakAuras/Types_Cata.lua`, `WeakAuras/Types_Mists.lua`,
-  `WeakAuras/Types_TBC.lua`, `WeakAuras/Types_Vanilla.lua`, and
-  `WeakAuras/Types_Wrath.lua`.
-- Template and model-path data also have flavor-specific files. Check all five
-  clients when you change either area.
+  contract. Put real client differences in the existing flavor files, such as
+  the per-client `WeakAuras/Types_*.lua`, template, and model-path files, and
+  check all five clients when you change these areas.
 - Preserve the adjacency of each `## Interface:` line and its
   `# WOW_INTERFACE_TARGETS:` marker. The
   `.github/workflows/update-wow-interface.yml` workflow owns their values.
 - Do not assume a WoW API exists on every client. Use the repository's current
   feature checks and compatibility patterns.
-
-## WoW API reference
-
-Always consult <https://warcraft.wiki.gg/wiki/World_of_Warcraft_API> for
-questions about the WoW API. Each function's page documents its signature,
-behavior, and the client flavors and patch versions that support it. Check it
-before you call an API in flavor-sensitive code, and trust it over memory when
-the two disagree. For historical changes to an API, such as a rename, a
-removal, or a changed signature in a given patch, reference
-<https://warcraft.wiki.gg/wiki/API_change_summaries>.
+- Always consult <https://warcraft.wiki.gg/wiki/World_of_Warcraft_API> for
+  questions about the WoW API. Each function's page documents its signature,
+  behavior, and the client flavors and patch versions that support it. Trust
+  the wiki over memory when the two disagree.
+- Reference <https://warcraft.wiki.gg/wiki/API_change_summaries> for
+  historical changes to an API, such as a rename, a removal, or a changed
+  signature in a given patch.
 
 ## Secure execution and taint
 
 WoW separates secure Blizzard code from tainted addon code. Taint that spreads
-into secure code blocks protected actions and raises blocked-action errors for
-users. See <https://warcraft.wiki.gg/wiki/Secure_Execution_and_Tainting> for
-the model.
+into secure code blocks protected actions and raises errors for users. See
+<https://warcraft.wiki.gg/wiki/Secure_Execution_and_Tainting> for the model.
 
 - Do not write to Blizzard frames, globals, or tables that secure code reads.
   Hook a Blizzard function with `hooksecurefunc`, as
@@ -116,11 +107,11 @@ the model.
 
 ## Code conventions
 
-- Use Lua 5.1 syntax. WoW runs a customized Lua 5.1: it removes standard
-  libraries such as `io` and most of `os`, and it adds utility functions and
-  aliases such as `strsplit`, `tinsert`, and `wipe`. See
-  <https://warcraft.wiki.gg/wiki/Lua_functions> for the full list. WoW
-  supplies the globals listed in `.luacheckrc`.
+- Use Lua 5.1 syntax. WoW runs a customized Lua 5.1 that removes standard
+  libraries such as `io` and most of `os`, and adds helpers such as
+  `strsplit`, `tinsert`, and `wipe`. See
+  <https://warcraft.wiki.gg/wiki/Lua_functions> for the full list, and
+  `.luacheckrc` for the globals WoW supplies.
 - Use two spaces for indentation, LF line endings, a final newline, and no
   trailing whitespace. Follow `.editorconfig` for its listed exceptions.
 - Do not add semicolons to new files. In an existing file, follow its local
@@ -192,16 +183,14 @@ check passed unless you ran it or GitHub reports it as passed.
 
 - Start a focused topic branch from current `main`.
 - Use conventional commit messages.
-- Keep each commit reviewable and keep the pull request description clear
-  about the reason, behavior change, risks, and validation.
+- Keep each commit reviewable. Keep the pull request title and description
+  clear about the reason, behavior change, risks, and validation, and update
+  them when new commits change what the pull request does.
 - Open every pull request with the repository template. `gh pr create` does
   not apply `.github/pull_request_template.md` on its own, so read that file
-  and pass its filled-in content as the body. Keep its sections, which are
-  Description, Type of change, How Has This Been Tested, and Checklist. Fill
-  each one in for this change, and delete only the type-of-change options
-  that do not apply.
-- Update the pull request title and description when new commits change what
-  the pull request does.
+  and pass its filled-in content as the body. Keep and fill in its sections
+  (Description, Type of change, How Has This Been Tested, Checklist), and
+  delete only the type-of-change options that do not apply.
 - Read all current review comments before you revise a pull request. When a
   comment is addressed, reply to its thread with what changed and the commit
   hash, then resolve the thread.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,8 +94,11 @@ into secure code blocks protected actions and raises errors for users. See
 - Do not write to Blizzard frames, globals, or tables that secure code reads.
   Hook a Blizzard function with `hooksecurefunc`, as
   `WeakAuras/Transmission.lua` does for `SetItemRef`.
-- A protected frame cannot change during combat lockdown. Follow the pattern
-  in `WeakAuras/RegionTypes/RegionPrototype.lua`: check `region:IsProtected()`
+- During combat lockdown, WoW blocks specific operations on a protected
+  frame, such as show, hide, move, resize, anchor, and secure attribute
+  changes. See <https://warcraft.wiki.gg/wiki/API_InCombatLockdown> for the
+  restricted set. Before such an operation, follow the pattern in
+  `WeakAuras/RegionTypes/RegionPrototype.lua`: check `region:IsProtected()`
   and `InCombatLockdown()`, raise an aura warning instead of touching the
   frame, and point users to
   <https://github.com/WeakAuras/WeakAuras2/wiki/Protected-Frames>.
@@ -178,9 +181,11 @@ Also check the relevant boundaries:
   and migration behavior as applicable.
 - For hot-path work, compare allocations and work per event or frame.
 
-Pull-request CI runs Luacheck and a dry-run package build. It can catch load
-order and packaging errors that a single-file check cannot catch. Do not say a
-check passed unless you ran it or GitHub reports it as passed.
+Pull-request CI runs Luacheck and a dry-run package build. It catches lint
+and packaging errors, but it does not load the addon in WoW, so it cannot
+prove `.toc` load order. Validate load order by inspecting the `.toc` files
+and by loading the addon in the affected clients. Do not say a check passed
+unless you ran it or GitHub reports it as passed.
 
 ## Git and review
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,162 @@
+# Repository guide for coding agents
+
+This file applies to the complete repository. Read `CONTRIBUTING.md` before you
+change code. A more specific `AGENTS.md` can add rules for its own directory.
+
+## Project map
+
+WeakAuras is a World of Warcraft addon written for Lua 5.1. The repository
+ships five addon packages:
+
+- `WeakAuras/` is the always-loaded runtime. It owns saved display data,
+  triggers, regions, conditions, animations, import, export, and migrations.
+- `WeakAurasOptions/` is the load-on-demand configuration UI. It depends on
+  `WeakAuras/`. Runtime code must not depend on this package.
+- `WeakAurasTemplates/` is the load-on-demand template browser and its
+  game-version data.
+- `WeakAurasModelPaths/` contains generated model-path data.
+- `WeakAurasArchive/` is the load-on-demand saved-variable container for the
+  archive.
+
+The `.toc` files define the load order. Treat this order as an API. When you
+add, remove, or move a Lua file, update every relevant `.toc` file and put the
+file after its dependencies.
+
+## Runtime ownership
+
+- `WeakAuras/Init.lua` creates the public global `WeakAuras` table.
+- Most runtime files use `local Private = select(2, ...)` for internal state
+  shared across files. Put public addon APIs on `WeakAuras` and internal APIs
+  on `Private`. Do not create another global.
+- `WeakAuras/Types.lua` and `WeakAuras/Types_*.lua` define shared LuaLS and
+  EmmyLua contracts. Keep these contracts consistent with runtime table
+  shapes and function parameters.
+- `WeakAuras/Prototypes.lua`, `WeakAuras/GenericTrigger.lua`, and
+  `WeakAuras/BuffTrigger2.lua` own major trigger behavior. Event dispatch and
+  trigger updates are hot paths. Avoid repeated scans, temporary tables, and
+  closures in these paths unless the behavior needs them.
+- `WeakAuras/RegionTypes/RegionPrototype.lua` owns common region behavior.
+  Concrete regions live in `WeakAuras/RegionTypes/`, and subregions live in
+  `WeakAuras/SubRegionTypes/`.
+- Region types register through `Private.RegisterRegionType`. Subregion types
+  register through `WeakAuras.RegisterSubRegionType`. Trigger systems register
+  through `WeakAuras.RegisterTriggerSystem`. Follow the nearby registration
+  pattern instead of adding a second registry.
+- A runtime region or subregion change often needs a matching change in
+  `WeakAurasOptions/RegionOptions/` or `WeakAurasOptions/SubRegionOptions/`.
+  Check both sides before you finish.
+
+## Persistent and wire data
+
+`WeakAurasSaved` and `WeakAurasArchive` survive addon reloads. Imported and
+exported display data also crosses addon versions.
+
+- Treat persisted table shapes, absent fields, `nil`, and `false` as public
+  compatibility behavior.
+- Add display-data migrations in `WeakAuras/Modernize.lua` when a shape change
+  needs old data to continue to work.
+- Review `WeakAuras/Transmission.lua` for changes that affect import, export,
+  serialization, or supported data versions.
+- Preserve deterministic ordering where serialized output or user-visible
+  output depends on it.
+- Do not move runtime state into the options package. The options package may
+  not be loaded during combat, login, or normal event handling.
+
+## Supported game versions
+
+The addon supports Cataclysm, Mists, The Burning Crusade, Classic Era, and
+Wrath/Titan. Each package has parallel `.toc` files for these clients.
+
+- Keep common behavior in common files when the WoW APIs have the same
+  contract.
+- Put real client differences in the existing flavor files, such as
+  `WeakAuras/Types_Cata.lua`, `WeakAuras/Types_Mists.lua`,
+  `WeakAuras/Types_TBC.lua`, `WeakAuras/Types_Vanilla.lua`, and
+  `WeakAuras/Types_Wrath.lua`.
+- Template and model-path data also have flavor-specific files. Check all five
+  clients when you change either area.
+- Preserve the adjacency of each `## Interface:` line and its
+  `# WOW_INTERFACE_TARGETS:` marker. The
+  `.github/workflows/update-wow-interface.yml` workflow owns their values.
+- Do not assume a WoW API exists on every client. Use the repository's current
+  feature checks and compatibility patterns.
+
+## Code conventions
+
+- Use Lua 5.1 syntax. WoW supplies the globals listed in `.luacheckrc`.
+- Use two spaces for indentation, LF line endings, a final newline, and no
+  trailing whitespace. Follow `.editorconfig` for its listed exceptions.
+- Do not add semicolons to new files. In an existing file, follow its local
+  form, but prefer no semicolons.
+- Localize every user-visible string. The translation scraper requires the
+  exact form `L["text"]`, with double quotes and a local table named `L`.
+- Mark a new user-visible feature with `WeakAuras.newFeatureString` as
+  described in `CONTRIBUTING.md`.
+- Keep changes narrow. Do not mix a fix with unrelated formatting, renaming,
+  or speculative refactoring.
+- Prefer a clear local branch over a new abstraction when the abstraction does
+  not remove a real invalid state, repeated decision, or repeated lookup.
+- Explain non-obvious ownership, lifecycle, and compatibility decisions. Do
+  not add comments that only repeat the code.
+
+## Generated data and external libraries
+
+Do not hand-edit generated files unless the task explicitly asks for generated
+output and you use the owning generator.
+
+- `.github/scripts/update-model-paths.sh` generates the large
+  `WeakAurasModelPaths/ModelPaths*.lua` files. Do not open or format these files
+  as part of a broad repository rewrite.
+- `.github/scripts/update-atlas-files.sh` and
+  `.github/scripts/atlas_update.lua` generate atlas data.
+- `.github/scripts/discordupdate.py` generates `WeakAuras/DiscordList.lua`.
+- `generate_changelog.sh` generates changelog output, including
+  `WeakAurasOptions/Changelog.lua`.
+- `babelfish.lua` extracts localization phrases. `update_translations.sh`
+  performs network writes and needs external credentials. Do not run it for
+  normal code validation.
+- `.pkgmeta` defines libraries that the BigWigs packager fetches into
+  `WeakAuras/Libs/` and `WeakAurasOptions/Libs/`. Do not vendor or edit a
+  fetched library unless the task is dependency work.
+- Release and update scripts can change many files or external services. Run
+  them only when the task requires that effect.
+
+## Validation
+
+Select checks that prove the changed behavior. Do not add a test that only
+restates the implementation.
+
+For every change:
+
+1. Run `git diff --check`.
+2. Parse each changed Lua file with `luac -p path/to/file.lua` when a compatible
+   Lua compiler is available. Local `luac` can use a newer Lua version, so CI
+   remains the authority for Lua 5.1 compatibility.
+3. Run `luacheck . --no-color -q` when Luacheck is available. This matches the
+   lint intent in `.github/workflows/pull_request.yml`.
+4. Use a focused Lua harness with WoW globals stubbed, or verify the behavior
+   in the correct WoW clients, when the change needs runtime proof.
+
+Also check the relevant boundaries:
+
+- For a region or subregion change, validate runtime behavior and its options
+  controls.
+- For a new or moved file, inspect every relevant `.toc` load order.
+- For flavor-sensitive behavior, validate all affected clients.
+- For saved or transmitted data, validate old data, new data, import, export,
+  and migration behavior as applicable.
+- For hot-path work, compare allocations and work per event or frame.
+
+Pull-request CI runs Luacheck and a dry-run package build. It can catch load
+order and packaging errors that a single-file check cannot catch. Do not say a
+check passed unless you ran it or GitHub reports it as passed.
+
+## Git and review
+
+- Start a focused topic branch from current `main`.
+- Use conventional commit messages.
+- Keep each commit reviewable and keep the pull request description clear
+  about the reason, behavior change, risks, and validation.
+- Read all current review comments before you revise a pull request. Reply to
+  and resolve each addressed thread when the task includes review follow-up.
+- Preserve unrelated work in a dirty worktree.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,6 +91,27 @@ behavior, and the client flavors and patch versions that support it. Check it
 before you call an API in flavor-sensitive code, and trust it over memory when
 the two disagree.
 
+## Secure execution and taint
+
+WoW separates secure Blizzard code from tainted addon code. Taint that spreads
+into secure code blocks protected actions and raises blocked-action errors for
+users. See <https://warcraft.wiki.gg/wiki/Secure_Execution_and_Tainting> for
+the model.
+
+- Do not write to Blizzard frames, globals, or tables that secure code reads.
+  Hook a Blizzard function with `hooksecurefunc`, as
+  `WeakAuras/Transmission.lua` does for `SetItemRef`.
+- A protected frame cannot change during combat lockdown. Follow the pattern
+  in `WeakAuras/RegionTypes/RegionPrototype.lua`: check `region:IsProtected()`
+  and `InCombatLockdown()`, raise an aura warning instead of touching the
+  frame, and point users to
+  <https://github.com/WeakAuras/WeakAuras2/wiki/Protected-Frames>.
+- Defer work that combat blocks until `PLAYER_REGEN_ENABLED`, as
+  `Private.LoadOptions` in `WeakAuras/WeakAuras.lua` defers the options UI.
+- Custom aura code runs in the sandbox that `WeakAuras/AuraEnvironment.lua`
+  builds. When you expose a new function there, check that it cannot spread
+  taint into secure code or perform a protected action.
+
 ## Code conventions
 
 - Use Lua 5.1 syntax. WoW runs a customized Lua 5.1: it removes standard

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,3 +162,16 @@ check passed unless you ran it or GitHub reports it as passed.
 - Read all current review comments before you revise a pull request. Reply to
   and resolve each addressed thread when the task includes review follow-up.
 - Preserve unrelated work in a dirty worktree.
+
+## Working with GitHub PRs, Issues, and Comments
+
+- **Open every PR with the repository template.** `gh pr create` does not apply `.github/pull_request_template.md` automatically, so read that file and pass its filled-in contents as the PR body (`--body`/`--body-file`). Keep every section (Summary, Squash Commit Body, Checklist), fill them in for this change, mark the checklist items, and remove only the lines the template says are inapplicable.
+- **Keep PR titles and descriptions current.** When pushing new changes to a PR, review the title and description and update them if they no longer accurately reflect what the PR does.
+- **Reply to and resolve review conversations.** Once a review comment has been addressed, reply to the thread with a description of the resolution including the commit hash that fixed it, then mark the conversation as resolved.
+- **Sign all agent-authored content.** When posting a comment, creating an issue, or opening a PR, append a footer to the message indicating that it was written by an agent. The footer must include the name of the agent and the name of the model used. Example:
+
+  ```markdown
+  ---
+  Written by an agent (Claude Code, claude-opus-4-7).
+  ```
+ 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md


### PR DESCRIPTION
# Description

Add a root `AGENTS.md` with repository-specific architecture, ownership, compatibility, generated-file, and validation guidance. Add `CLAUDE.md` as a one-line `@AGENTS.md` import so Claude Code reads the same guide on all platforms. Exclude both files from packaged addon releases through `.pkgmeta`.

Fixes #6299

## Type of change

- [x] This change requires a documentation update

## How Has This Been Tested

- [x] Ran `git diff --check`
- [x] Parsed `.pkgmeta` as YAML
- [x] Verified every repository path and function name referenced by the guide
- [x] Confirmed `CLAUDE.md` imports `AGENTS.md`
- [x] Confirmed all GitHub CI checks pass

No runtime tests were run because this change does not modify addon behavior.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

No source-code comments were needed because no runtime code changed.

---
Written by an agent (Codex, GPT-5).