### PR TITLE
revert: remove Midnight warnings and disable gate

### DIFF
--- a/WeakAuras/Init.lua
+++ b/WeakAuras/Init.lua
@@ -462,11 +462,6 @@ function WeakAuras.IsTWW()
 end
 
 ---@return boolean result
-function WeakAuras.IsMidnight()
-  return WeakAuras.BuildInfo >= 120000
-end
-
----@return boolean result
 function WeakAuras.IsClassicOrTBC()
   return WeakAuras.IsClassicEra() or WeakAuras.IsTBC()
 end
@@ -665,11 +660,6 @@ if WeakAuras.IsWrathClassic() then
   C_Timer.After(1, function()
     WeakAuras.prettyPrint("This version of WeakAuras is provided as is. We are unable to test it ourselves on CN Servers.")
   end)
-elseif WeakAuras.IsMidnight() then
-  C_Timer.After(1, function()
-    WeakAuras.prettyPrint("WeakAuras does not support Midnight due to Blizzard restricting addons. Read more at https://patreon.com/WeakAuras")
-  end)
-  libsAreOk = false
 end
 
 -- These function stubs are defined here to reduce the number of errors that occur if WeakAuras.lua fails to compile

--- a/WeakAuras/Init.lua
+++ b/WeakAuras/Init.lua
@@ -670,10 +670,6 @@ elseif WeakAuras.IsMidnight() then
     WeakAuras.prettyPrint("WeakAuras does not support Midnight due to Blizzard restricting addons. Read more at https://patreon.com/WeakAuras")
   end)
   libsAreOk = false
-elseif WeakAuras.IsTWW() then
-  C_Timer.After(1, function()
-    WeakAuras.prettyPrint("WeakAuras does not support Midnight due to Blizzard's new addon restrictions. Read more at https://patreon.com/WeakAuras")
-  end)
 end
 
 -- These function stubs are defined here to reduce the number of errors that occur if WeakAuras.lua fails to compile

--- a/WeakAurasOptions/OptionsFrames/OptionsFrame.lua
+++ b/WeakAurasOptions/OptionsFrames/OptionsFrame.lua
@@ -1623,28 +1623,5 @@ function OptionsPrivate.CreateFrame()
   local left, right, top, bottom = w/2,-w/2, 0, h-25
   frame:SetClampRectInsets(left, right, top, bottom)
 
-  if WeakAuras.IsTWW() then
-    local midnightWarning = CreateFrame("Frame", nil, frame, "BackdropTemplate")
-    midnightWarning:SetBackdrop({
-      bgFile = "Interface\\Addons\\WeakAuras\\Media\\Textures\\Square_FullWhite.tga",
-      edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
-      tile = true,
-      tileSize = 16,
-      edgeSize = 16,
-      insets = { left = 4, right = 4, top = 4, bottom = 4 }
-    })
-
-    midnightWarning:SetBackdropBorderColor(1, 0, 0, 1);
-    midnightWarning:SetBackdropColor(0, 0, 0, 1)
-
-    midnightWarning:SetPoint("TOPLEFT", frame, "BOTTOMLEFT")
-    midnightWarning:SetPoint("TOPRIGHT", frame, "BOTTOMRIGHT")
-    midnightWarning:SetHeight(50)
-
-    local text = midnightWarning:CreateFontString(nil, "OVERLAY", "GameFontNormalLarge")
-    text:SetPoint("LEFT", midnightWarning, "LEFT", 10, 0)
-    text:SetText(L["WeakAuras will not support Midnight. On release of the prepatch, WeakAuras will be disabled.\nRead more on our Patreon page https://patreon.com/WeakAuras"])
-  end
-
   return frame
 end


### PR DESCRIPTION
# Description

This PR directly reverts these commits:

- [70d8c7b8](https://github.com/WeakAuras/WeakAuras2/commit/70d8c7b82befde80855179901c0ae8dee9ae75df), which added TWW warnings about Midnight
- [4bade526](https://github.com/WeakAuras/WeakAuras2/commit/4bade526eca364295ad4149b8d69a7288c5fb2de), which disabled WeakAuras on Midnight

The revert removes the Midnight warning messages, the options-window warning, the `WeakAuras.IsMidnight()` predicate, and the `libsAreOk = false` shutdown gate. It keeps the later Wrath warning unchanged.

No dependencies are required.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

- [x] `git diff --check`
- [x] Parsed both changed Lua files with `luac -p` (Lua 5.5.1)
- [x] Confirmed that no `IsMidnight` or removed Midnight warning reference remains
- [x] Confirmed that the Wrath warning remains unchanged

Luacheck was not run because it is not installed in this worktree.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] No code comments are needed because this change removes warning and shutdown code
- [x] No documentation changes are needed
- [x] My changes generate no new warnings

---
Written by an agent (Codex, GPT-5).