### PR TITLE
perf: stop idle animation updates

### DIFF
--- a/WeakAuras/Animations.lua
+++ b/WeakAuras/Animations.lua
@@ -157,12 +157,21 @@ local function RunAnimation(key, anim, elapsed, time)
   Private.StopProfileUID(anim.auraUID)
 end
 
-local updatingAnimations;
-local last_update = GetTime();
-local function UpdateAnimations()
-  if not updatingAnimations then
-    return
+local frame = CreateFrame("Frame")
+Private.frames["WeakAuras Animation Frame"] = frame
+
+local updatingAnimations
+
+-- Every insertion into animations or pending_controls must start updates.
+-- Updates stop only after both tables are empty at the end of UpdateAnimations.
+local function StopUpdatingAnimationsIfIdle()
+  if updatingAnimations and not next(animations) and not next(pending_controls) then
+    updatingAnimations = nil
+    frame:SetScript("OnUpdate", nil)
   end
+end
+
+local function UpdateAnimations(_, elapsed)
   Private.StartProfileSystem("animations");
 
   for groupUid, groupRegion in pairs(pending_controls) do
@@ -171,26 +180,25 @@ local function UpdateAnimations()
   end
 
   local time = GetTime();
-  local elapsed = time - last_update;
-  last_update = time;
 
   for key, anim in pairs(animations) do
     RunAnimation(key, anim, elapsed, time)
   end
 
   Private.StopProfileSystem("animations");
+  StopUpdatingAnimationsIfIdle()
 end
 
-local frame = CreateFrame("Frame")
-Private.frames["WeakAuras Animation Frame"] = frame
-frame:SetScript("OnUpdate", UpdateAnimations)
+local function StartUpdatingAnimations()
+  if not updatingAnimations then
+    updatingAnimations = true
+    frame:SetScript("OnUpdate", UpdateAnimations)
+  end
+end
 
 function Private.RegisterGroupForPositioning(uid, region)
   pending_controls[uid] = region
-  if not updatingAnimations then
-    updatingAnimations = true
-    last_update = GetTime()
-  end
+  StartUpdatingAnimations()
 end
 
 function Private.Animate(namespace, uid, type, anim, region, inverse, onFinished, loop, cloneId)
@@ -383,10 +391,7 @@ function Private.Animate(namespace, uid, type, anim, region, inverse, onFinished
     animation.anim = anim;
     animation.auraUID = uid
 
-    if not(updatingAnimations) then
-      last_update = GetTime()
-      updatingAnimations = true;
-    end
+    StartUpdatingAnimations()
     return true;
   else
     if(animations[key]) then


### PR DESCRIPTION
# Description

Stop the animation frame's `OnUpdate` handler when there are no active animations or pending group-position requests.

The handler now starts on the idle-to-active transition and stops after both work collections drain. It uses the elapsed value supplied by `OnUpdate`, and teardown happens only at the end of that handler. Completion callbacks and loop restarts are checked before the handler stops.

Public animation interfaces and saved data are unchanged. `CancelAnimation` never touches the handler; if it removes the last animation, the handler runs one more frame and removes itself.

Fixes #6304

## Type of change

- [x] Performance improvement (non-breaking, no intended behavior change)

## How Has This Been Tested

- [x] Ran a focused LuaJIT harness against the real `Animations.lua` for idle startup, group-only work, restart after idle, final cancellation, cancellation during group positioning, completion callbacks that queue work, and loop restart/cancellation.
- [x] Parsed `WeakAuras/Animations.lua` with LuaJIT and `luac -p`.
- [x] Ran `git diff --check`, `luac -p`, and Luacheck on the final commit.
- [x] GitHub CI passed Luacheck, the dry-run package build, and CodeQL.

The code now documents the lifecycle invariant. No user documentation changes are required.

## Checklist
<!-- These can be checked off after the pull request is submitted, in case you want discussion before they are completely ready -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

<!-- Is there any additional work that needs to be done? If so, add it to the above list -->

---
Written by an agent (Codex, GPT-5.6).

