### PR TITLE
fix(options): use unique new button frame names

### DIFF
--- a/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasNewButton.lua
+++ b/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasNewButton.lua
@@ -4,7 +4,7 @@ local AddonName = ...
 ---@class OptionsPrivate
 local OptionsPrivate = select(2, ...)
 
-local Type, Version = "WeakAurasNewButton", 27
+local Type, Version = "WeakAurasNewButton", 28
 local AceGUI = LibStub and LibStub("AceGUI-3.0", true)
 if not AceGUI or (AceGUI:GetWidgetVersion(Type) or 0) >= Version then return end
 
@@ -93,7 +93,7 @@ Constructor
 -------------------------------------------------------------------------------]]
 
 local function Constructor()
-  local name = "WeakAurasDisplayButton"..AceGUI:GetNextWidgetNum(Type);
+  local name = "WeakAurasNewButton"..AceGUI:GetNextWidgetNum(Type);
   local button = CreateFrame("Button", name, UIParent, "OptionsListButtonTemplate");
   button:SetHeight(40);
   button:SetWidth(380);


### PR DESCRIPTION
# Description

`WeakAurasNewButton` and `WeakAurasDisplayButton` use separate AceGUI counters but currently create frames with the same `WeakAurasDisplayButton` prefix. Both widget types can therefore request the same global frame name.

Use the NewButton widget type as its frame-name prefix and increase its widget version. The frame remains named because `OptionsListButtonTemplate` requires a parent name for its named children.

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
<!-- A #ticketNumber will be sufficient. -->
Fixes #6306

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] `git diff --check`
- [x] Parsed `WeakAurasNewButton.lua` with LuaJIT for Lua 5.1 compatibility

This source-level fix has not been tested in a WoW client. Luacheck was not available locally.

## Checklist
<!-- These can be checked off after the pull request is submitted, in case you want discussion before they are completely ready -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

<!-- Is there any additional work that needs to be done? If so, add it to the above list -->

---
Written by an agent (Codex, GPT-5).
