### PR TITLE
perf: avoid temporary table allocations in aura environment stack

### DIFF
--- a/WeakAuras/AuraEnvironment.lua
+++ b/WeakAuras/AuraEnvironment.lua
@@ -241,8 +241,25 @@ end
 
 local current_uid = nil
 local current_aura_env = nil
--- Stack of of aura environments/uids, allows use of recursive aura activations through calls to WeakAuras.ScanEvents().
+-- Stacks of aura environments/uids, allow use of recursive aura activations through calls to WeakAuras.ScanEvents().
 local aura_env_stack = {}
+local aura_uid_stack = {}
+
+local function PushAuraEnvironment()
+  local index = #aura_env_stack + 1
+  aura_env_stack[index] = current_aura_env
+  aura_uid_stack[index] = current_uid
+end
+
+local function PopAuraEnvironment()
+  local index = #aura_env_stack
+  if index > 0 then
+    aura_env_stack[index] = nil
+    aura_uid_stack[index] = nil
+  end
+  current_aura_env = aura_env_stack[index - 1]
+  current_uid = aura_uid_stack[index - 1]
+end
 
 
 local function UpdateSavedDataWarning(uid, size)
@@ -320,13 +337,7 @@ function Private.ActivateAuraEnvironment(id, cloneId, state, states, onlyConfig)
   local data = id and WeakAuras.GetData(id)
   if not data then
     -- Pop the last aura_env from the stack, and update current_aura_env appropriately.
-    tremove(aura_env_stack)
-    if aura_env_stack[#aura_env_stack] then
-      current_aura_env, current_uid = unpack(aura_env_stack[#aura_env_stack])
-    else
-      current_aura_env = nil
-      current_uid = nil
-    end
+    PopAuraEnvironment()
   else
     -- Existing config is initialized to a high enough value
     if environment_initialized[id] == 2 or (onlyConfig and environment_initialized[id] == 1) then
@@ -340,7 +351,7 @@ function Private.ActivateAuraEnvironment(id, cloneId, state, states, onlyConfig)
       current_aura_env.states = states
       current_aura_env.region = region
       -- Push the new environment onto the stack
-      tinsert(aura_env_stack, {current_aura_env, data.uid})
+      PushAuraEnvironment()
     elseif onlyConfig then
       environment_initialized[id] = 1
       aura_environments[id] = {}
@@ -351,7 +362,7 @@ function Private.ActivateAuraEnvironment(id, cloneId, state, states, onlyConfig)
       current_aura_env.cloneId = cloneId
       current_aura_env.state = state
       current_aura_env.states = states
-      tinsert(aura_env_stack, {current_aura_env, data.uid})
+      PushAuraEnvironment()
 
       if not data.controlledChildren then
         current_aura_env.config = CopyTable(data.config)
@@ -371,7 +382,7 @@ function Private.ActivateAuraEnvironment(id, cloneId, state, states, onlyConfig)
       current_aura_env.region = region
       Private.RestoreAuraEnvironment(id)
       -- push new environment onto the stack
-      tinsert(aura_env_stack, {current_aura_env, data.uid})
+      PushAuraEnvironment()
 
       if data.controlledChildren then
         current_aura_env.child_envs = {}


### PR DESCRIPTION
# Description

Replace the temporary environment/UID table created on each aura activation
with two parallel stacks.

Previously, each activation allocated a new table containing the aura
environment and UID. These short-lived tables create unnecessary garbage
in a frequently used code path.

The environment stack now determines the depth, allowing the UID stack to
contain nil values. Nested activation and environment restoration behavior
remain unchanged.

This isn't a classic leak, but rather massive garbage churn:
- Every aura activation created a new two-element table.
- GenericTrigger, animations, conditions, and custom text invoked this path very frequently.
- Although the tables were released, they were only collected during the next garbage collection cycle.
- As a result, WeakAuras' memory usage steadily climbed from around 52 MB to 80–100 MB.

## Type of change

- [x] Performance improvement (non-breaking, no intended behavior change)

## How Has This Been Tested

- [x] `git diff --check`
- [x] Syntax validation with `luac -p` using Lua 5.4.2
- [x] Temporary Lua harness with WoW globals stubbed, comparing the previous
      implementation with this change
- [x] Manual in-game idle observations using a temporary memory debug window

The harness covered nested activations, repeated activation of the same
aura, group/child initialization, custom init callbacks, nil UIDs, and
empty-stack pops.

With garbage collection stopped after warm-up, 100,000 activation/pop
pairs allocated approximately 8.4 MiB before this change and no measurable
additional memory afterward in the Lua 5.4 harness. This measures
allocations, not execution speed.

The in-game screenshots are rough idle observations, not a controlled
benchmark. In the screenshots with the exclamation mark, garbage collection
kicked in sooner during the ~100 MB run than during the ~80 MB run.
Since the measurement durations and GC timing differ, the final memory
deltas should not be compared directly.

---

## Before:

<img width="218" height="112" alt="Screenshot 2026-09-03 192458" src="https://github.com/user-attachments/assets/c156f886-a181-485b-a43a-43ce028e542f" />

## After:

<img width="225" height="105" alt="Screenshot 2026-09-03 192715" src="https://github.com/user-attachments/assets/7527992b-9fa0-43c2-8c3a-4a8c1865e269" />

---

## Before:
<img width="307" height="149" alt="Screenshot 2026-09-04 000423" src="https://github.com/user-attachments/assets/67926f3d-cf8b-4a6a-a2ad-306460ae01cd" />

## After:

<img width="304" height="140" alt="Screenshot 2026-09-04 000038" src="https://github.com/user-attachments/assets/ec8d6dab-038d-41e3-b2cf-e5a8f23411d5" />

---

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings