### PR TITLE
fix: keep profiling state consistent on aura rename and deletion

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,9 +49,6 @@ file after its dependencies.
 - When changing per-aura state, check both rename and deletion in
   `WeakAuras/WeakAuras.lua`. Keep cached UI rows consistent with the state,
   use the existing lifecycle hooks, and respect their `.toc` load order.
-  Before adding lifecycle guards, verify the callers and sandbox restrictions
-  in `WeakAuras/AuraEnvironment.lua`. A direct call in a test harness does not
-  prove that the same call is reachable through a supported runtime path.
 
 ## Persistent and wire data
 
@@ -164,10 +161,41 @@ output and you use the owning generator.
 - Release and update scripts can change many files or external services. Run
   them only when the task requires that effect.
 
+## Reasoning before changes
+
+Source-based reasoning is required for behavior changes. A passing harness
+or CI job does not replace it. Before editing, explain the affected behavior
+and, for fixes, the actual failure path. Include file references and the rule
+the change must preserve. Keep facts, assumptions, and unknowns distinct.
+
+- Trace the real entry point, callers, and state owner. Check relevant `.toc`
+  order, sandbox restrictions, WoW API contracts, and supported clients.
+  A direct call to an internal function does not prove runtime reachability.
+- Trace the affected lifecycle: creation, updates, rename, unload, deletion,
+  and cached views as applicable. For reentrancy or deferred work, identify
+  the actual callback, yield, or event boundary and its ordering. Do not
+  invent an interleaving merely because a harness can construct it.
+- Treat a guard, fallback, or swallowed error as a behavior change. Determine
+  whether missing state is valid or indicates a broken caller contract.
+  Repair the cause; do not silently accept invalid state to make a test pass.
+- Tie each added branch or helper to a demonstrated defect or an explicit
+  requirement. Before finishing, ask what assumption would make the fix
+  unnecessary or wrong, then check that assumption against the source.
+  Search for contradictory evidence, not only examples that support the fix.
+
 ## Validation
 
-Select checks that prove the changed behavior. Do not add a test that only
-restates the implementation.
+WoW supplies runtime behavior that a local Lua harness does not reproduce.
+Use source inspection and the documented client contracts as the primary
+local evidence. Verify behavior in the affected WoW clients when available.
+When it is not available, state the specific in-game behavior that remains
+unverified; do not replace that gap with a stronger test claim.
+
+Use a focused harness only when it can answer a specific question about
+isolated logic. Identify its stubs and assumptions, and verify those
+assumptions against real callers before using its results. Synthetic states
+can test robustness, but they do not establish a supported failure path.
+Do not build a mock WoW runtime or add tests that restate the implementation.
 
 For every change:
 
@@ -177,8 +205,9 @@ For every change:
    remains the authority for Lua 5.1 compatibility.
 3. Run `luacheck . --no-color -q` when Luacheck is available. This matches the
    lint intent in `.github/workflows/pull_request.yml`.
-4. Use a focused Lua harness with WoW globals stubbed, or verify the behavior
-   in the correct WoW clients, when the change needs runtime proof.
+4. Review the final diff against the source-based explanation. Report the
+   relevant evidence, checks actually run, and remaining uncertainty. Scale
+   this explanation to the change; test counts alone are not validation.
 
 Also check the relevant boundaries:
 
@@ -218,6 +247,10 @@ Do not say a check passed unless you ran it or GitHub reports it as passed.
 - Read all current review comments before you revise a pull request. When a
   comment is addressed, reply to its thread with what changed and the commit
   hash, then resolve the thread.
+- Keep a reviewer's statement separate from your interpretation. Investigate
+  vague feedback before changing code. If materially different fixes remain
+  possible, explain the evidence and ask for clarification instead of
+  presenting a guessed rationale as established fact.
 - Sign agent-authored content. Append a footer that names the agent and the
   model when you post a comment, create an issue, or open a pull request.
   Example:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,10 @@ file after its dependencies.
 - A runtime region or subregion change often needs a matching change in
   `WeakAurasOptions/RegionOptions/` or `WeakAurasOptions/SubRegionOptions/`.
   Check both sides before you finish.
+- When changing per-aura state, check both rename and deletion in
+  `WeakAuras/WeakAuras.lua`. Keep cached UI rows consistent with the state,
+  and check callbacks that can finish after the aura is deleted. Use the
+  existing lifecycle hooks and respect their `.toc` load order.
 
 ## Persistent and wire data
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,8 +48,10 @@ file after its dependencies.
   Check both sides before you finish.
 - When changing per-aura state, check both rename and deletion in
   `WeakAuras/WeakAuras.lua`. Keep cached UI rows consistent with the state,
-  and check callbacks that can finish after the aura is deleted. Use the
-  existing lifecycle hooks and respect their `.toc` load order.
+  use the existing lifecycle hooks, and respect their `.toc` load order.
+  Before adding lifecycle guards, verify the callers and sandbox restrictions
+  in `WeakAuras/AuraEnvironment.lua`. A direct call in a test harness does not
+  prove that the same call is reachable through a supported runtime path.
 
 ## Persistent and wire data
 

--- a/WeakAuras/Profiling.lua
+++ b/WeakAuras/Profiling.lua
@@ -120,10 +120,7 @@ local function StopProfileSystem(system)
 end
 
 local function StopProfileAura(id)
-  -- A callback can delete the aura before its profiling sample stops.
-  if profileData.auras[id] then
-    StopProfiling(profileData.auras, id)
-  end
+  StopProfiling(profileData.auras, id)
 end
 
 local function StartProfileUID(uid)
@@ -131,7 +128,7 @@ local function StartProfileUID(uid)
 end
 
 local function StopProfileUID(uid)
-  StopProfileAura(Private.UIDtoID(uid))
+  StopProfiling(profileData.auras, Private.UIDtoID(uid))
 end
 
 local function RefreshProfileBars()

--- a/WeakAuras/Profiling.lua
+++ b/WeakAuras/Profiling.lua
@@ -132,7 +132,7 @@ local function StopProfileUID(uid)
 end
 
 function Private.ProfileRenameAura(oldid, id)
-  profileData.auras[id] = profileData.auras[id]
+  profileData.auras[id] = profileData.auras[oldid]
   profileData.auras[oldid] = nil
 end
 

--- a/WeakAuras/Profiling.lua
+++ b/WeakAuras/Profiling.lua
@@ -120,7 +120,10 @@ local function StopProfileSystem(system)
 end
 
 local function StopProfileAura(id)
-  StopProfiling(profileData.auras, id)
+  -- A callback can delete the aura before its profiling sample stops.
+  if profileData.auras[id] then
+    StopProfiling(profileData.auras, id)
+  end
 end
 
 local function StartProfileUID(uid)
@@ -128,12 +131,25 @@ local function StartProfileUID(uid)
 end
 
 local function StopProfileUID(uid)
-  StopProfiling(profileData.auras, Private.UIDtoID(uid))
+  StopProfileAura(Private.UIDtoID(uid))
+end
+
+local function RefreshProfileBars()
+  if WeakAurasProfilingFrame and WeakAurasProfilingFrame.bars then
+    WeakAurasProfilingFrame:ResetBars()
+    WeakAurasProfilingFrame:RefreshBars(nil, true)
+  end
 end
 
 function Private.ProfileRenameAura(oldid, id)
   profileData.auras[id] = profileData.auras[oldid]
   profileData.auras[oldid] = nil
+  RefreshProfileBars()
+end
+
+function Private.ProfileDeleteAura(id)
+  profileData.auras[id] = nil
+  RefreshProfileBars()
 end
 
 local RegisterProfile = function(startType)

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -2233,6 +2233,8 @@ function WeakAuras.Delete(data)
 
   Private.RemoveHistory(data.uid)
 
+  Private.ProfileDeleteAura(id)
+
   Private.AddParents(data)
   Private.callbacks:Fire("Delete", uid, id, parentUid, parentId)
 end


### PR DESCRIPTION
# Description

Renaming an aura discards its profiling measurements, while deleting an aura leaves its measurements behind. Move the record on rename and remove it from the normal deletion path. The profiling window rebuilds its cached rows after either change.

The per-aura lifecycle guidance in `AGENTS.md` is updated in a separate commit.
<!-- A #ticketNumber will be sufficient. -->
Fixes #6309

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

- [x] Loaded the real `WeakAuras/Profiling.lua` in a focused LuaJIT harness with a controlled clock and game/UI globals stubbed. Eight checks pass: completed measurements surviving rename, subsequent samples adding to those measurements, completed nested samples surviving rename, rename without prior measurements, completed-record deletion, deletion without prior measurements/repeated deletion, reuse of a deleted name, and cached row updates after profiling stops. Rename and deletion occur between completed aura samples in these checks.
- [x] Checked real `PrintProfile` output and `RefreshBars` behavior. Renames retain elapsed/spike times; deletion removes report entries and cached rows. A replacement aura starts with fresh measurements. The new deletion and stale-row cases reproduced failures before this update.
- [x] Compiled both changed Lua files with `luajit -b path/to/file.lua /dev/null`; ran `git diff --check`.
- [x] Inspected all five core TOCs: `Profiling.lua` loads before `WeakAuras.lua`, so both lifecycle hooks exist before use.
- [x] GitHub CI passed Luacheck, the dry-run package build, and CodeQL for `1eea548c`.

Local `luac -p` uses Lua 5.5.1 and rejects existing loop-variable assignments in both Lua files on the baseline and this branch. Luacheck is not installed locally; GitHub CI runs it and the dry-run package build. In-game validation has not been performed.

## Checklist
<!-- These can be checked off after the pull request is submitted, in case you want discussion before they are completely ready -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

<!-- Is there any additional work that needs to be done? If so, add it to the above list -->

---
Written by an agent (Codex, GPT-6).
