### PR TITLE
fix: close two aura sandbox escapes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,6 +132,9 @@ into secure code blocks protected actions and raises errors for users. See
   not remove a real invalid state, repeated decision, or repeated lookup.
 - Explain non-obvious ownership, lifecycle, and compatibility decisions. Do
   not add comments that only repeat the code.
+- Do not add a comment at every place you change. Never repeat the same
+  comment at more than one site. When a change needs a reason, explain it
+  once, in the commit message or at the one place a reader would look.
 
 ## Generated data and external libraries
 

--- a/WeakAuras/AuraEnvironment.lua
+++ b/WeakAuras/AuraEnvironment.lua
@@ -588,11 +588,15 @@ local exec_env_custom = setmetatable(CopyTable(mixins),
     elseif _G[k] then
       return _G[k]
     elseif k:find(".", 1, true) then
+      -- The frame chooser names a child frame without a name after its parent,
+      -- e.g. "PlayerFrame.healthbar". Resolve the first segment through this
+      -- sandbox, not through the real _G. Otherwise "_G.loadstring" or
+      -- "WeakAuras.Add" would return the real, blocked functions.
       local f
       for i, n in ipairs{strsplit(".", k)} do
         if i == 1 then
-          f = _G[n]
-        elseif f then
+          f = t[n]
+        elseif type(f) == "table" then
           f = f[n]
         else
           return

--- a/WeakAuras/AuraEnvironment.lua
+++ b/WeakAuras/AuraEnvironment.lua
@@ -588,10 +588,8 @@ local exec_env_custom = setmetatable(CopyTable(mixins),
     elseif _G[k] then
       return _G[k]
     elseif k:find(".", 1, true) then
-      -- The frame chooser names a child frame without a name after its parent,
-      -- e.g. "PlayerFrame.healthbar". Resolve the first segment through this
-      -- sandbox, not through the real _G. Otherwise "_G.loadstring" or
-      -- "WeakAuras.Add" would return the real, blocked functions.
+      -- e.g. "PlayerFrame.healthbar" from the frame chooser. The first segment
+      -- goes through the sandbox so "_G.loadstring" stays blocked.
       local f
       for i, n in ipairs{strsplit(".", k)} do
         if i == 1 then

--- a/WeakAurasOptions/CommonOptions.lua
+++ b/WeakAurasOptions/CommonOptions.lua
@@ -2029,9 +2029,6 @@ local function AddCodeOptionTimeMachine(args, data, name, prefix, url, order, hi
 
       code = "return " .. code;
 
-      -- Aura code must only run inside the sandbox. A raw loadstring here would
-      -- execute the stored code with the real global environment every time
-      -- the options panel renders.
       local loadedFunction, errorString = OptionsPrivate.Private.LoadFunction(code, data.id, true);
       if(errorString and not loadedFunction) then
         return false;
@@ -2138,9 +2135,6 @@ local function AddCodeOption(args, data, name, prefix, url, order, hiddenFunc, p
 
       code = "return " .. code;
 
-      -- Aura code must only run inside the sandbox. A raw loadstring here would
-      -- execute the stored code with the real global environment every time
-      -- the options panel renders.
       local loadedFunction, errorString = OptionsPrivate.Private.LoadFunction(code, data.id, true);
       if(errorString and not loadedFunction) then
         return false;

--- a/WeakAurasOptions/CommonOptions.lua
+++ b/WeakAurasOptions/CommonOptions.lua
@@ -1934,9 +1934,6 @@ local function BorderOptions(id, data, showBackDropOptions, hiddenFunc, order)
   return borderOptions;
 end
 
-local function noop()
-end
-
 local function GetCustomCode(data, path)
   for _, key in ipairs(path) do
     if (not data or not data[key]) then
@@ -2032,14 +2029,16 @@ local function AddCodeOptionTimeMachine(args, data, name, prefix, url, order, hi
 
       code = "return " .. code;
 
-      local loadedFunction, errorString = loadstring(code);
+      -- Aura code must only run inside the sandbox. A raw loadstring here would
+      -- execute the stored code with the real global environment every time
+      -- the options panel renders.
+      local loadedFunction, errorString = OptionsPrivate.Private.LoadFunction(code, data.id, true);
       if(errorString and not loadedFunction) then
         return false;
       else
         if options.validator then
-          local ok, validate = xpcall(loadedFunction, noop)
-          if ok then
-            return options.validator(validate)
+          if loadedFunction ~= nil then
+            return options.validator(loadedFunction)
           end
           return false
         end
@@ -2139,14 +2138,16 @@ local function AddCodeOption(args, data, name, prefix, url, order, hiddenFunc, p
 
       code = "return " .. code;
 
-      local loadedFunction, errorString = loadstring(code);
+      -- Aura code must only run inside the sandbox. A raw loadstring here would
+      -- execute the stored code with the real global environment every time
+      -- the options panel renders.
+      local loadedFunction, errorString = OptionsPrivate.Private.LoadFunction(code, data.id, true);
       if(errorString and not loadedFunction) then
         return false;
       else
         if options.validator then
-          local ok, validate = xpcall(loadedFunction, noop)
-          if ok then
-            return options.validator(validate)
+          if loadedFunction ~= nil then
+            return options.validator(loadedFunction)
           end
           return false
         end


### PR DESCRIPTION
# Description

While investigating a set of malicious auras on Wago that silently installed additional auras on victims' clients, I found two ways for custom aura code to run outside the sandbox. Both are closed here. Neither change restricts anything a legitimate aura can do today.

**1. Dotted global names resolved through the real `_G`** (`WeakAuras/AuraEnvironment.lua`)

The lookup added in 0f426a80 lets the frame chooser anchor to a child frame without a name, such as `PlayerFrame.healthbar`. It resolved the first segment in the real `_G`, so custom code could write `_G["_G.loadstring"]` or `_G["WeakAuras.Add"]` and receive the real functions that the sandbox blocks. The real `loadstring` compiles code with the real global environment, so this was a complete escape. The first segment now resolves through the sandbox table, and intermediate values must be tables before they are indexed.

**2. Raw `loadstring` in the options panel** (`WeakAurasOptions/CommonOptions.lua`)

The `hidden` callback of the `_customError` description compiled the stored custom code with `loadstring` and executed it with `xpcall` in the real global environment. AceConfig evaluates `hidden` on every render, so opening the trigger tab of a malicious aura ran its code unsandboxed. The custom variables field of a TSU trigger reaches this path because it is the only field with a `validator`. The callback now uses `OptionsPrivate.Private.LoadFunction`, which the neighboring `name` callback already used. The `noop` helper had no other user and is removed.

The two commits are independent and can be reviewed separately.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

Both escapes were reproduced with LuaJIT harnesses that load the real addon files with WoW globals stubbed, run against `main` and against this branch.

- **Escape 1.** A harness loads the real `WeakAuras/AuraEnvironment.lua` and runs custom aura code that reads `_G["_G.loadstring"]`, `getglobal("_G.pcall")`, `_G["_G.EnumerateFrames"]`, `_G["WeakAuras.Add"]`, `getglobal("WeakAuras.PreAdd")`, `_G["_G.WeakAuras.HideOptions"]`, `_G["_G.WeakAurasSaved"]` and `_G["_G._G._G.loadstring"]`. On `main` all eight return the real values, no sandbox warning fires, and the leaked `loadstring` then compiles and runs code that writes the real `_G` (arbitrary execution). With this change all eight return the blocked stubs, eight warnings fire, and `Private.GetSanitizedGlobal("PlayerFrame.healthbar")` still returns the child frame.
- **Escape 2.** A harness loads the real `CommonOptions.lua` and drives the real `AddCodeOption` for the Custom Variables field (`encloseInFunction = false`, with a `validator`), then calls the `_customError.hidden` callback that AceConfig evaluates on every render. On `main` the stored code runs in the real environment: it writes a real global and reaches the real `EnumerateFrames`. With this change the same input runs inside the sandbox, the real `_G` is untouched, `EnumerateFrames` is not reached, and a sandbox warning fires.
- `luajit -bl` and `luac -p` parse both changed files.
- `git diff --check` is clean.
- Not run: Luacheck locally (not installed here; CI covers it) and an in-game check of the options panel.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

---
Written by an agent (Claude Code, claude-fable-5-1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
