### PR TITLE
test: add aura sandbox tests that run outside WoW

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -66,8 +66,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
 
-      # The aura sandbox is built on loadstring and setfenv, so the tests need
-      # a Lua 5.1 interpreter, the same major version the WoW client uses.
+      # The sandbox uses setfenv, so the tests need Lua 5.1 like the WoW client
       - name: Install Lua 5.1
         run: |
           sudo apt-get update

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -57,3 +57,21 @@ jobs:
           path:  .release/*.zip
           include-hidden-files: true
           archive: false
+
+  sandbox-tests:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+
+      # The aura sandbox is built on loadstring and setfenv, so the tests need
+      # a Lua 5.1 interpreter, the same major version the WoW client uses.
+      - name: Install Lua 5.1
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends lua5.1
+
+      - name: Run sandbox tests
+        run: lua5.1 tests/run.lua

--- a/.pkgmeta
+++ b/.pkgmeta
@@ -47,6 +47,7 @@ ignore:
   - CONTRIBUTING.md
   - AGENTS.md
   - CLAUDE.md
+  - tests
   - babelfish.lua
   - update_translations.sh
   - generate_changelog.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -191,9 +191,9 @@ Also check the relevant boundaries:
 
 Pull-request CI runs Luacheck, the sandbox tests, and a dry-run package
 build. It catches lint, sandbox, and packaging errors, but it does not load
-the addon in WoW, so it cannot prove `.toc` load order. Validate load order by inspecting the `.toc` files
-and by loading the addon in the affected clients. Do not say a check passed
-unless you ran it or GitHub reports it as passed.
+the addon in WoW, so it cannot prove `.toc` load order. Validate load order by
+inspecting the `.toc` files and by loading the addon in the affected clients.
+Do not say a check passed unless you ran it or GitHub reports it as passed.
 
 ## Git and review
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -186,12 +186,14 @@ Also check the relevant boundaries:
 - For a change to the aura sandbox in `WeakAuras/AuraEnvironment.lua`, or to
   code that compiles or evaluates custom aura code, run the sandbox tests in
   `tests/` with `lua5.1 tests/run.lua` or `luajit tests/run.lua`. They need a
-  Lua 5.1 interpreter because the sandbox is built on `setfenv`. See
-  `tests/README.md` for what they cover and how to add one.
+  Lua 5.1 interpreter because the sandbox is built on `setfenv`. They are
+  regression tests for known escape routes, not a security proof, so still
+  reason about the change against the WoW API. When you close a new escape,
+  add a case for it. See `tests/README.md`.
 
 Pull-request CI runs Luacheck, the sandbox tests, and a dry-run package
-build. It catches lint, sandbox, and packaging errors, but it does not load
-the addon in WoW, so it cannot prove `.toc` load order. Validate load order by
+build. It catches lint errors, known sandbox escapes, and packaging errors,
+but it does not load the addon in WoW, so it cannot prove `.toc` load order. Validate load order by
 inspecting the `.toc` files and by loading the addon in the affected clients.
 Do not say a check passed unless you ran it or GitHub reports it as passed.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -183,10 +183,15 @@ Also check the relevant boundaries:
 - For saved or transmitted data, validate old data, new data, import, export,
   and migration behavior as applicable.
 - For hot-path work, compare allocations and work per event or frame.
+- For a change to the aura sandbox in `WeakAuras/AuraEnvironment.lua`, or to
+  code that compiles or evaluates custom aura code, run the sandbox tests in
+  `tests/` with `lua5.1 tests/run.lua` or `luajit tests/run.lua`. They need a
+  Lua 5.1 interpreter because the sandbox is built on `setfenv`. See
+  `tests/README.md` for what they cover and how to add one.
 
-Pull-request CI runs Luacheck and a dry-run package build. It catches lint
-and packaging errors, but it does not load the addon in WoW, so it cannot
-prove `.toc` load order. Validate load order by inspecting the `.toc` files
+Pull-request CI runs Luacheck, the sandbox tests, and a dry-run package
+build. It catches lint, sandbox, and packaging errors, but it does not load
+the addon in WoW, so it cannot prove `.toc` load order. Validate load order by inspecting the `.toc` files
 and by loading the addon in the affected clients. Do not say a check passed
 unless you ran it or GitHub reports it as passed.
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,41 @@
+# Tests
+
+These tests load real addon files outside of World of Warcraft, with the WoW
+globals they need stubbed, and check the aura sandbox boundary:
+
+- `aura_environment_test.lua` checks that custom aura code compiled through
+  `WeakAuras.LoadFunction` cannot reach the real global table, the blocked WoW
+  functions, or the data-changing WeakAuras API, and that legitimate lookups
+  such as anchoring to a child frame without a name keep working.
+- `common_options_test.lua` checks that the options panel evaluates stored
+  custom code only inside the sandbox when it renders the error label under a
+  code box.
+
+They do not emulate the WoW API, taint, or secure execution. They prove that
+aura code cannot leave the sandbox, not that the block lists are complete.
+
+## Running
+
+The sandbox is built on `loadstring` and `setfenv`, which Lua 5.2 removed, so
+the tests need Lua 5.1 or LuaJIT:
+
+```sh
+lua5.1 tests/run.lua
+```
+
+or
+
+```sh
+luajit tests/run.lua
+```
+
+Each test file also runs on its own, for example
+`luajit tests/aura_environment_test.lua`. A failing expectation prints `FAIL`
+and the process exits with a non-zero status.
+
+## Adding a test
+
+Put shared WoW stubs in `wow_stubs.lua`. Keep them to what the loaded files
+touch. Write a new `*_test.lua` that requires `helpers` and `wow_stubs`, loads
+the addon file with `T.loadAddonFile`, states expectations with `T.expect`,
+and ends with `T.finish()`. Then add the file name to the list in `run.lua`.

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,7 +1,8 @@
 # Tests
 
-These tests load real addon files outside of World of Warcraft, with the WoW
-globals they need stubbed, and check the aura sandbox boundary:
+These are regression tests for the aura sandbox. They load real addon files
+outside of World of Warcraft, with the WoW globals they need stubbed, and check
+that the escape routes we have found and closed stay closed:
 
 - `aura_environment_test.lua` checks that custom aura code compiled through
   `WeakAuras.LoadFunction` cannot reach the real global table, the blocked WoW
@@ -11,8 +12,11 @@ globals they need stubbed, and check the aura sandbox boundary:
   custom code only inside the sandbox when it renders the error label under a
   code box.
 
-They do not emulate the WoW API, taint, or secure execution. They prove that
-aura code cannot leave the sandbox, not that the block lists are complete.
+A passing run is not a security proof. The tests only probe the routes they
+name. They cannot show that the block lists are complete, that no other route
+exists, or that an allowed WoW function is harmless. They do not emulate the
+WoW API, taint, or secure execution. When a new escape is found, add it here so
+it cannot come back.
 
 ## Running
 

--- a/tests/aura_environment_test.lua
+++ b/tests/aura_environment_test.lua
@@ -1,0 +1,173 @@
+-- Tests for the aura sandbox in WeakAuras/AuraEnvironment.lua.
+--
+-- The security property under test: code that an aura author writes in a
+-- custom trigger, action, or condition runs through WeakAuras.LoadFunction and
+-- must not be able to reach the real global table, the blocked WoW functions,
+-- or the data-changing WeakAuras API. Each test states the expectation as an
+-- aura author would try it, so a passing run shows the boundary holds rather
+-- than that a list in the implementation has a given content.
+local testsDir = (arg and arg[0] or ""):match("^(.*)[/\\][^/\\]*$") or "."
+package.path = testsDir .. "/?.lua;" .. package.path
+local T = require("helpers")
+local stubs = require("wow_stubs")
+
+stubs.install()
+local realG = _G
+_G.WeakAuras = stubs.newWeakAuras()
+local WeakAuras = _G.WeakAuras
+local Private, warnings = stubs.newPrivate()
+
+local auraData = { id = "test", uid = "test-uid", config = {}, information = {}, actions = {} }
+WeakAuras.GetData = function(id)
+  if id == "test" then
+    return auraData
+  end
+end
+Private.UIDtoID = function(uid)
+  if uid == "test-uid" then
+    return "test"
+  end
+end
+
+T.loadAddonFile("WeakAuras/AuraEnvironment.lua", "WeakAuras", Private)
+
+--- Runs code the way a custom trigger runs it: compiled through the public
+--- loader into the custom environment, then called.
+local function runCustom(body)
+  local fn, err = WeakAuras.LoadFunction("return function()\n" .. body .. "\nend", "test")
+  assert(fn, err)
+  return fn()
+end
+
+--- Runs code through the loader that WeakAuras uses for its own generated
+--- code and for validation in the options panel.
+local function runBuiltin(body)
+  local fn, err = Private.LoadFunction("return function()\n" .. body .. "\nend", "test", true)
+  assert(fn, err)
+  return fn()
+end
+
+local function warned(key)
+  for _, warning in ipairs(warnings) do
+    if warning.key == key then
+      return true
+    end
+  end
+  return false
+end
+
+local function clearWarnings()
+  for i = #warnings, 1, -1 do
+    warnings[i] = nil
+  end
+end
+
+T.section("blocked functions and tables are not reachable from custom code")
+for _, name in ipairs({ "loadstring", "getfenv", "setfenv", "pcall", "xpcall",
+                        "EnumerateFrames", "RunScript", "SendMail", "securecall" }) do
+  clearWarnings()
+  local got = runCustom("return " .. name)
+  T.expect(type(got) == "function" and got ~= realG[name], name .. " is replaced by a stub")
+  T.expect(warned("SandboxForbidden"), name .. " raises a SandboxForbidden warning")
+end
+for _, name in ipairs({ "SlashCmdList", "WeakAurasSaved", "WeakAurasOptions" }) do
+  clearWarnings()
+  local got = runCustom("return " .. name)
+  T.expect(type(got) == "table" and got ~= realG[name], name .. " is replaced by an empty table")
+  T.expect(warned("SandboxForbidden"), name .. " raises a SandboxForbidden warning")
+end
+
+T.section("_G and getglobal resolve to the sandbox")
+T.expect(runCustom("return _G") ~= realG, "_G is not the real global table")
+T.expect(runCustom("return getglobal('_G')") ~= realG, "getglobal('_G') is not the real global table")
+T.expect(runCustom("return _G._G._G") ~= realG, "nested _G stays inside the sandbox")
+T.expect(runCustom("return _G.loadstring") ~= loadstring, "_G.loadstring is the stub")
+
+T.section("dotted names resolve through the sandbox")
+-- The frame chooser produces names like PlayerFrame.healthbar, so the sandbox
+-- resolves dotted keys. The first segment must go through the sandbox, or
+-- these names would return the real, blocked values.
+local probes = {
+  { '_G["_G.loadstring"]', loadstring },
+  { 'getglobal("_G.pcall")', pcall },
+  { '_G["_G.EnumerateFrames"]', realG.EnumerateFrames },
+  { '_G["WeakAuras.Add"]', WeakAuras.Add },
+  { 'getglobal("WeakAuras.PreAdd")', WeakAuras.PreAdd },
+  { '_G["_G.WeakAuras.HideOptions"]', WeakAuras.HideOptions },
+  { '_G["_G.WeakAurasSaved"]', realG.WeakAurasSaved },
+  { '_G["_G._G._G.loadstring"]', loadstring },
+}
+for _, probe in ipairs(probes) do
+  local got = runCustom("return " .. probe[1])
+  T.expect(got ~= probe[2], probe[1] .. " does not return the real value")
+end
+T.expect(runCustom('return getglobal("getglobal.anything")') == nil,
+         "a dotted name that passes through a function returns nil instead of erroring")
+
+T.section("custom code cannot obtain a loader with the real environment")
+local leaked = runCustom([[
+  local candidates = { loadstring, _G["_G.loadstring"], getglobal("_G.loadstring"), _G._G.loadstring }
+  for _, candidate in ipairs(candidates) do
+    if type(candidate) == "function" then
+      local chunk = candidate("return _G")
+      if type(chunk) == "function" then
+        return chunk()
+      end
+    end
+  end
+]])
+T.expect(leaked ~= realG, "no candidate loader compiles code against the real global table")
+
+T.section("the WeakAuras table is a guarded proxy")
+T.expect(runCustom("return WeakAuras") ~= WeakAuras, "custom code sees a proxy, not the real WeakAuras table")
+for _, name in ipairs({ "Add", "PreAdd", "Import", "Delete", "HideOptions" }) do
+  clearWarnings()
+  local got = runCustom("return WeakAuras." .. name)
+  T.expect(got ~= WeakAuras[name], "WeakAuras." .. name .. " is blocked")
+  T.expect(warned("SandboxForbidden"), "WeakAuras." .. name .. " raises a SandboxForbidden warning")
+end
+clearWarnings()
+runCustom("WeakAuras.Injected = true")
+T.expect(WeakAuras.Injected == nil, "writing to WeakAuras does not change the real table")
+T.expect(warned("FakeWeakAurasSet"), "writing to WeakAuras raises a warning")
+T.expect(runCustom("return WeakAuras.IsLibsOK") == WeakAuras.IsLibsOK, "allowed WeakAuras functions pass through")
+
+T.section("global writes from custom code stay inside the sandbox")
+clearWarnings()
+runCustom("BrandNewGlobal = 1")
+T.expect(realG.BrandNewGlobal == nil, "a new global is not created in the real environment")
+T.expect(runCustom("return BrandNewGlobal") == 1, "the aura still sees its own global")
+runCustom("UnitExists = nil")
+T.expect(type(realG.UnitExists) == "function", "overwriting an existing global does not change the real one")
+T.expect(warned("OverridingGlobal"), "overwriting an existing global raises a warning")
+clearWarnings()
+runCustom("aura_env = {}")
+T.expect(warned("OverridingAuraEnv"), "overwriting aura_env raises a warning")
+
+T.section("aura code gets a copy of aura data")
+Private.ActivateAuraEnvironment("test", nil, {}, {})
+local env = runCustom("return aura_env")
+T.expect(type(env) == "table" and env.id == "test", "aura_env is the environment of the active aura")
+local seen = runCustom("local d = WeakAuras.GetData('test'); d.actions.tampered = true; return d")
+T.expect(seen ~= auraData, "WeakAuras.GetData returns a copy")
+T.expect(auraData.actions.tampered == nil, "writes to the copy do not reach the stored data")
+Private.ActivateAuraEnvironment()
+
+T.section("legitimate lookups keep working")
+T.expect(Private.GetSanitizedGlobal("PlayerFrame") == realG.PlayerFrame, "a named frame resolves")
+T.expect(Private.GetSanitizedGlobal("PlayerFrame.healthbar") == realG.PlayerFrame.healthbar,
+         "a child frame without a name resolves through its parent")
+T.expect(Private.GetSanitizedGlobal("PlayerFrame.missing") == nil, "an unknown child resolves to nil")
+T.expect(runCustom("return UnitExists") == realG.UnitExists, "allowed API functions pass through")
+T.expect(runCustom("return WA_Utf8Sub") == WeakAuras.WA_Utf8Sub, "WeakAuras helper functions are available")
+
+T.section("the builtin environment has the same boundary")
+for _, name in ipairs({ "loadstring", "getfenv", "setfenv", "EnumerateFrames" }) do
+  T.expect(runBuiltin("return " .. name) ~= realG[name], "builtin: " .. name .. " is a stub")
+end
+T.expect(runBuiltin("return _G") ~= realG, "builtin: _G is not the real global table")
+local builtinPrivate = runBuiltin("return Private")
+T.expect(type(builtinPrivate) == "table" and builtinPrivate.ExecEnv == Private.ExecEnv
+         and builtinPrivate.LoadFunction == nil, "builtin: Private exposes only ExecEnv")
+
+T.finish()

--- a/tests/aura_environment_test.lua
+++ b/tests/aura_environment_test.lua
@@ -1,12 +1,7 @@
--- Tests for the aura sandbox in WeakAuras/AuraEnvironment.lua.
---
--- The security property under test: code that an aura author writes in a
--- custom trigger, action, or condition runs through WeakAuras.LoadFunction and
--- must not be able to reach the real global table, the blocked WoW functions,
--- or the data-changing WeakAuras API. Each test states the expectation as an
--- aura author would try it, so a passing run shows the boundary holds rather
--- than that a list in the implementation has a given content.
-local testsDir = (arg and arg[0] or ""):match("^(.*)[/\\][^/\\]*$") or "."
+-- Custom aura code runs through WeakAuras.LoadFunction and must not reach the
+-- real global table, the blocked WoW functions, or the data-changing WeakAuras
+-- API. Each check probes the boundary the way an aura author would.
+local testsDir = arg[0]:match("^(.*)[/\\][^/\\]*$") or "."
 package.path = testsDir .. "/?.lua;" .. package.path
 local T = require("helpers")
 local stubs = require("wow_stubs")
@@ -31,16 +26,14 @@ end
 
 T.loadAddonFile("WeakAuras/AuraEnvironment.lua", "WeakAuras", Private)
 
---- Runs code the way a custom trigger runs it: compiled through the public
---- loader into the custom environment, then called.
+--- Runs code the way a custom trigger runs it.
 local function runCustom(body)
   local fn, err = WeakAuras.LoadFunction("return function()\n" .. body .. "\nend", "test")
   assert(fn, err)
   return fn()
 end
 
---- Runs code through the loader that WeakAuras uses for its own generated
---- code and for validation in the options panel.
+--- Runs code through the loader for generated code and options validation.
 local function runBuiltin(body)
   local fn, err = Private.LoadFunction("return function()\n" .. body .. "\nend", "test", true)
   assert(fn, err)

--- a/tests/common_options_test.lua
+++ b/tests/common_options_test.lua
@@ -1,31 +1,22 @@
--- Tests for the custom code options in WeakAurasOptions/CommonOptions.lua.
---
--- The options panel compiles stored aura code to show syntax and validation
--- errors next to the code box. AceConfig evaluates the name and hidden
--- callbacks of that error label on every render. The property under test:
--- this evaluation must run the stored code inside the sandbox, never in the
--- real global environment, or opening the options of a malicious aura would
--- execute its code unsandboxed.
-local testsDir = (arg and arg[0] or ""):match("^(.*)[/\\][^/\\]*$") or "."
+-- The options panel compiles stored aura code to show errors under the code
+-- box, and AceConfig evaluates the name and hidden callbacks of that label on
+-- every render. That evaluation must stay inside the sandbox.
+local testsDir = arg[0]:match("^(.*)[/\\][^/\\]*$") or "."
 package.path = testsDir .. "/?.lua;" .. package.path
 local T = require("helpers")
 local stubs = require("wow_stubs")
 
 stubs.install()
 local realG = _G
--- The options file refers to many WeakAuras and OptionsPrivate members that
--- these tests do not exercise, so both tables answer unknown keys with no-ops.
 _G.WeakAuras = stubs.permissive(stubs.newWeakAuras())
 local Private, warnings = stubs.newPrivate()
 
--- The real sandbox provides Private.LoadFunction, which the options code uses.
 T.loadAddonFile("WeakAuras/AuraEnvironment.lua", "WeakAuras", Private)
 local OptionsPrivate = stubs.permissive({ Private = Private })
 T.loadAddonFile("WeakAurasOptions/CommonOptions.lua", "WeakAurasOptions", OptionsPrivate)
 
--- The Custom Variables field of a custom trigger is registered with
--- encloseInFunction = false and a validator, so its stored text is evaluated
--- as an expression whenever the error label is rendered.
+-- Custom Variables is registered without encloseInFunction and with a
+-- validator, so its text is evaluated as an expression on every render.
 local maliciousCode = table.concat({
   "(function()",
   "  _G.OWNED_FROM_OPTIONS = true",

--- a/tests/common_options_test.lua
+++ b/tests/common_options_test.lua
@@ -1,0 +1,78 @@
+-- Tests for the custom code options in WeakAurasOptions/CommonOptions.lua.
+--
+-- The options panel compiles stored aura code to show syntax and validation
+-- errors next to the code box. AceConfig evaluates the name and hidden
+-- callbacks of that error label on every render. The property under test:
+-- this evaluation must run the stored code inside the sandbox, never in the
+-- real global environment, or opening the options of a malicious aura would
+-- execute its code unsandboxed.
+local testsDir = (arg and arg[0] or ""):match("^(.*)[/\\][^/\\]*$") or "."
+package.path = testsDir .. "/?.lua;" .. package.path
+local T = require("helpers")
+local stubs = require("wow_stubs")
+
+stubs.install()
+local realG = _G
+-- The options file refers to many WeakAuras and OptionsPrivate members that
+-- these tests do not exercise, so both tables answer unknown keys with no-ops.
+_G.WeakAuras = stubs.permissive(stubs.newWeakAuras())
+local Private, warnings = stubs.newPrivate()
+
+-- The real sandbox provides Private.LoadFunction, which the options code uses.
+T.loadAddonFile("WeakAuras/AuraEnvironment.lua", "WeakAuras", Private)
+local OptionsPrivate = stubs.permissive({ Private = Private })
+T.loadAddonFile("WeakAurasOptions/CommonOptions.lua", "WeakAurasOptions", OptionsPrivate)
+
+-- The Custom Variables field of a custom trigger is registered with
+-- encloseInFunction = false and a validator, so its stored text is evaluated
+-- as an expression whenever the error label is rendered.
+local maliciousCode = table.concat({
+  "(function()",
+  "  _G.OWNED_FROM_OPTIONS = true",
+  "  _G.SEEN_ENUMERATE = EnumerateFrames()",
+  "  return {}",
+  "end)()",
+}, "\n")
+
+local function buildErrorLabel(addCodeOption, code, validator)
+  local data = { id = "victim", customVariables = code }
+  local args = {}
+  addCodeOption(args, data, "Custom Variables", "custom_variables", "https://example.invalid/wiki", 11,
+                function() return false end, { "customVariables" }, false, { validator = validator })
+  return args["custom_variables_customError"]
+end
+
+for _, builder in ipairs({ "AddCodeOption", "AddCodeOptionTimeMachine" }) do
+  local addCodeOption = OptionsPrivate.commonOptions[builder]
+  T.section(builder .. ": rendering the error label runs stored code only inside the sandbox")
+
+  local validatedWith
+  local label = buildErrorLabel(addCodeOption, maliciousCode, function(value)
+    validatedWith = value
+    return nil
+  end)
+  if T.expect(label and type(label.hidden) == "function" and type(label.name) == "function",
+              "the error label has name and hidden callbacks") then
+    for _, callback in ipairs({ "hidden", "name" }) do
+      realG.OWNED_FROM_OPTIONS = nil
+      realG.SEEN_ENUMERATE = nil
+      validatedWith = nil
+      label[callback]()
+      T.expect(realG.OWNED_FROM_OPTIONS == nil, callback .. ": the stored code does not write the real global table")
+      T.expect(realG.SEEN_ENUMERATE ~= "REAL_EnumerateFrames", callback .. ": the stored code does not reach the real EnumerateFrames")
+      T.expect(type(validatedWith) == "table", callback .. ": the code was still evaluated and its result reached the validator")
+    end
+  end
+
+  T.section(builder .. ": the error label still reports problems")
+  local broken = buildErrorLabel(addCodeOption, "{ this is not lua", function() return nil end)
+  T.expect(broken.hidden() == false, "a syntax error shows the label")
+  T.expect(type(broken.name()) == "string" and broken.name():find("|cFFFF0000", 1, true) ~= nil,
+           "a syntax error is reported in red")
+  local rejected = buildErrorLabel(addCodeOption, "{}", function() return "Not what I wanted" end)
+  T.expect(rejected.name():find("Not what I wanted", 1, true) ~= nil, "a validator message is reported")
+end
+
+T.expect(#warnings > 0, "the sandbox raised warnings while evaluating the malicious code")
+
+T.finish()

--- a/tests/helpers.lua
+++ b/tests/helpers.lua
@@ -1,0 +1,53 @@
+-- Shared helpers for the tests in this directory.
+--
+-- The tests load real addon files with the WoW globals they need stubbed, so
+-- they run in any Lua 5.1 compatible interpreter. The aura sandbox is built on
+-- loadstring and setfenv, which Lua 5.2 removed, so Lua 5.2 and later cannot
+-- run these tests.
+local M = {}
+
+if not (loadstring and setfenv) then
+  print(("These tests need Lua 5.1 or LuaJIT. %s has no loadstring/setfenv."):format(_VERSION))
+  os.exit(2)
+end
+
+-- Directory of the running test script, and the repository root above it.
+local script = arg and arg[0] or ""
+M.testsDir = script:match("^(.*)[/\\][^/\\]*$") or "."
+M.repoRoot = M.testsDir .. "/.."
+
+local passes, failures = 0, 0
+
+function M.section(name)
+  print("# " .. name)
+end
+
+--- Records one expectation. Prints ok or FAIL, and returns the condition so a
+--- caller can skip follow-up checks that depend on it.
+function M.expect(condition, message)
+  if condition then
+    passes = passes + 1
+    print("  ok    " .. message)
+  else
+    failures = failures + 1
+    print("  FAIL  " .. message)
+  end
+  return condition
+end
+
+function M.finish()
+  print(("%d passed, %d failed"):format(passes, failures))
+  os.exit(failures > 0 and 1 or 0)
+end
+
+--- Loads a repository Lua file the way WoW does: the chunk receives the addon
+--- name and the private table as its vararg.
+function M.loadAddonFile(relativePath, addonName, privateTable)
+  local chunk, err = loadfile(M.repoRoot .. "/" .. relativePath)
+  if not chunk then
+    error(err)
+  end
+  return chunk(addonName, privateTable)
+end
+
+return M

--- a/tests/helpers.lua
+++ b/tests/helpers.lua
@@ -1,19 +1,13 @@
 -- Shared helpers for the tests in this directory.
---
--- The tests load real addon files with the WoW globals they need stubbed, so
--- they run in any Lua 5.1 compatible interpreter. The aura sandbox is built on
--- loadstring and setfenv, which Lua 5.2 removed, so Lua 5.2 and later cannot
--- run these tests.
 local M = {}
 
+-- The sandbox is built on loadstring and setfenv, which Lua 5.2 removed.
 if not (loadstring and setfenv) then
   print(("These tests need Lua 5.1 or LuaJIT. %s has no loadstring/setfenv."):format(_VERSION))
   os.exit(2)
 end
 
--- Directory of the running test script, and the repository root above it.
-local script = arg and arg[0] or ""
-M.testsDir = script:match("^(.*)[/\\][^/\\]*$") or "."
+M.testsDir = arg[0]:match("^(.*)[/\\][^/\\]*$") or "."
 M.repoRoot = M.testsDir .. "/.."
 
 local passes, failures = 0, 0
@@ -22,8 +16,7 @@ function M.section(name)
   print("# " .. name)
 end
 
---- Records one expectation. Prints ok or FAIL, and returns the condition so a
---- caller can skip follow-up checks that depend on it.
+--- Returns the condition so a caller can skip checks that depend on it.
 function M.expect(condition, message)
   if condition then
     passes = passes + 1
@@ -43,10 +36,7 @@ end
 --- Loads a repository Lua file the way WoW does: the chunk receives the addon
 --- name and the private table as its vararg.
 function M.loadAddonFile(relativePath, addonName, privateTable)
-  local chunk, err = loadfile(M.repoRoot .. "/" .. relativePath)
-  if not chunk then
-    error(err)
-  end
+  local chunk = assert(loadfile(M.repoRoot .. "/" .. relativePath))
   return chunk(addonName, privateTable)
 end
 

--- a/tests/run.lua
+++ b/tests/run.lua
@@ -3,7 +3,7 @@
 --
 -- Usage: lua5.1 tests/run.lua
 --    or: luajit tests/run.lua
-local testsDir = (arg and arg[0] or ""):match("^(.*)[/\\][^/\\]*$") or "."
+local testsDir = arg[0]:match("^(.*)[/\\][^/\\]*$") or "."
 package.path = testsDir .. "/?.lua;" .. package.path
 io.stdout:setvbuf("no") -- keep the headers in order with the child output
 require("helpers") -- exits with a clear message on an unsupported Lua version
@@ -13,7 +13,7 @@ local tests = {
   "common_options_test.lua",
 }
 
-local interpreter = arg[-1] or "lua"
+local interpreter = arg[-1]
 local failed = {}
 for _, name in ipairs(tests) do
   print("==> " .. name)

--- a/tests/run.lua
+++ b/tests/run.lua
@@ -1,0 +1,31 @@
+-- Runs every test in this directory, each in its own interpreter process so
+-- that stubbed globals cannot leak from one test into another.
+--
+-- Usage: lua5.1 tests/run.lua
+--    or: luajit tests/run.lua
+local testsDir = (arg and arg[0] or ""):match("^(.*)[/\\][^/\\]*$") or "."
+package.path = testsDir .. "/?.lua;" .. package.path
+io.stdout:setvbuf("no") -- keep the headers in order with the child output
+require("helpers") -- exits with a clear message on an unsupported Lua version
+
+local tests = {
+  "aura_environment_test.lua",
+  "common_options_test.lua",
+}
+
+local interpreter = arg[-1] or "lua"
+local failed = {}
+for _, name in ipairs(tests) do
+  print("==> " .. name)
+  local status = os.execute(string.format('"%s" "%s/%s"', interpreter, testsDir, name))
+  if status ~= 0 then
+    failed[#failed + 1] = name
+  end
+  print("")
+end
+
+if #failed > 0 then
+  print("FAILED: " .. table.concat(failed, ", "))
+  os.exit(1)
+end
+print("All test files passed.")

--- a/tests/wow_stubs.lua
+++ b/tests/wow_stubs.lua
@@ -1,7 +1,5 @@
--- Stand-ins for the WoW globals that WeakAuras/AuraEnvironment.lua and
--- WeakAurasOptions/CommonOptions.lua touch when they load or when the tests
--- drive them. This is not a WoW API emulation. It provides only what the
--- sandbox needs to be constructed and exercised.
+-- Stand-ins for the WoW globals that the loaded addon files touch. This is not
+-- a WoW API emulation.
 local M = {}
 
 local function strsplit(delimiter, text)
@@ -25,9 +23,8 @@ local function CopyTable(source)
   return copy
 end
 
---- Installs the global helpers, API functions, frames, libraries, and
---- sensitive globals that the tests refer to. Sensitive globals return a
---- marker string so a test can tell the real function from a sandbox stub.
+--- Sensitive globals return a marker string so a test can tell the real
+--- function from a sandbox stub.
 function M.install()
   _G.strsplit = strsplit
   _G.strtrim = strtrim
@@ -51,11 +48,9 @@ function M.install()
   _G.UnitExists = function() return false end
   _G.C_Timer = { After = function() end, NewTicker = function() end }
 
-  -- Frames are plain tables here. A child frame without a name is reached
-  -- through its parent, which is what the frame chooser produces.
+  -- A child frame without a name, as the frame chooser produces it
   _G.PlayerFrame = { healthbar = {} }
 
-  -- Globals the sandbox must hide from aura code.
   _G.EnumerateFrames = function() return "REAL_EnumerateFrames" end
   _G.RunScript = function() return "REAL_RunScript" end
   _G.SendMail = function() return "REAL_SendMail" end
@@ -75,16 +70,13 @@ function M.install()
   })
 end
 
---- Returns a table that answers any unknown key with a no-op function. Use it
---- for objects whose many members a test does not exercise.
+--- Answers any unknown key with a no-op function.
 function M.permissive(table)
   return setmetatable(table or {}, {
     __index = function() return function() end end,
   })
 end
 
---- A WeakAuras table with markers for the functions that aura code must not be
---- able to reach.
 function M.newWeakAuras()
   return {
     IsLibsOK = function() return true end,
@@ -102,8 +94,7 @@ function M.newWeakAuras()
   }
 end
 
---- The Private table that AuraEnvironment.lua expects. Sandbox warnings are
---- appended to the returned list as { key = ..., message = ... }.
+--- Sandbox warnings are appended to the returned list as { key, message }.
 function M.newPrivate()
   local warnings = {}
   local Private = {

--- a/tests/wow_stubs.lua
+++ b/tests/wow_stubs.lua
@@ -1,0 +1,132 @@
+-- Stand-ins for the WoW globals that WeakAuras/AuraEnvironment.lua and
+-- WeakAurasOptions/CommonOptions.lua touch when they load or when the tests
+-- drive them. This is not a WoW API emulation. It provides only what the
+-- sandbox needs to be constructed and exercised.
+local M = {}
+
+local function strsplit(delimiter, text)
+  local out = {}
+  local escaped = delimiter:gsub("%p", "%%%0")
+  for piece in (text .. delimiter):gmatch("([^" .. escaped .. "]*)" .. escaped) do
+    out[#out + 1] = piece
+  end
+  return unpack(out)
+end
+
+local function strtrim(text)
+  return (text:gsub("^%s+", ""):gsub("%s+$", ""))
+end
+
+local function CopyTable(source)
+  local copy = {}
+  for key, value in pairs(source) do
+    copy[key] = type(value) == "table" and CopyTable(value) or value
+  end
+  return copy
+end
+
+--- Installs the global helpers, API functions, frames, libraries, and
+--- sensitive globals that the tests refer to. Sensitive globals return a
+--- marker string so a test can tell the real function from a sandbox stub.
+function M.install()
+  _G.strsplit = strsplit
+  _G.strtrim = strtrim
+  -- WoW adds trim to the string library, so code can call ("x"):trim()
+  rawset(string, "trim", strtrim)
+  _G.tinsert = table.insert
+  _G.tremove = table.remove
+  _G.ceil = math.ceil
+  _G.wipe = function(t)
+    for key in pairs(t) do
+      t[key] = nil
+    end
+    return t
+  end
+  _G.CopyTable = CopyTable
+
+  _G.GetUnitName = function() return "Tester" end
+  _G.UnitGUID = function() return "Player-1-1" end
+  _G.UnitAura = function() return nil end
+  _G.IsInRaid = function() return false end
+  _G.UnitExists = function() return false end
+  _G.C_Timer = { After = function() end, NewTicker = function() end }
+
+  -- Frames are plain tables here. A child frame without a name is reached
+  -- through its parent, which is what the frame chooser produces.
+  _G.PlayerFrame = { healthbar = {} }
+
+  -- Globals the sandbox must hide from aura code.
+  _G.EnumerateFrames = function() return "REAL_EnumerateFrames" end
+  _G.RunScript = function() return "REAL_RunScript" end
+  _G.SendMail = function() return "REAL_SendMail" end
+  _G.securecall = function() return "REAL_securecall" end
+  _G.SlashCmdList = {}
+  _G.WeakAurasSaved = { displays = {} }
+  _G.WeakAurasOptions = {}
+
+  local libs = {
+    LibSerialize = {},
+    LibDeflate = {},
+    ["LibCustomGlow-1.0"] = { ButtonGlow_Start = function() end, ButtonGlow_Stop = function() end },
+    ["LibGetFrame-1.0"] = { GetUnitFrame = function() end, GetUnitNameplate = function() end },
+  }
+  _G.LibStub = setmetatable({ GetLibrary = function(_, name) return libs[name] end }, {
+    __call = function(_, name) return libs[name] end,
+  })
+end
+
+--- Returns a table that answers any unknown key with a no-op function. Use it
+--- for objects whose many members a test does not exercise.
+function M.permissive(table)
+  return setmetatable(table or {}, {
+    __index = function() return function() end end,
+  })
+end
+
+--- A WeakAuras table with markers for the functions that aura code must not be
+--- able to reach.
+function M.newWeakAuras()
+  return {
+    IsLibsOK = function() return true end,
+    L = setmetatable({}, { __index = function(_, key) return key end }),
+    Add = function() return "REAL_Add" end,
+    PreAdd = function() return "REAL_PreAdd" end,
+    Import = function() return "REAL_Import" end,
+    Delete = function() return "REAL_Delete" end,
+    HideOptions = function() return "REAL_HideOptions" end,
+    GetData = function() return nil end,
+    GetRegion = function() return nil end,
+    doubleWidth = 2,
+    normalWidth = 1,
+    halfWidth = 0.5,
+  }
+end
+
+--- The Private table that AuraEnvironment.lua expects. Sandbox warnings are
+--- appended to the returned list as { key = ..., message = ... }.
+function M.newPrivate()
+  local warnings = {}
+  local Private = {
+    ExecEnv = {},
+    clones = {},
+    regions = {},
+    multiUnitUnits = { nameplate = {} },
+    AuraWarnings = {
+      UpdateWarning = function(_, key, severity, message)
+        -- A call without a severity clears a warning.
+        if severity then
+          warnings[#warnings + 1] = { key = key, message = message }
+        end
+      end,
+    },
+    UIDtoID = function() return nil end,
+    DebugLog = { Print = function() end },
+    customActionsFunctions = {},
+    GetErrorHandlerId = function() return function() end end,
+    EnsureRegion = function() return nil end,
+    AuraEnvironmentWrappedSystem = { Get = function() return _G.C_Timer end },
+  }
+  return Private, warnings
+end
+
+return M


### PR DESCRIPTION
# Description

Follow-up to #6311, which closed two ways for custom aura code to leave the sandbox. This adds tests that catch that class of bug outside of WoW, and a CI job that runs them on every pull request. The branch is stacked on #6311, so this PR targets that branch; once #6311 merges it can be retargeted to `main`.

**What this is and is not.** These are regression tests. They encode the escape routes found and closed in #6311 so the same classes of bug fail CI instead of shipping again. The dotted-name lookup came in with a feature commit in 2024 and went unnoticed for two years; one of these assertions would have failed that PR. A passing run is not a security proof. The tests only probe the routes they name. They cannot show that the block lists are complete, that no other route exists, or that an allowed WoW function is harmless.

**Why this works outside WoW.** The aura sandbox in `WeakAuras/AuraEnvironment.lua` is pure Lua 5.1: metatables, `loadstring`, `setfenv`, and two block lists. The tests load the real, unmodified addon files with the handful of globals they touch stubbed. They do not emulate the WoW API, taint, or secure execution.

**Lua version.** The sandbox uses `setfenv`, which Lua 5.2 removed, so the tests need Lua 5.1 or LuaJIT. Under Lua 5.4 or 5.5 they exit with a clear message. The CI job installs the `lua5.1` package from Ubuntu, the same major version the WoW client uses.

**What is in the PR**

- `tests/aura_environment_test.lua` loads the real `AuraEnvironment.lua` and states the boundary the way an aura author would probe it: blocked functions and tables return stubs and raise warnings; `_G`, `getglobal`, and dotted names such as `_G["_G.loadstring"]` and `getglobal("WeakAuras.Add")` resolve through the sandbox; no candidate loader compiles code against the real global table; the `WeakAuras` proxy blocks `Add`, `PreAdd`, `Import`, `Delete`, and `HideOptions` and rejects writes; global writes stay in the sandbox; `WeakAuras.GetData` returns a copy; the builtin environment has the same boundary and exposes only `Private.ExecEnv`. It also checks that legitimate lookups keep working: `PlayerFrame`, `PlayerFrame.healthbar`, allowed API functions, and the `WA_*` helpers.
- `tests/common_options_test.lua` loads the real `CommonOptions.lua`, drives `AddCodeOption` and `AddCodeOptionTimeMachine` for the Custom Variables field, and checks that the `name` and `hidden` callbacks of the error label evaluate stored code only inside the sandbox, while still reporting syntax errors and validator messages.
- `tests/wow_stubs.lua`, `tests/helpers.lua`, `tests/run.lua`, and `tests/README.md` hold the shared stubs, a tiny assertion helper with the version guard, a runner that executes each test file in its own interpreter process, and instructions.
- `.pkgmeta` ignores `tests/` so the packager does not ship it.
- `.github/workflows/pull_request.yml` gains a `sandbox-tests` job.
- `AGENTS.md` points agents at the tests for sandbox changes and records that CI runs them.

The tests are framework free and Luacheck clean, so `luacheck .` keeps passing with no config change.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested

- `luajit tests/run.lua` on this branch: 92 expectations pass, 0 fail.
- The same tests copied onto a detached checkout of `main`, without the fixes from #6311: 13 expectations fail, 9 in the environment test (the eight dotted-name probes and the leaked-loader check) and 4 in the options test (the `hidden` callback writing the real global table and reaching the real `EnumerateFrames`, for both builders). Every other expectation passes on both, so the failures point at the two bugs and nothing else.
- `luacheck . --no-color -q` with Luacheck 1.2.0: 0 warnings, 0 errors in 202 files, including the new tests.
- `luajit -bl` parses each test file as Lua 5.1. `git diff --check` is clean.
- Not run locally: the tests under PUC Lua 5.1, which is what the CI job installs. Only LuaJIT is available here. The tests avoid LuaJIT extensions, and the CI run on this PR is the check for that.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

---
Written by an agent (Claude Code, claude-fable-5-1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
