### PR TITLE
docs(agents): reflow the CI paragraph in Validation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -193,9 +193,10 @@ Also check the relevant boundaries:
 
 Pull-request CI runs Luacheck, the sandbox tests, and a dry-run package
 build. It catches lint errors, known sandbox escapes, and packaging errors,
-but it does not load the addon in WoW, so it cannot prove `.toc` load order. Validate load order by
-inspecting the `.toc` files and by loading the addon in the affected clients.
-Do not say a check passed unless you ran it or GitHub reports it as passed.
+but it does not load the addon in WoW, so it cannot prove `.toc` load order.
+Validate load order by inspecting the `.toc` files and by loading the addon
+in the affected clients. Do not say a check passed unless you ran it or
+GitHub reports it as passed.
 
 ## Git and review
 


### PR DESCRIPTION
# Description

Reflows one paragraph in the Validation section of `AGENTS.md`. A wording edit in #6312 matched a line prefix and left a 99 character line. No text changes, only line breaks.

## Type of change

- [x] This change requires a documentation update

## How Has This Been Tested

- `awk 'length > 80' AGENTS.md` reports no lines.
- `git diff --check` is clean.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

---
Written by an agent (Claude Code, claude-fable-5-1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
